### PR TITLE
Refactor R4C: move dev status endpoint to dev system router

### DIFF
--- a/backend/app/api/dev_system_routes.py
+++ b/backend/app/api/dev_system_routes.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from fastapi import APIRouter, Header
+
+
+def create_dev_system_router(
+    *,
+    require_platform_admin_user: Callable[[Optional[str]], object],
+    count_table: Callable[[str], int],
+) -> APIRouter:
+    router = APIRouter()
+
+    @router.get('/api/dev/status')
+    def get_dev_status(authorization: Optional[str] = Header(None)):
+        require_platform_admin_user(authorization)
+        return {
+            'spaces': count_table('spaces'),
+            'sublocations': count_table('sublocations'),
+            'inventory': count_table('inventory'),
+        }
+
+    return router

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,6 +48,7 @@ import cv2
 
 from app.db import engine, get_runtime_datastore_info
 from app.api.system_routes import router as system_router
+from app.api.dev_system_routes import create_dev_system_router
 from app.api.receipt_diagnosis_routes import router as receipt_diagnosis_router
 from app.api.receipt_preview_routes import router as receipt_preview_router, configure_receipt_preview_routes
 from app.services.receipt_baseline_service import run_receipt_parsing_baseline_suite
@@ -168,6 +169,10 @@ users = {email: dict(profile) for email, profile in DEFAULT_AUTH_USERS.items()}
 
 
 app.include_router(system_router)
+app.include_router(create_dev_system_router(
+    require_platform_admin_user=require_platform_admin_user,
+    count_table=count_table,
+))
 app.include_router(receipt_diagnosis_router)
 app.add_middleware(
     CORSMiddleware,
@@ -13131,15 +13136,6 @@ def reset_dev_tables():
 def count_table(table_name: str) -> int:
     with engine.begin() as conn:
         return conn.execute(text(f"SELECT COUNT(*) FROM {table_name}")).scalar() or 0
-
-@app.get("/api/dev/status")
-def get_dev_status(authorization: Optional[str] = Header(None)):
-    require_platform_admin_user(authorization)
-    return {
-        "spaces": count_table("spaces"),
-        "sublocations": count_table("sublocations"),
-        "inventory": count_table("inventory"),
-    }
 
 @app.post("/api/dev/browser-regression/reset-fixture")
 def reset_browser_regression_fixture(authorization: Optional[str] = Header(None)):


### PR DESCRIPTION
## Doel

R4C verplaatst alleen de read-only route `/api/dev/status` uit `backend/app/main.py` naar een aparte dev-system router.

## Wijzigingen

- Nieuwe router-factory: `backend/app/api/dev_system_routes.py`
- `main.py` importeert `create_dev_system_router`
- `main.py` registreert de router met bestaande dependencies:
  - `require_platform_admin_user`
  - `count_table`
- De directe `@app.get('/api/dev/status')` route is verwijderd uit `main.py`

## Niet gewijzigd

- Geen businesslogica
- Geen databasewijzigingen
- Geen auth-wijzigingen
- Geen receipt/parser/OCR-wijzigingen
- Geen Gmail/integratie-wijzigingen
- Geen frontendwijzigingen

## Validatie

Lokaal uitgevoerd:

```bash
python -m py_compile backend/app/main.py backend/app/api/dev_system_routes.py
```

Resultaat: geslaagd.

## PO-testadvies

Na merge:

```bash
git checkout sync/local-rezzerv-receipt-basis-v2
git pull
docker compose up --build -d
```

Controleer daarna:

- `/docs` opent
- login werkt
- `/api/dev/status` blijft reageren zoals voorheen
