### PR TITLE
Refactor R2: extract inventory and location schemas from main.py

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,14 @@ import mimetypes
 from typing import Any, List, Mapping, Optional
 from dataclasses import dataclass
 from app.schemas.testing import TestStartResponse, TestStatusResponse, TestReportResponse, TestCompleteRequest
+from app.schemas.inventory import (
+    SpaceCreate,
+    SpaceUpdateRequest,
+    SublocationCreate,
+    SublocationUpdateRequest,
+    InventoryCreate,
+    InventoryUpdate,
+)
 from app.schemas.receipts import (
     ReceiptDeleteRequest,
     ReceiptPurgeArchivedRequest,
@@ -318,80 +326,6 @@ class HouseholdNameUpdateRequest(BaseModel):
 
 class HouseholdPermissionPolicyUpdateRequest(BaseModel):
     member_allowed: bool = False
-
-class SpaceCreate(BaseModel):
-    naam: str
-    household_id: Optional[str] = None
-    active: bool = True
-
-    @field_validator("naam")
-    @classmethod
-    def validate_naam(cls, value):
-        normalized = ' '.join(str(value or '').strip().split())
-        if not normalized:
-            raise ValueError("Ruimtenaam is verplicht")
-        if len(normalized) > 120:
-            raise ValueError("Ruimtenaam mag maximaal 120 tekens bevatten")
-        return normalized
-
-class SpaceUpdateRequest(BaseModel):
-    naam: str
-    active: bool = True
-
-    @field_validator("naam")
-    @classmethod
-    def validate_naam(cls, value):
-        normalized = ' '.join(str(value or '').strip().split())
-        if not normalized:
-            raise ValueError("Ruimtenaam is verplicht")
-        if len(normalized) > 120:
-            raise ValueError("Ruimtenaam mag maximaal 120 tekens bevatten")
-        return normalized
-
-class SublocationCreate(BaseModel):
-    naam: str
-    space_id: str
-    active: bool = True
-
-    @field_validator("naam")
-    @classmethod
-    def validate_naam(cls, value):
-        normalized = ' '.join(str(value or '').strip().split())
-        if not normalized:
-            raise ValueError("Sublocatienaam is verplicht")
-        if len(normalized) > 120:
-            raise ValueError("Sublocatienaam mag maximaal 120 tekens bevatten")
-        return normalized
-
-class SublocationUpdateRequest(BaseModel):
-    naam: str
-    space_id: str
-    active: bool = True
-
-    @field_validator("naam")
-    @classmethod
-    def validate_naam(cls, value):
-        normalized = ' '.join(str(value or '').strip().split())
-        if not normalized:
-            raise ValueError("Sublocatienaam is verplicht")
-        if len(normalized) > 120:
-            raise ValueError("Sublocatienaam mag maximaal 120 tekens bevatten")
-        return normalized
-
-class InventoryCreate(BaseModel):
-    naam: str
-    aantal: int
-    space_id: str
-    sublocation_id: Optional[str] = None
-
-
-class InventoryUpdate(BaseModel):
-    naam: str
-    aantal: int
-    space_id: Optional[str] = None
-    sublocation_id: Optional[str] = None
-    space_name: Optional[str] = None
-    sublocation_name: Optional[str] = None
 
 
 class ManualPurchaseCreateRequest(BaseModel):

--- a/backend/app/schemas/inventory.py
+++ b/backend/app/schemas/inventory.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, field_validator
+
+
+class SpaceCreate(BaseModel):
+    naam: str
+    household_id: Optional[str] = None
+    active: bool = True
+
+    @field_validator("naam")
+    @classmethod
+    def validate_naam(cls, value):
+        normalized = ' '.join(str(value or '').strip().split())
+        if not normalized:
+            raise ValueError("Ruimtenaam is verplicht")
+        if len(normalized) > 120:
+            raise ValueError("Ruimtenaam mag maximaal 120 tekens bevatten")
+        return normalized
+
+
+class SpaceUpdateRequest(BaseModel):
+    naam: str
+    active: bool = True
+
+    @field_validator("naam")
+    @classmethod
+    def validate_naam(cls, value):
+        normalized = ' '.join(str(value or '').strip().split())
+        if not normalized:
+            raise ValueError("Ruimtenaam is verplicht")
+        if len(normalized) > 120:
+            raise ValueError("Ruimtenaam mag maximaal 120 tekens bevatten")
+        return normalized
+
+
+class SublocationCreate(BaseModel):
+    naam: str
+    space_id: str
+    active: bool = True
+
+    @field_validator("naam")
+    @classmethod
+    def validate_naam(cls, value):
+        normalized = ' '.join(str(value or '').strip().split())
+        if not normalized:
+            raise ValueError("Sublocatienaam is verplicht")
+        if len(normalized) > 120:
+            raise ValueError("Sublocatienaam mag maximaal 120 tekens bevatten")
+        return normalized
+
+
+class SublocationUpdateRequest(BaseModel):
+    naam: str
+    space_id: str
+    active: bool = True
+
+    @field_validator("naam")
+    @classmethod
+    def validate_naam(cls, value):
+        normalized = ' '.join(str(value or '').strip().split())
+        if not normalized:
+            raise ValueError("Sublocatienaam is verplicht")
+        if len(normalized) > 120:
+            raise ValueError("Sublocatienaam mag maximaal 120 tekens bevatten")
+        return normalized
+
+
+class InventoryCreate(BaseModel):
+    naam: str
+    aantal: int
+    space_id: str
+    sublocation_id: Optional[str] = None
+
+
+class InventoryUpdate(BaseModel):
+    naam: str
+    aantal: int
+    space_id: Optional[str] = None
+    sublocation_id: Optional[str] = None
+    space_name: Optional[str] = None
+    sublocation_name: Optional[str] = None


### PR DESCRIPTION
## Doel

Refactor R2 verkleint `backend/app/main.py` zonder functionele wijziging.

## Wijzigingen

- Nieuwe schema-module toegevoegd: `backend/app/schemas/inventory.py`
- Inventory/location requestmodellen verplaatst naar deze schema-module:
  - `SpaceCreate`
  - `SpaceUpdateRequest`
  - `SublocationCreate`
  - `SublocationUpdateRequest`
  - `InventoryCreate`
  - `InventoryUpdate`
- `main.py` importeert deze modellen nu vanuit `app.schemas.inventory`

## Bewust niet meegenomen

De volgende modellen blijven nog in `main.py`, omdat zij helperfuncties/normalizers uit `main.py` gebruiken en eerst een utility/service-extractie nodig hebben:

- `ManualPurchaseCreateRequest`
- `InventoryEventMutationRequest`
- `InventoryTransferRequest`

## Niet gewijzigd

- Geen routewijzigingen
- Geen endpointcontractwijzigingen
- Geen OCR/parserwijzigingen
- Geen statuslogica gewijzigd
- Geen databasewijzigingen
- Geen frontendwijzigingen

## Validatie

Lokaal uitgevoerd:

```bash
python -m py_compile backend/app/main.py backend/app/schemas/inventory.py
```

Resultaat: geslaagd.

## PO-testadvies

Na merge volstaat:

```bash
git pull
docker compose up --build -d
```

Daarna controleren:

- app start normaal
- `/docs` opent
- bestaande voorraad-/locatie-endpoints zijn aanwezig
- één bestaande voorraad- of locatiehandeling als smoke test
