### PR TITLE
Refactor R4B: move health and version endpoints to system router

### DIFF
--- a/backend/app/api/system_routes.py
+++ b/backend/app/api/system_routes.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter
+
+from app.db import get_runtime_datastore_info
+
+router = APIRouter()
+
+VERSION_FILE_PATH = Path(__file__).resolve().parents[2] / 'VERSION.txt'
+VERSION_TAG = VERSION_FILE_PATH.read_text(encoding='utf-8').strip() if VERSION_FILE_PATH.exists() else 'dev'
+
+
+@router.get('/api/health')
+def health():
+    datastore_info = get_runtime_datastore_info()
+    payload = {'status': 'ok', 'datastore': datastore_info.get('datastore', 'onbekend')}
+    if datastore_info.get('database'):
+        payload['database'] = datastore_info['database']
+    if datastore_info.get('storage'):
+        payload['storage'] = datastore_info['storage']
+    return payload
+
+
+@router.get('/api/version')
+def api_version():
+    return {
+        'version': VERSION_TAG,
+        'source': 'VERSION.txt',
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -47,6 +47,7 @@ import tempfile
 import cv2
 
 from app.db import engine, get_runtime_datastore_info
+from app.api.system_routes import router as system_router
 from app.api.receipt_diagnosis_routes import router as receipt_diagnosis_router
 from app.api.receipt_preview_routes import router as receipt_preview_router, configure_receipt_preview_routes
 from app.services.receipt_baseline_service import run_receipt_parsing_baseline_suite
@@ -166,6 +167,7 @@ households = {}
 users = {email: dict(profile) for email, profile in DEFAULT_AUTH_USERS.items()}
 
 
+app.include_router(system_router)
 app.include_router(receipt_diagnosis_router)
 app.add_middleware(
     CORSMiddleware,
@@ -10780,26 +10782,6 @@ async def log_runtime_datastore_configuration():
 
 
 ensure_release_1221_schema()
-
-
-@app.get("/api/health")
-def health():
-    datastore_info = get_runtime_datastore_info()
-    payload = {"status": "ok", "datastore": datastore_info.get('datastore', 'onbekend')}
-    if datastore_info.get('database'):
-        payload['database'] = datastore_info['database']
-    if datastore_info.get('storage'):
-        payload['storage'] = datastore_info['storage']
-    return payload
-
-
-@app.get("/api/version")
-def api_version():
-    return {
-        "version": VERSION_TAG,
-        "source": "VERSION.txt",
-    }
-
 
 @app.post("/api/admin/backfill-purchase-import-live-aliases")
 def run_purchase_import_live_alias_backfill(household_id: Optional[str] = None, limit: Optional[int] = None):


### PR DESCRIPTION
## Doel

R4B verplaatst alleen de systeemroutes `/api/health` en `/api/version` uit `backend/app/main.py` naar een aparte FastAPI-router.

## Wijzigingen

- Nieuwe router: `backend/app/api/system_routes.py`
- `main.py` importeert en registreert `system_router`
- De oude directe `@app.get('/api/health')` en `@app.get('/api/version')` routes zijn verwijderd uit `main.py`

## Niet gewijzigd

- Geen businesslogica
- Geen databasewijzigingen
- Geen auth-wijzigingen
- Geen receipt/parser/OCR-wijzigingen
- Geen Gmail/integratie-wijzigingen
- Geen frontendwijzigingen

## Validatie

Lokaal uitgevoerd:

```bash
python -m py_compile backend/app/main.py backend/app/api/system_routes.py
```

Resultaat: geslaagd.

Diff:

```text
backend/app/main.py | 22 ++--------------------
1 file changed, 2 insertions(+), 20 deletions(-)
```

## PO-testadvies

Na merge:

```bash
git checkout sync/local-rezzerv-receipt-basis-v2
git pull
docker compose up --build -d
```

Controleer daarna:

- `/docs` opent
- login werkt
- `/api/health` geeft status ok
- `/api/version` geeft versie-informatie
