### PR TITLE
Refactor R3A: extract email config helpers from main.py

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -51,6 +51,29 @@ from app.api.receipt_diagnosis_routes import router as receipt_diagnosis_router
 from app.api.receipt_preview_routes import router as receipt_preview_router, configure_receipt_preview_routes
 from app.services.receipt_baseline_service import run_receipt_parsing_baseline_suite
 from app.services.receipt_status_baseline_service import diagnose_receipt_status_baseline, validate_receipt_status_baseline
+from app.services.email_config_service import (
+    GMAIL_OAUTH_CLIENT_ID,
+    GMAIL_OAUTH_CLIENT_SECRET,
+    GMAIL_OAUTH_REDIRECT_URI,
+    GMAIL_OAUTH_SCOPES,
+    GMAIL_STATE_SECRET,
+    GMAIL_DEFAULT_LABEL_NAME,
+    GMAIL_SYNC_BATCH_SIZE,
+    RECEIPT_EMAIL_DOMAIN,
+    RESEND_API_KEY,
+    RESEND_API_BASE_URL,
+    REZZERV_NOTIFICATION_FROM_EMAIL,
+    REZZERV_NOTIFICATION_FROM_NAME,
+    REZZERV_APP_BASE_URL,
+    REZZERV_EMAIL_ENABLED,
+    normalize_api_error_message,
+    outbound_email_delivery_enabled,
+    resend_api_key_ready,
+    outbound_email_sender_ready,
+    build_outbound_email_configuration_warnings,
+    build_outbound_email_configuration_summary,
+    build_resend_error_message,
+)
 from datetime import datetime, date, timedelta, timezone
 from decimal import Decimal
 from email import policy
@@ -77,27 +100,6 @@ RECEIPT_STORAGE_ROOT = Path(os.getenv('RECEIPT_STORAGE_ROOT', '/app/data/receipt
 RECEIPT_PREVIEW_NORMALIZER = ReceiptPhotoNormalizer()
 
 
-GMAIL_OAUTH_CLIENT_ID = os.getenv('REZZERV_GMAIL_CLIENT_ID', '').strip()
-GMAIL_OAUTH_CLIENT_SECRET = os.getenv('REZZERV_GMAIL_CLIENT_SECRET', '').strip()
-GMAIL_OAUTH_REDIRECT_URI = os.getenv('REZZERV_GMAIL_REDIRECT_URI', '').strip()
-GMAIL_OAUTH_SCOPES = tuple(
-    scope.strip()
-    for scope in os.getenv(
-        'REZZERV_GMAIL_SCOPES',
-        'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.labels',
-    ).split()
-    if scope.strip()
-)
-GMAIL_STATE_SECRET = (os.getenv('REZZERV_GMAIL_STATE_SECRET', 'rezzerv-gmail-dev-secret') or 'rezzerv-gmail-dev-secret').encode('utf-8')
-GMAIL_DEFAULT_LABEL_NAME = os.getenv('REZZERV_GMAIL_LABEL_NAME', 'Rezzerv/Bonnen').strip() or 'Rezzerv/Bonnen'
-GMAIL_SYNC_BATCH_SIZE = max(1, min(int(os.getenv('REZZERV_GMAIL_SYNC_BATCH_SIZE', '25') or '25'), 100))
-RECEIPT_EMAIL_DOMAIN = (os.getenv('REZZERV_RECEIPT_EMAIL_DOMAIN', 'rezzerv.local') or 'rezzerv.local').strip() or 'rezzerv.local'
-RESEND_API_KEY = (os.getenv('REZZERV_RESEND_API_KEY', '') or '').strip()
-RESEND_API_BASE_URL = (os.getenv('REZZERV_RESEND_API_BASE_URL', 'https://api.resend.com') or 'https://api.resend.com').rstrip('/')
-REZZERV_NOTIFICATION_FROM_EMAIL = (os.getenv('REZZERV_NOTIFICATION_FROM_EMAIL', '') or '').strip()
-REZZERV_NOTIFICATION_FROM_NAME = (os.getenv('REZZERV_NOTIFICATION_FROM_NAME', 'Rezzerv') or 'Rezzerv').strip() or 'Rezzerv'
-REZZERV_APP_BASE_URL = (os.getenv('REZZERV_APP_BASE_URL', 'http://localhost:5174') or 'http://localhost:5174').rstrip('/')
-REZZERV_EMAIL_ENABLED = str(os.getenv('REZZERV_EMAIL_ENABLED', 'false') or 'false').strip().lower() in {'1', 'true', 'yes', 'on'}
 RECEIPT_INBOUND_PATH = '/api/receipts/inbound'
 VERSION_FILE_PATH = Path(__file__).resolve().parents[2] / 'VERSION.txt'
 VERSION_TAG = VERSION_FILE_PATH.read_text(encoding='utf-8').strip() if VERSION_FILE_PATH.exists() else 'dev'
@@ -127,106 +129,6 @@ async def unhandled_api_exception_handler(request: Request, exc: Exception):
             )
         return JSONResponse(status_code=500, content={'detail': 'Interne serverfout in de API'})
     raise exc
-
-def normalize_api_error_message(value: Any, fallback: str = 'Verzoek mislukt') -> str:
-    if value is None:
-        return fallback
-    message = str(value).strip()
-    return message or fallback
-
-
-def mask_secret(value: Any, visible_suffix: int = 4) -> str:
-    secret = str(value or '').strip()
-    if not secret:
-        return 'ontbreekt'
-    if len(secret) <= visible_suffix:
-        return '*' * len(secret)
-    return ('*' * max(0, len(secret) - visible_suffix)) + secret[-visible_suffix:]
-
-
-def outbound_email_delivery_enabled() -> bool:
-    return bool(REZZERV_EMAIL_ENABLED)
-
-
-def resend_api_key_ready() -> bool:
-    key = str(RESEND_API_KEY or '').strip()
-    return bool(key) and not key.upper().startswith('PASTE_')
-
-
-def outbound_email_sender_ready() -> tuple[bool, str]:
-    from_email = str(REZZERV_NOTIFICATION_FROM_EMAIL or '').strip().lower()
-    if not from_email:
-        return False, 'afzenderadres ontbreekt'
-    if '@' not in from_email:
-        return False, 'afzenderadres is ongeldig'
-    if from_email.endswith('.local'):
-        return False, 'afzenderadres gebruikt nog een .local-domein en is daarom niet bruikbaar voor Resend'
-    return True, ''
-
-
-def build_outbound_email_configuration_warnings() -> list[str]:
-    warnings: list[str] = []
-    from_email = str(REZZERV_NOTIFICATION_FROM_EMAIL or '').strip().lower()
-    app_base_url = str(REZZERV_APP_BASE_URL or '').strip()
-    if not from_email or '@' not in from_email:
-        warnings.append('afzenderadres ontbreekt of is ongeldig')
-    elif from_email.endswith('.local'):
-        warnings.append('afzenderadres gebruikt nog een .local-domein en is meestal niet bruikbaar voor Resend')
-    if app_base_url.startswith('http://localhost'):
-        warnings.append('app-url verwijst nog naar localhost')
-    return warnings
-
-
-def build_outbound_email_configuration_summary() -> str:
-    warnings = build_outbound_email_configuration_warnings()
-    email_state = 'ingeschakeld' if outbound_email_delivery_enabled() else 'uitgeschakeld'
-    key_state = 'aanwezig' if resend_api_key_ready() else 'ontbreekt of placeholder'
-    summary_parts = [
-        f'e-mail: {email_state}',
-        f'API-sleutel: {key_state} ({mask_secret(RESEND_API_KEY)})',
-        f"afzender: {REZZERV_NOTIFICATION_FROM_EMAIL or '(niet ingesteld)'}",
-        f'api: {RESEND_API_BASE_URL}/emails',
-        f'app-url: {REZZERV_APP_BASE_URL}/login',
-    ]
-    if warnings:
-        summary_parts.append('waarschuwingen: ' + '; '.join(warnings))
-    return 'Configuratie: ' + ' | '.join(summary_parts)
-
-
-def build_resend_error_message(status_code: int, reason: Any, external_detail: Any = None, headers: Any = None) -> str:
-    normalized_detail = normalize_api_error_message(external_detail, 'Onbekende fout vanuit Resend.')
-    request_id = ''
-    cf_ray = ''
-    server_header = ''
-    if headers is not None:
-        try:
-            request_id = str(headers.get('x-request-id') or headers.get('X-Request-Id') or '').strip()
-        except Exception:
-            request_id = ''
-        try:
-            cf_ray = str(headers.get('cf-ray') or headers.get('CF-RAY') or '').strip()
-        except Exception:
-            cf_ray = ''
-        try:
-            server_header = str(headers.get('server') or headers.get('Server') or '').strip()
-        except Exception:
-            server_header = ''
-    reason_text = str(reason or "").strip()
-    detail_parts = [
-        'Uitnodigingsmail niet verzonden.',
-        f'Resend antwoordde met HTTP {status_code} {reason_text}.' if reason_text else f'Resend antwoordde met HTTP {status_code}.',
-        f'Externe melding: {normalized_detail}',
-        build_outbound_email_configuration_summary(),
-    ]
-    if request_id:
-        detail_parts.append(f'Resend request-id: {request_id}')
-    if cf_ray:
-        detail_parts.append(f'Cloudflare-ray: {cf_ray}')
-    if server_header:
-        detail_parts.append(f'Server: {server_header}')
-    if "browser's signature" in normalized_detail.lower():
-        detail_parts.append('Diagnosehint: Resend of een tussenliggende beveiligingslaag blokkeert dit verzoek als verdacht browser/signature-verkeer. Controleer of het afzenderadres een geverifieerd domein gebruikt, of de API-sleutel in de backend-container actief is, en of firewall, proxy, VPN, adblocker of browserbeveiliging verkeer naar api.resend.com wijzigt.')
-    return ' '.join(part for part in detail_parts if part)
 
 # Runtime opslag voor auth-context. De bron van waarheid wordt vanaf 01.09.96 uit SQLite geladen.
 DEFAULT_AUTH_USERS = {

--- a/backend/app/services/email_config_service.py
+++ b/backend/app/services/email_config_service.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import hmac
+import os
+from typing import Any
+
+
+GMAIL_OAUTH_CLIENT_ID = os.getenv('REZZERV_GMAIL_CLIENT_ID', '').strip()
+GMAIL_OAUTH_CLIENT_SECRET = os.getenv('REZZERV_GMAIL_CLIENT_SECRET', '').strip()
+GMAIL_OAUTH_REDIRECT_URI = os.getenv('REZZERV_GMAIL_REDIRECT_URI', '').strip()
+GMAIL_OAUTH_SCOPES = tuple(
+    scope.strip()
+    for scope in os.getenv(
+        'REZZERV_GMAIL_SCOPES',
+        'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.labels',
+    ).split()
+    if scope.strip()
+)
+GMAIL_STATE_SECRET = (os.getenv('REZZERV_GMAIL_STATE_SECRET', 'rezzerv-gmail-dev-secret') or 'rezzerv-gmail-dev-secret').encode('utf-8')
+GMAIL_DEFAULT_LABEL_NAME = os.getenv('REZZERV_GMAIL_LABEL_NAME', 'Rezzerv/Bonnen').strip() or 'Rezzerv/Bonnen'
+GMAIL_SYNC_BATCH_SIZE = max(1, min(int(os.getenv('REZZERV_GMAIL_SYNC_BATCH_SIZE', '25') or '25'), 100))
+RECEIPT_EMAIL_DOMAIN = (os.getenv('REZZERV_RECEIPT_EMAIL_DOMAIN', 'rezzerv.local') or 'rezzerv.local').strip() or 'rezzerv.local'
+RESEND_API_KEY = (os.getenv('REZZERV_RESEND_API_KEY', '') or '').strip()
+RESEND_API_BASE_URL = (os.getenv('REZZERV_RESEND_API_BASE_URL', 'https://api.resend.com') or 'https://api.resend.com').rstrip('/')
+REZZERV_NOTIFICATION_FROM_EMAIL = (os.getenv('REZZERV_NOTIFICATION_FROM_EMAIL', '') or '').strip()
+REZZERV_NOTIFICATION_FROM_NAME = (os.getenv('REZZERV_NOTIFICATION_FROM_NAME', 'Rezzerv') or 'Rezzerv').strip() or 'Rezzerv'
+REZZERV_APP_BASE_URL = (os.getenv('REZZERV_APP_BASE_URL', 'http://localhost:5174') or 'http://localhost:5174').rstrip('/')
+REZZERV_EMAIL_ENABLED = str(os.getenv('REZZERV_EMAIL_ENABLED', 'false') or 'false').strip().lower() in {'1', 'true', 'yes', 'on'}
+
+
+def mask_secret(value: Any, visible_suffix: int = 4) -> str:
+    secret = str(value or '').strip()
+    if not secret:
+        return 'ontbreekt'
+    if len(secret) <= visible_suffix:
+        return '*' * len(secret)
+    return ('*' * max(0, len(secret) - visible_suffix)) + secret[-visible_suffix:]
+
+
+def normalize_api_error_message(value: Any, fallback: str = 'Verzoek mislukt') -> str:
+    if value is None:
+        return fallback
+    message = str(value).strip()
+    return message or fallback
+
+
+def outbound_email_delivery_enabled() -> bool:
+    return bool(REZZERV_EMAIL_ENABLED)
+
+
+def resend_api_key_ready() -> bool:
+    key = str(RESEND_API_KEY or '').strip()
+    return bool(key) and not key.upper().startswith('PASTE_')
+
+
+def outbound_email_sender_ready() -> tuple[bool, str]:
+    from_email = str(REZZERV_NOTIFICATION_FROM_EMAIL or '').strip().lower()
+    if not from_email:
+        return False, 'afzenderadres ontbreekt'
+    if '@' not in from_email:
+        return False, 'afzenderadres is ongeldig'
+    if from_email.endswith('.local'):
+        return False, 'afzenderadres gebruikt nog een .local-domein en is daarom niet bruikbaar voor Resend'
+    return True, ''
+
+
+def build_outbound_email_configuration_warnings() -> list[str]:
+    warnings: list[str] = []
+    from_email = str(REZZERV_NOTIFICATION_FROM_EMAIL or '').strip().lower()
+    app_base_url = str(REZZERV_APP_BASE_URL or '').strip()
+    if not from_email or '@' not in from_email:
+        warnings.append('afzenderadres ontbreekt of is ongeldig')
+    elif from_email.endswith('.local'):
+        warnings.append('afzenderadres gebruikt nog een .local-domein en is meestal niet bruikbaar voor Resend')
+    if app_base_url.startswith('http://localhost'):
+        warnings.append('app-url verwijst nog naar localhost')
+    return warnings
+
+
+def build_outbound_email_configuration_summary() -> str:
+    warnings = build_outbound_email_configuration_warnings()
+    email_state = 'ingeschakeld' if outbound_email_delivery_enabled() else 'uitgeschakeld'
+    key_state = 'aanwezig' if resend_api_key_ready() else 'ontbreekt of placeholder'
+    summary_parts = [
+        f'e-mail: {email_state}',
+        f'API-sleutel: {key_state} ({mask_secret(RESEND_API_KEY)})',
+        f"afzender: {REZZERV_NOTIFICATION_FROM_EMAIL or '(niet ingesteld)'}",
+        f'api: {RESEND_API_BASE_URL}/emails',
+        f'app-url: {REZZERV_APP_BASE_URL}/login',
+    ]
+    if warnings:
+        summary_parts.append('waarschuwingen: ' + '; '.join(warnings))
+    return 'Configuratie: ' + ' | '.join(summary_parts)
+
+
+def build_resend_error_message(status_code: int, reason: Any, external_detail: Any = None, headers: Any = None) -> str:
+    normalized_detail = normalize_api_error_message(external_detail, 'Onbekende fout vanuit Resend.')
+    request_id = ''
+    cf_ray = ''
+    server_header = ''
+    if headers is not None:
+        try:
+            request_id = str(headers.get('x-request-id') or headers.get('X-Request-Id') or '').strip()
+        except Exception:
+            request_id = ''
+        try:
+            cf_ray = str(headers.get('cf-ray') or headers.get('CF-RAY') or '').strip()
+        except Exception:
+            cf_ray = ''
+        try:
+            server_header = str(headers.get('server') or headers.get('Server') or '').strip()
+        except Exception:
+            server_header = ''
+    reason_text = str(reason or "").strip()
+    detail_parts = [
+        'Uitnodigingsmail niet verzonden.',
+        f'Resend antwoordde met HTTP {status_code} {reason_text}.' if reason_text else f'Resend antwoordde met HTTP {status_code}.',
+        f'Externe melding: {normalized_detail}',
+        build_outbound_email_configuration_summary(),
+    ]
+    if request_id:
+        detail_parts.append(f'Resend request-id: {request_id}')
+    if cf_ray:
+        detail_parts.append(f'Cloudflare-ray: {cf_ray}')
+    if server_header:
+        detail_parts.append(f'Server: {server_header}')
+    if "browser's signature" in normalized_detail.lower():
+        detail_parts.append('Diagnosehint: Resend of een tussenliggende beveiligingslaag blokkeert dit verzoek als verdacht browser/signature-verkeer. Controleer of het afzenderadres een geverifieerd domein gebruikt, of de API-sleutel in de backend-container actief is, en of firewall, proxy, VPN, adblocker of browserbeveiliging verkeer naar api.resend.com wijzigt.')
+    return ' '.join(part for part in detail_parts if part)


### PR DESCRIPTION
## Doel

Refactor R3A verkleint `backend/app/main.py` zonder functionele wijziging door mail-/integratieconfiguratie en helperfuncties te isoleren.

## Wijzigingen

- Nieuwe service-module toegevoegd: `backend/app/services/email_config_service.py`
- De volgende configuratie/constants zijn uit `main.py` verplaatst:
  - `GMAIL_*`
  - `RESEND_*`
  - `REZZERV_EMAIL_*`
  - `RECEIPT_EMAIL_DOMAIN`
- De volgende helperfuncties zijn uit `main.py` verplaatst:
  - `mask_secret`
  - `normalize_api_error_message`
  - `outbound_email_delivery_enabled`
  - `resend_api_key_ready`
  - `outbound_email_sender_ready`
  - `build_outbound_email_configuration_warnings`
  - `build_outbound_email_configuration_summary`
  - `build_resend_error_message`
- `main.py` importeert deze nu vanuit `app.services.email_config_service`

## Niet gewijzigd

- Geen routewijzigingen
- Geen endpointcontractwijzigingen
- Geen Gmail-syncwijziging
- Geen inbound e-mail parsing gewijzigd
- Geen OCR/parserwijzigingen
- Geen statuslogica gewijzigd
- Geen databasewijzigingen
- Geen frontendwijzigingen

## Validatie

Lokaal uitgevoerd:

```bash
python -m py_compile backend/app/main.py backend/app/services/email_config_service.py
```

Resultaat: geslaagd.

## PO-testadvies

Na merge:

```bash
git pull
docker compose up --build -d
```

Daarna controleren:

- app start normaal
- `/docs` opent
- login werkt
- bestaande receipt schermen openen
