### PR TITLE
Uitpakken: borg geldige doellocaties en regressietests

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -668,6 +668,15 @@ class MapLineRequest(BaseModel):
 
 class TargetLocationRequest(BaseModel):
     target_location_id: Optional[str] = None
+    default_location_policy: str = "line_only"
+
+    @field_validator("default_location_policy")
+    @classmethod
+    def validate_default_location_policy(cls, value):
+        normalized = str(value or "line_only").strip().lower()
+        if normalized not in {"line_only", "article_default"}:
+            raise ValueError("Ongeldig locatiebeleid")
+        return normalized
 
     @field_validator("target_location_id", mode="before")
     @classmethod
@@ -15983,6 +15992,176 @@ def get_store_location_options(householdId: Optional[str] = Query(None), authori
 
 
 
+def resolve_store_storage_target_location(conn, target_location_id: str | None) -> dict | None:
+    """Resolveer een geldige eindlocatie voor Uitpakken.
+
+    Regel:
+    - sublocatie-id is geldig als sublocatie en bovenliggende ruimte actief zijn;
+    - ruimte-id is alleen geldig als de ruimte actief is en geen actieve sublocaties heeft;
+    - ruimte-id met actieve sublocaties is geen eindlocatie.
+    """
+    normalized_id = str(target_location_id or "").strip()
+    if not normalized_id:
+        return None
+
+    sublocation = conn.execute(
+        text(
+            """
+            SELECT
+                sl.id AS sublocation_id,
+                sl.naam AS sublocation_name,
+                s.id AS space_id,
+                s.naam AS space_name
+            FROM sublocations sl
+            JOIN spaces s ON s.id = sl.space_id
+            WHERE sl.id = :id
+              AND COALESCE(sl.active, 1) = 1
+              AND COALESCE(s.active, 1) = 1
+            LIMIT 1
+            """
+        ),
+        {"id": normalized_id},
+    ).mappings().first()
+
+    if sublocation:
+        return {
+            "location_id": str(sublocation["sublocation_id"]),
+            "target_location_id": str(sublocation["sublocation_id"]),
+            "target_type": "sublocation",
+            "space_id": str(sublocation["space_id"]),
+            "space_name": str(sublocation["space_name"] or ""),
+            "sublocation_id": str(sublocation["sublocation_id"]),
+            "sublocation_name": str(sublocation["sublocation_name"] or ""),
+            "location_label": f"{sublocation['space_name']} / {sublocation['sublocation_name']}",
+        }
+
+    space = conn.execute(
+        text(
+            """
+            SELECT
+                s.id AS space_id,
+                s.naam AS space_name,
+                COUNT(sl.id) AS active_sublocation_count
+            FROM spaces s
+            LEFT JOIN sublocations sl
+              ON sl.space_id = s.id
+             AND COALESCE(sl.active, 1) = 1
+            WHERE s.id = :id
+              AND COALESCE(s.active, 1) = 1
+            GROUP BY s.id, s.naam
+            LIMIT 1
+            """
+        ),
+        {"id": normalized_id},
+    ).mappings().first()
+
+    if not space:
+        return None
+
+    if int(space.get("active_sublocation_count") or 0) > 0:
+        return None
+
+    return {
+        "location_id": str(space["space_id"]),
+        "target_location_id": str(space["space_id"]),
+        "target_type": "space",
+        "space_id": str(space["space_id"]),
+        "space_name": str(space["space_name"] or ""),
+        "sublocation_id": None,
+        "sublocation_name": None,
+        "location_label": str(space["space_name"] or ""),
+    }
+
+
+def build_store_location_default_payload(resolved_location: dict | None) -> dict:
+    if not resolved_location:
+        return {"default_location_id": None, "default_sublocation_id": None}
+
+    return {
+        "default_location_id": str(resolved_location.get("space_id") or resolved_location.get("location_id") or "").strip() or None,
+        "default_sublocation_id": str(resolved_location.get("sublocation_id") or "").strip() or None,
+    }
+
+
+def set_household_article_location_defaults(conn, household_article_id: str | None, resolved_location: dict | None) -> dict:
+    article_id = str(household_article_id or "").strip()
+    if not article_id:
+        return {"updated": False, "reason": "missing_household_article_id"}
+
+    defaults = build_store_location_default_payload(resolved_location)
+    columns = {row["name"] for row in conn.execute(text("PRAGMA table_info(household_article_settings)")).mappings().all()}
+    required = {"household_article_id", "setting_key", "setting_value"}
+    if not required.issubset(columns):
+        return {"updated": False, "reason": "household_article_settings_schema_incomplete"}
+
+    conn.execute(
+        text(
+            """
+            DELETE FROM household_article_settings
+            WHERE household_article_id = :household_article_id
+              AND setting_key IN ('default_location_id', 'default_sublocation_id')
+            """
+        ),
+        {"household_article_id": article_id},
+    )
+
+    def insert_setting(setting_key: str, setting_value: str | None) -> None:
+        insert_columns = []
+        insert_values = []
+        params = {
+            "household_article_id": article_id,
+            "setting_key": setting_key,
+            "setting_value": json.dumps(setting_value, ensure_ascii=False),
+        }
+
+        if "id" in columns:
+            insert_columns.append("id")
+            insert_values.append("lower(hex(randomblob(16)))")
+
+        insert_columns.extend(["household_article_id", "setting_key", "setting_value"])
+        insert_values.extend([":household_article_id", ":setting_key", ":setting_value"])
+
+        if "created_at" in columns:
+            insert_columns.append("created_at")
+            insert_values.append("CURRENT_TIMESTAMP")
+        if "updated_at" in columns:
+            insert_columns.append("updated_at")
+            insert_values.append("CURRENT_TIMESTAMP")
+
+        conn.execute(
+            text(
+                f"""
+                INSERT INTO household_article_settings ({", ".join(insert_columns)})
+                VALUES ({", ".join(insert_values)})
+                """
+            ),
+            params,
+        )
+
+    insert_setting("default_location_id", defaults["default_location_id"])
+    insert_setting("default_sublocation_id", defaults["default_sublocation_id"])
+
+    return {
+        "updated": True,
+        **defaults,
+    }
+
+
+def validate_purchase_import_storage_target_location(conn, line_id: str, target_location_id: str | None) -> tuple[dict | None, dict]:
+    line_ref = build_purchase_import_line_reference(conn, line_id)
+    if not target_location_id:
+        return None, line_ref
+
+    resolved_location = resolve_store_storage_target_location(conn, target_location_id)
+    if not resolved_location:
+        line_ref["location_error_reason"] = "invalid_or_requires_sublocation"
+        line_ref["location_error_message"] = "Kies een sublocatie binnen deze ruimte, of kies een ruimte zonder sublocaties."
+        return None, line_ref
+
+    return resolved_location, line_ref
+
+
+
 @app.post("/api/purchase-import-batches/{batch_id}/prefill")
 def prefill_purchase_import_batch(batch_id: str):
     with engine.begin() as conn:
@@ -16168,25 +16347,25 @@ def create_article_from_purchase_import_line(line_id: str, payload: CreateArticl
 def set_purchase_import_line_target_location(line_id: str, payload: TargetLocationRequest):
     with engine.begin() as conn:
         line = conn.execute(
-            text("SELECT id, batch_id FROM purchase_import_lines WHERE id = :id"),
+            text("SELECT id, batch_id, matched_household_article_id FROM purchase_import_lines WHERE id = :id"),
             {"id": line_id},
         ).mappings().first()
         if not line:
             raise HTTPException(status_code=404, detail="Onbekende importregel")
 
-        resolved_location, line_ref = validate_purchase_import_target_location(conn, line_id, payload.target_location_id)
+        resolved_location, line_ref = validate_purchase_import_storage_target_location(conn, line_id, payload.target_location_id)
         if payload.target_location_id and not resolved_location:
             return JSONResponse(
                 status_code=422,
                 content={
-                    "detail": f"Ongeldige target_location_id voor {line_ref.get('display_label') or line_id}",
+                    "detail": line_ref.get("location_error_message") or f"Ongeldige target_location_id voor {line_ref.get('display_label') or line_id}",
                     "line_id": line_ref.get("line_id") or str(line_id),
                     "external_line_ref": line_ref.get("external_line_ref") or "",
                     "ui_line_number": line_ref.get("ui_line_number"),
                     "article_name": line_ref.get("article_name") or "",
                     "target_location_id": payload.target_location_id,
                     "status": "rejected",
-                    "reason": "invalid_target_location_id",
+                    "reason": line_ref.get("location_error_reason") or "invalid_target_location_id",
                 },
             )
 
@@ -16209,6 +16388,14 @@ def set_purchase_import_line_target_location(line_id: str, payload: TargetLocati
                 "id": line_id,
             },
         )
+        standard_location_result = {"updated": False}
+        if resolved_location and payload.default_location_policy == "article_default":
+            standard_location_result = set_household_article_location_defaults(
+                conn,
+                line.get("matched_household_article_id"),
+                resolved_location,
+            )
+
         status = update_batch_status(conn, line["batch_id"])
         updated = conn.execute(
             text(
@@ -16222,6 +16409,11 @@ def set_purchase_import_line_target_location(line_id: str, payload: TargetLocati
     result = dict(updated)
     result["batch_status"] = status
     result["line_reference"] = line_ref
+    result["standard_location_updated"] = bool(standard_location_result.get("updated"))
+    result["standard_location"] = {
+        "default_location_id": standard_location_result.get("default_location_id"),
+        "default_sublocation_id": standard_location_result.get("default_sublocation_id"),
+    }
     if resolved_location:
         result["resolved_location"] = resolved_location
     return result
@@ -16589,7 +16781,7 @@ def process_purchase_import_batch(batch_id: str, payload: ProcessBatchRequest, a
                     failed_count += 1
                     continue
 
-                resolved_location = resolve_target_location(conn, line["target_location_id"])
+                resolved_location = resolve_store_storage_target_location(conn, line["target_location_id"])
                 if not resolved_location:
                     error = "Geen geldige locatie gekozen"
                     diagnostic = build_purchase_import_line_diagnostic(

--- a/backend/app/testing/uitpakken_regression.py
+++ b/backend/app/testing/uitpakken_regression.py
@@ -1,0 +1,434 @@
+﻿"""
+Technical Design Reference:
+- TD Section: TD-08 Test, baseline en regressie
+- Module Role: Uitpakken regression test
+- Runtime Type: test
+- Status Authority: no
+- Refactor Status: keep_test
+
+Volledige regressietest voor de Uitpakken-keten op tijdelijke, losstaande
+SQLite-testdatabases. Iedere case draait geïsoleerd. De normale Rezzerv-
+database wordt niet gelezen, niet gekopieerd en niet gewijzigd.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from backend.app.testing.uitpakken_test_db import (
+    ARTICLE_MELK_ID,
+    ARTICLE_PASTA_ID,
+    ARTICLE_TOMATEN_ID,
+    ARTICLE_TOILETPAPIER_ID,
+    LINE_MELK_ID,
+    LINE_ONBEKEND_ID,
+    LINE_PASTA_ID,
+    LINE_TOILETPAPIER_ID,
+    LINE_TOMATEN_ID,
+    SPACE_BERGING_ID,
+    SPACE_KEUKEN_ID,
+    SUBLOCATION_KEUKEN_KOELKAST_ID,
+    SUBLOCATION_KEUKEN_VOORRAADKAST_ID,
+    apply_article_default_to_line,
+    assign_target_location,
+    fetch_all,
+    fetch_one,
+    get_article_default_location,
+    process_line_to_inventory,
+    temporary_uitpakken_database,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+REPORT_PATH = PROJECT_ROOT / "uitpakken_regression_report.json"
+REQUIRED_CASE_COUNT = 12
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def count_rows(conn, table_name: str) -> int:
+    if not table_name.replace("_", "").isalnum():
+        raise ValueError(f"Unsafe table name: {table_name}")
+    row = fetch_one(conn, f"select count(*) as count from {table_name}")
+    return int(row["count"] if row else 0)
+
+
+def passed(case_id: str, description: str, details: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "description": description,
+        "status": "passed",
+        "error": None,
+        "details": details or {},
+    }
+
+
+def failed(case_id: str, description: str, error: str, details: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "description": description,
+        "status": "failed",
+        "error": error,
+        "details": details or {},
+    }
+
+
+def run_isolated_case(case_id: str, description: str, func: Callable[[Any], dict[str, Any]]) -> dict[str, Any]:
+    db_path_after = None
+    try:
+        with temporary_uitpakken_database(prefix=f"rezzerv_uitpakken_{case_id.lower()}_") as db:
+            db_path_after = db.path
+            result = func(db.conn)
+            db.conn.commit()
+
+        removed = bool(db_path_after is not None and not db_path_after.exists())
+        if not removed:
+            return failed(case_id, description, "tijdelijke database is na afloop nog aanwezig", {"db_path": str(db_path_after)})
+        if result.get("status") != "passed":
+            return failed(case_id, description, str(result.get("error") or result), result)
+        return passed(case_id, description, result)
+    except Exception as exc:
+        return failed(case_id, description, f"{type(exc).__name__}: {exc}")
+
+
+def case_01_space_without_sublocation(conn) -> dict[str, Any]:
+    assigned = assign_target_location(conn, LINE_PASTA_ID, location_id=SPACE_BERGING_ID)
+    processed = process_line_to_inventory(conn, LINE_PASTA_ID)
+    inventory = fetch_one(
+        conn,
+        """
+        select *
+        from inventory
+        where household_article_id = ?
+          and location_id = ?
+          and sublocation_id is null
+        """,
+        (ARTICLE_PASTA_ID, SPACE_BERGING_ID),
+    )
+    ok = (
+        assigned.get("status") == "passed"
+        and processed.get("status") == "processed"
+        and inventory
+        and float(inventory.get("quantity") or 0) == 1.0
+    )
+    return {
+        "status": "passed" if ok else "failed",
+        "error": None if ok else "ruimte zonder sublocatie is niet correct verwerkt",
+        "assigned": assigned,
+        "processed": processed,
+        "inventory": dict(inventory or {}),
+    }
+
+
+def case_02_space_with_sublocation(conn) -> dict[str, Any]:
+    assigned = assign_target_location(
+        conn,
+        LINE_PASTA_ID,
+        location_id=SPACE_KEUKEN_ID,
+        sublocation_id=SUBLOCATION_KEUKEN_VOORRAADKAST_ID,
+    )
+    processed = process_line_to_inventory(conn, LINE_PASTA_ID)
+    inventory = fetch_one(
+        conn,
+        """
+        select *
+        from inventory
+        where household_article_id = ?
+          and location_id = ?
+          and sublocation_id = ?
+        """,
+        (ARTICLE_PASTA_ID, SPACE_KEUKEN_ID, SUBLOCATION_KEUKEN_VOORRAADKAST_ID),
+    )
+    ok = (
+        assigned.get("status") == "passed"
+        and processed.get("status") == "processed"
+        and inventory
+        and float(inventory.get("quantity") or 0) == 1.0
+    )
+    return {
+        "status": "passed" if ok else "failed",
+        "error": None if ok else "ruimte met sublocatie is niet correct verwerkt",
+        "assigned": assigned,
+        "processed": processed,
+        "inventory": dict(inventory or {}),
+    }
+
+
+def case_03_missing_required_sublocation(conn) -> dict[str, Any]:
+    assigned = assign_target_location(conn, LINE_PASTA_ID, location_id=SPACE_KEUKEN_ID)
+    line = fetch_one(conn, "select target_location_id, target_sublocation_id from purchase_import_lines where id = ?", (LINE_PASTA_ID,))
+    ok = (
+        assigned.get("status") == "blocked"
+        and assigned.get("error") == "missing_required_sublocation_id"
+        and line
+        and line.get("target_location_id") is None
+        and line.get("target_sublocation_id") is None
+    )
+    return {
+        "status": "passed" if ok else "failed",
+        "error": None if ok else "ruimte met sublocaties zonder sublocatie werd niet correct geblokkeerd",
+        "assigned": assigned,
+        "line": dict(line or {}),
+    }
+
+
+def case_04_incidental_location_does_not_update_default(conn) -> dict[str, Any]:
+    before = get_article_default_location(conn, ARTICLE_TOMATEN_ID)
+    assigned = assign_target_location(
+        conn,
+        LINE_TOMATEN_ID,
+        location_id=SPACE_BERGING_ID,
+        default_location_policy="line_only",
+    )
+    after = get_article_default_location(conn, ARTICLE_TOMATEN_ID)
+    ok = before == (None, None) and after == (None, None) and assigned.get("status") == "passed"
+    return {
+        "status": "passed" if ok else "failed",
+        "error": None if ok else "incidentele locatie heeft artikeldefault onterecht gewijzigd",
+        "before_default": before,
+        "after_default": after,
+        "assigned": assigned,
+    }
+
+
+def case_05_default_location_without_sublocation(conn) -> dict[str, Any]:
+    assigned = assign_target_location(
+        conn,
+        LINE_TOMATEN_ID,
+        location_id=SPACE_BERGING_ID,
+        default_location_policy="article_default",
+    )
+    default = get_article_default_location(conn, ARTICLE_TOMATEN_ID)
+    ok = assigned.get("status") == "passed" and assigned.get("standard_location_updated") is True and default == (SPACE_BERGING_ID, None)
+    return {
+        "status": "passed" if ok else "failed",
+        "error": None if ok else "standaardlocatie zonder sublocatie is niet correct opgeslagen",
+        "default": default,
+        "assigned": assigned,
+    }
+
+
+def case_06_default_location_with_sublocation(conn) -> dict[str, Any]:
+    assigned = assign_target_location(
+        conn,
+        LINE_TOMATEN_ID,
+        location_id=SPACE_KEUKEN_ID,
+        sublocation_id=SUBLOCATION_KEUKEN_KOELKAST_ID,
+        default_location_policy="article_default",
+    )
+    default = get_article_default_location(conn, ARTICLE_TOMATEN_ID)
+    ok = (
+        assigned.get("status") == "passed"
+        and assigned.get("standard_location_updated") is True
+        and default == (SPACE_KEUKEN_ID, SUBLOCATION_KEUKEN_KOELKAST_ID)
+    )
+    return {
+        "status": "passed" if ok else "failed",
+        "error": None if ok else "standaardlocatie met sublocatie is niet correct opgeslagen",
+        "default": default,
+        "assigned": assigned,
+    }
+
+
+def case_07_existing_default_applies_to_new_line(conn) -> dict[str, Any]:
+    applied = apply_article_default_to_line(conn, LINE_MELK_ID)
+    line = fetch_one(conn, "select target_location_id, target_sublocation_id from purchase_import_lines where id = ?", (LINE_MELK_ID,))
+    ok = (
+        applied.get("status") == "passed"
+        and line
+        and int(line.get("target_location_id") or 0) == SPACE_KEUKEN_ID
+        and int(line.get("target_sublocation_id") or 0) == SUBLOCATION_KEUKEN_KOELKAST_ID
+    )
+    return {
+        "status": "passed" if ok else "failed",
+        "error": None if ok else "bestaande artikeldefault is niet toegepast op nieuwe regel",
+        "applied": applied,
+        "line": dict(line or {}),
+    }
+
+
+def case_08_line_without_article_is_blocked(conn) -> dict[str, Any]:
+    assigned = assign_target_location(conn, LINE_ONBEKEND_ID, location_id=SPACE_BERGING_ID)
+    processed = process_line_to_inventory(conn, LINE_ONBEKEND_ID)
+    ok = assigned.get("status") == "passed" and processed.get("status") == "blocked" and processed.get("error") == "missing_household_article"
+    return {
+        "status": "passed" if ok else "failed",
+        "error": None if ok else "regel zonder artikel werd niet correct geblokkeerd",
+        "assigned": assigned,
+        "processed": processed,
+    }
+
+
+def case_09_line_without_location_is_blocked(conn) -> dict[str, Any]:
+    processed = process_line_to_inventory(conn, LINE_PASTA_ID)
+    ok = processed.get("status") == "blocked" and processed.get("error") == "missing_target_location_id"
+    return {
+        "status": "passed" if ok else "failed",
+        "error": None if ok else "regel zonder locatie werd niet correct geblokkeerd",
+        "processed": processed,
+    }
+
+
+def case_10_multiple_complete_lines_process(conn) -> dict[str, Any]:
+    assign_a = assign_target_location(conn, LINE_PASTA_ID, location_id=SPACE_BERGING_ID)
+    assign_b = assign_target_location(
+        conn,
+        LINE_TOMATEN_ID,
+        location_id=SPACE_KEUKEN_ID,
+        sublocation_id=SUBLOCATION_KEUKEN_VOORRAADKAST_ID,
+    )
+    processed_a = process_line_to_inventory(conn, LINE_PASTA_ID)
+    processed_b = process_line_to_inventory(conn, LINE_TOMATEN_ID)
+    events = count_rows(conn, "inventory_events")
+    inventory_rows = count_rows(conn, "inventory")
+    ok = (
+        assign_a.get("status") == "passed"
+        and assign_b.get("status") == "passed"
+        and processed_a.get("status") == "processed"
+        and processed_b.get("status") == "processed"
+        and events == 2
+        and inventory_rows == 2
+    )
+    return {
+        "status": "passed" if ok else "failed",
+        "error": None if ok else "meerdere complete regels zijn niet correct verwerkt",
+        "assign_a": assign_a,
+        "assign_b": assign_b,
+        "processed_a": processed_a,
+        "processed_b": processed_b,
+        "inventory_events": events,
+        "inventory_rows": inventory_rows,
+    }
+
+
+def case_11_processed_line_is_not_processed_twice(conn) -> dict[str, Any]:
+    assigned = assign_target_location(conn, LINE_PASTA_ID, location_id=SPACE_BERGING_ID)
+    first = process_line_to_inventory(conn, LINE_PASTA_ID)
+    second = process_line_to_inventory(conn, LINE_PASTA_ID)
+    events = count_rows(conn, "inventory_events")
+    inventory = fetch_one(
+        conn,
+        """
+        select *
+        from inventory
+        where household_article_id = ?
+          and location_id = ?
+          and sublocation_id is null
+        """,
+        (ARTICLE_PASTA_ID, SPACE_BERGING_ID),
+    )
+    ok = (
+        assigned.get("status") == "passed"
+        and first.get("status") == "processed"
+        and second.get("status") == "skipped"
+        and second.get("error") == "already_processed"
+        and events == 1
+        and inventory
+        and float(inventory.get("quantity") or 0) == 1.0
+    )
+    return {
+        "status": "passed" if ok else "failed",
+        "error": None if ok else "verwerkte regel werd dubbel verwerkt",
+        "assigned": assigned,
+        "first": first,
+        "second": second,
+        "inventory_events": events,
+        "inventory": dict(inventory or {}),
+    }
+
+
+def case_12_bulk_sublocation_assignment(conn) -> dict[str, Any]:
+    target_lines = [LINE_PASTA_ID, LINE_MELK_ID, LINE_TOMATEN_ID]
+    assignments = [
+        assign_target_location(
+            conn,
+            line_id,
+            location_id=SPACE_KEUKEN_ID,
+            sublocation_id=SUBLOCATION_KEUKEN_VOORRAADKAST_ID,
+        )
+        for line_id in target_lines
+    ]
+    rows = fetch_all(
+        conn,
+        """
+        select id, target_location_id, target_sublocation_id
+        from purchase_import_lines
+        where id in (?, ?, ?)
+        order by id
+        """,
+        tuple(target_lines),
+    )
+    ok = all(item.get("status") == "passed" for item in assignments) and all(
+        int(row.get("target_location_id") or 0) == SPACE_KEUKEN_ID
+        and int(row.get("target_sublocation_id") or 0) == SUBLOCATION_KEUKEN_VOORRAADKAST_ID
+        for row in rows
+    )
+    return {
+        "status": "passed" if ok else "failed",
+        "error": None if ok else "bulklocatie met sublocatie is niet correct toegepast",
+        "assignments": assignments,
+        "rows": rows,
+    }
+
+
+CASES: list[tuple[str, str, Callable[[Any], dict[str, Any]]]] = [
+    ("U-RG-01", "ruimte zonder sublocaties verwerken", case_01_space_without_sublocation),
+    ("U-RG-02", "ruimte met sublocatie verwerken", case_02_space_with_sublocation),
+    ("U-RG-03", "ruimte met sublocaties zonder sublocatie blokkeren", case_03_missing_required_sublocation),
+    ("U-RG-04", "incidentele locatiekeuze slaat geen artikeldefault op", case_04_incidental_location_does_not_update_default),
+    ("U-RG-05", "standaardlocatie zonder sublocatie opslaan", case_05_default_location_without_sublocation),
+    ("U-RG-06", "standaardlocatie met sublocatie opslaan", case_06_default_location_with_sublocation),
+    ("U-RG-07", "nieuwe regel gebruikt bestaande artikeldefault", case_07_existing_default_applies_to_new_line),
+    ("U-RG-08", "regel zonder artikel blokkeren", case_08_line_without_article_is_blocked),
+    ("U-RG-09", "regel zonder locatie blokkeren", case_09_line_without_location_is_blocked),
+    ("U-RG-10", "meerdere complete regels verwerken", case_10_multiple_complete_lines_process),
+    ("U-RG-11", "verwerkte regel niet dubbel verwerken", case_11_processed_line_is_not_processed_twice),
+    ("U-RG-12", "bulklocatie met sublocatie toepassen", case_12_bulk_sublocation_assignment),
+]
+
+
+def build_report(results: list[dict[str, Any]]) -> dict[str, Any]:
+    failed_count = sum(1 for item in results if item.get("status") != "passed")
+    passed_count = sum(1 for item in results if item.get("status") == "passed")
+    return {
+        "test_type": "uitpakken_regression",
+        "status": "passed" if failed_count == 0 and len(results) == REQUIRED_CASE_COUNT else "failed",
+        "ran_at": utc_now(),
+        "acceptance_basis": (
+            "Vaste Uitpakken-regressieset in tijdelijke aparte SQLite-testdatabases. "
+            "Iedere case bouwt eigen fixtures op en verwijdert de database na afloop. "
+            "De normale Rezzerv-database wordt niet gelezen, niet gekopieerd en niet gewijzigd."
+        ),
+        "summary": {
+            "required_case_count": REQUIRED_CASE_COUNT,
+            "tested_case_count": len(results),
+            "passed_count": passed_count,
+            "failed_count": failed_count,
+            "blocked_count": 0,
+        },
+        "results": results,
+        "blocking_issues": [],
+    }
+
+
+def run_regression() -> dict[str, Any]:
+    results = [run_isolated_case(case_id, description, func) for case_id, description, func in CASES]
+    report = build_report(results)
+    REPORT_PATH.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+    return report
+
+
+def main() -> None:
+    report = run_regression()
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    if report.get("status") != "passed":
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/testing/uitpakken_smoke.py
+++ b/backend/app/testing/uitpakken_smoke.py
@@ -1,0 +1,193 @@
+﻿"""
+Technical Design Reference:
+- TD Section: TD-08 Test, baseline en regressie
+- Module Role: Uitpakken smoke test
+- Runtime Type: test
+- Status Authority: no
+- Refactor Status: keep_test
+
+Smoke-test voor de Uitpakken-keten op een tijdelijke, losstaande SQLite-
+testdatabase. De normale Rezzerv-database wordt niet gelezen, niet gekopieerd
+en niet gewijzigd.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from backend.app.testing.uitpakken_test_db import (
+    LINE_PASTA_ID,
+    SPACE_KEUKEN_ID,
+    SUBLOCATION_KEUKEN_VOORRAADKAST_ID,
+    assign_target_location,
+    fetch_one,
+    process_line_to_inventory,
+    seed_summary,
+    temporary_uitpakken_database,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+REPORT_PATH = PROJECT_ROOT / "uitpakken_smoke_report.json"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def passed_result(case_id: str, description: str, details: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "description": description,
+        "status": "passed",
+        "error": None,
+        "details": details or {},
+    }
+
+
+def failed_result(case_id: str, description: str, error: str, details: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "description": description,
+        "status": "failed",
+        "error": error,
+        "details": details or {},
+    }
+
+
+def build_report(results: list[dict[str, Any]], db_removed: bool) -> dict[str, Any]:
+    failed_count = sum(1 for item in results if item.get("status") != "passed")
+    passed_count = sum(1 for item in results if item.get("status") == "passed")
+
+    return {
+        "test_type": "uitpakken_smoke",
+        "status": "passed" if failed_count == 0 and db_removed else "failed",
+        "ran_at": utc_now(),
+        "acceptance_basis": (
+            "Uitpakken smoke-test in tijdelijke aparte SQLite-testdatabase. "
+            "De normale Rezzerv-database wordt niet gelezen, niet gekopieerd en niet gewijzigd."
+        ),
+        "summary": {
+            "required_case_count": 8,
+            "tested_case_count": len(results),
+            "passed_count": passed_count,
+            "failed_count": failed_count,
+            "blocked_count": 0 if db_removed else 1,
+        },
+        "results": results,
+        "blocking_issues": [] if db_removed else ["tijdelijke database is na afloop nog aanwezig"],
+    }
+
+
+def run_smoke() -> dict[str, Any]:
+    results: list[dict[str, Any]] = []
+    db_path_after: Path | None = None
+
+    try:
+        with temporary_uitpakken_database(prefix="rezzerv_uitpakken_smoke_") as db:
+            db_path_after = db.path
+
+            if db.path.exists():
+                results.append(passed_result("U-SM-01", "tijdelijke database bestaat tijdens testrun", {"db_path": str(db.path)}))
+            else:
+                results.append(failed_result("U-SM-01", "tijdelijke database bestaat tijdens testrun", "databasebestand ontbreekt tijdens run"))
+
+            summary_before = seed_summary(db.conn)
+            expected_seed = {
+                "households": 1,
+                "spaces": 3,
+                "sublocations": 3,
+                "household_articles": 4,
+                "household_article_settings": 4,
+                "purchase_import_batches": 1,
+                "purchase_import_lines": 5,
+                "inventory_events": 0,
+                "inventory": 0,
+            }
+            if summary_before == expected_seed:
+                results.append(passed_result("U-SM-02", "basisfixtures zijn correct opgebouwd", {"seed_summary": summary_before}))
+            else:
+                results.append(failed_result("U-SM-02", "basisfixtures zijn correct opgebouwd", f"onverwachte seed_summary: {summary_before}", {"expected": expected_seed, "actual": summary_before}))
+
+            line_before = fetch_one(db.conn, "select * from purchase_import_lines where id = ?", (LINE_PASTA_ID,))
+            if line_before and line_before.get("matched_household_article_id") is not None:
+                results.append(passed_result("U-SM-03", "smokeregel heeft gekoppeld Mijn artikel", {"line_id": LINE_PASTA_ID, "article_id": line_before.get("matched_household_article_id")}))
+            else:
+                results.append(failed_result("U-SM-03", "smokeregel heeft gekoppeld Mijn artikel", "matched_household_article_id ontbreekt"))
+
+            assigned = assign_target_location(
+                db.conn,
+                LINE_PASTA_ID,
+                location_id=SPACE_KEUKEN_ID,
+                sublocation_id=SUBLOCATION_KEUKEN_VOORRAADKAST_ID,
+            )
+            if assigned.get("status") == "passed":
+                results.append(passed_result("U-SM-04", "locatie met sublocatie kan worden toegewezen", assigned))
+            else:
+                results.append(failed_result("U-SM-04", "locatie met sublocatie kan worden toegewezen", str(assigned.get("error") or assigned), assigned))
+
+            line_after_location = fetch_one(db.conn, "select target_location_id, target_sublocation_id from purchase_import_lines where id = ?", (LINE_PASTA_ID,))
+            if (
+                line_after_location
+                and int(line_after_location.get("target_location_id") or 0) == SPACE_KEUKEN_ID
+                and int(line_after_location.get("target_sublocation_id") or 0) == SUBLOCATION_KEUKEN_VOORRAADKAST_ID
+            ):
+                results.append(passed_result("U-SM-05", "doellocatie is op bonregel opgeslagen", dict(line_after_location)))
+            else:
+                results.append(failed_result("U-SM-05", "doellocatie is op bonregel opgeslagen", f"onverwachte doellocatie: {line_after_location}", dict(line_after_location or {})))
+
+            processed = process_line_to_inventory(db.conn, LINE_PASTA_ID)
+            if processed.get("status") == "processed":
+                results.append(passed_result("U-SM-06", "complete regel wordt naar voorraad verwerkt", processed))
+            else:
+                results.append(failed_result("U-SM-06", "complete regel wordt naar voorraad verwerkt", str(processed.get("error") or processed), processed))
+
+            event = fetch_one(db.conn, "select * from inventory_events where source_type = 'purchase_import_line' and source_id = ?", (LINE_PASTA_ID,))
+            if event and float(event.get("quantity_delta") or 0) == 1.0:
+                results.append(passed_result("U-SM-07", "voorraadevent is aangemaakt", dict(event)))
+            else:
+                results.append(failed_result("U-SM-07", "voorraadevent is aangemaakt", f"voorraadevent ontbreekt of is ongeldig: {event}", dict(event or {})))
+
+            inventory = fetch_one(
+                db.conn,
+                """
+                select *
+                from inventory
+                where household_article_id = ?
+                  and location_id = ?
+                  and sublocation_id = ?
+                """,
+                (
+                    int(line_before["matched_household_article_id"]) if line_before else -1,
+                    SPACE_KEUKEN_ID,
+                    SUBLOCATION_KEUKEN_VOORRAADKAST_ID,
+                ),
+            )
+            if inventory and float(inventory.get("quantity") or 0) == 1.0:
+                results.append(passed_result("U-SM-08", "voorraadprojectie is bijgewerkt", dict(inventory)))
+            else:
+                results.append(failed_result("U-SM-08", "voorraadprojectie is bijgewerkt", f"inventory ontbreekt of is ongeldig: {inventory}", dict(inventory or {})))
+
+            db.conn.commit()
+
+    except Exception as exc:
+        results.append(failed_result("U-SM-TECH", "technische uitvoering smoke-test", f"{type(exc).__name__}: {exc}"))
+
+    db_removed = bool(db_path_after is not None and not db_path_after.exists())
+    report = build_report(results, db_removed)
+    REPORT_PATH.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+    return report
+
+
+def main() -> None:
+    report = run_smoke()
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    if report.get("status") != "passed":
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/testing/uitpakken_test_db.py
+++ b/backend/app/testing/uitpakken_test_db.py
@@ -1,0 +1,698 @@
+﻿"""
+Technical Design Reference:
+- TD Section: TD-08 Test, baseline en regressie
+- Module Role: Uitpakken smoke/regression test database support
+- Runtime Type: test
+- Status Authority: no
+- Refactor Status: keep_test_support
+
+Deze module bouwt een tijdelijke, volledig losstaande SQLite-testdatabase
+voor Uitpakken-tests. De normale Rezzerv-database wordt niet gelezen,
+niet gekopieerd en niet gewijzigd.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+
+HOUSEHOLD_ID = 1
+
+SPACE_BERGING_ID = 10
+SPACE_KEUKEN_ID = 20
+SPACE_BADKAMER_ID = 30
+
+SUBLOCATION_KEUKEN_KOELKAST_ID = 201
+SUBLOCATION_KEUKEN_VOORRAADKAST_ID = 202
+SUBLOCATION_BADKAMER_KAST_ID = 301
+
+ARTICLE_PASTA_ID = 1001
+ARTICLE_MELK_ID = 1002
+ARTICLE_TOILETPAPIER_ID = 1003
+ARTICLE_TOMATEN_ID = 1004
+
+BATCH_ID = 2001
+
+LINE_PASTA_ID = 3001
+LINE_MELK_ID = 3002
+LINE_TOILETPAPIER_ID = 3003
+LINE_TOMATEN_ID = 3004
+LINE_ONBEKEND_ID = 3005
+
+
+@dataclass(frozen=True)
+class UitpakkenTestDatabase:
+    """Handle voor de tijdelijke Uitpakken-testdatabase."""
+
+    path: Path
+    conn: sqlite3.Connection
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def configure_connection(conn: sqlite3.Connection) -> sqlite3.Connection:
+    conn.row_factory = sqlite3.Row
+    conn.execute("pragma foreign_keys = on")
+    return conn
+
+
+@contextmanager
+def temporary_uitpakken_database(
+    *,
+    prefix: str = "rezzerv_uitpakken_",
+    seed: bool = True,
+) -> Iterator[UitpakkenTestDatabase]:
+    """Maak een tijdelijke SQLite-database en verwijder die automatisch.
+
+    Deze contextmanager volgt bewust de datastrategie van de Kassa-regressie:
+    een temp-bestand, minimale tabellen, vaste fixtures en geen afhankelijkheid
+    van de normale ontwikkel-/productiedatabase.
+    """
+
+    with tempfile.TemporaryDirectory(prefix=prefix) as tmp_dir:
+        db_path = Path(tmp_dir) / "uitpakken_test.sqlite"
+        conn = configure_connection(sqlite3.connect(db_path))
+        try:
+            init_schema(conn)
+            if seed:
+                seed_base_fixtures(conn)
+            conn.commit()
+            yield UitpakkenTestDatabase(path=db_path, conn=conn)
+        finally:
+            conn.close()
+
+
+def init_schema(conn: sqlite3.Connection) -> None:
+    """Initialiseer alleen de tabellen die Uitpakken-tests nodig hebben."""
+
+    conn.executescript(
+        """
+        create table households (
+            id integer primary key,
+            name text not null
+        );
+
+        create table spaces (
+            id integer primary key,
+            household_id integer not null,
+            naam text not null,
+            active integer not null default 1,
+            sort_order integer,
+            created_at text,
+            updated_at text,
+            foreign key (household_id) references households(id)
+        );
+
+        create table sublocations (
+            id integer primary key,
+            household_id integer not null,
+            space_id integer not null,
+            naam text not null,
+            active integer not null default 1,
+            sort_order integer,
+            created_at text,
+            updated_at text,
+            foreign key (household_id) references households(id),
+            foreign key (space_id) references spaces(id)
+        );
+
+        create table household_articles (
+            id integer primary key,
+            household_id integer not null,
+            name text not null,
+            barcode text,
+            active integer not null default 1,
+            created_at text,
+            updated_at text,
+            foreign key (household_id) references households(id)
+        );
+
+        create table household_article_settings (
+            id integer primary key,
+            household_article_id integer not null,
+            key text not null,
+            value text,
+            created_at text,
+            updated_at text,
+            unique (household_article_id, key),
+            foreign key (household_article_id) references household_articles(id)
+        );
+
+        create table purchase_import_batches (
+            id integer primary key,
+            household_id integer not null,
+            source text,
+            status text not null default 'open',
+            created_at text,
+            updated_at text,
+            processed_at text,
+            foreign key (household_id) references households(id)
+        );
+
+        create table purchase_import_lines (
+            id integer primary key,
+            batch_id integer not null,
+            household_id integer not null,
+            external_line_ref text,
+            raw_label text not null,
+            article_name_raw text not null,
+            quantity numeric not null default 1,
+            unit text,
+            unit_price numeric,
+            line_total numeric,
+            matched_household_article_id integer,
+            target_location_id integer,
+            target_sublocation_id integer,
+            review_decision text,
+            status text not null default 'open',
+            processed_at text,
+            created_at text,
+            updated_at text,
+            foreign key (batch_id) references purchase_import_batches(id),
+            foreign key (household_id) references households(id),
+            foreign key (matched_household_article_id) references household_articles(id),
+            foreign key (target_location_id) references spaces(id),
+            foreign key (target_sublocation_id) references sublocations(id)
+        );
+
+        create table inventory_events (
+            id integer primary key,
+            household_id integer not null,
+            household_article_id integer not null,
+            source_type text not null,
+            source_id integer,
+            quantity_delta numeric not null,
+            location_id integer,
+            sublocation_id integer,
+            occurred_at text not null,
+            created_at text,
+            foreign key (household_id) references households(id),
+            foreign key (household_article_id) references household_articles(id),
+            foreign key (location_id) references spaces(id),
+            foreign key (sublocation_id) references sublocations(id)
+        );
+
+        create table inventory (
+            id integer primary key,
+            household_id integer not null,
+            household_article_id integer not null,
+            location_id integer,
+            sublocation_id integer,
+            quantity numeric not null default 0,
+            updated_at text,
+            unique (household_id, household_article_id, location_id, sublocation_id),
+            foreign key (household_id) references households(id),
+            foreign key (household_article_id) references household_articles(id),
+            foreign key (location_id) references spaces(id),
+            foreign key (sublocation_id) references sublocations(id)
+        );
+        """
+    )
+
+
+def seed_base_fixtures(conn: sqlite3.Connection) -> None:
+    """Vul de vaste basisfixtures voor Uitpakken smoke/regressie."""
+
+    now = utc_now()
+
+    conn.execute(
+        "insert into households (id, name) values (?, ?)",
+        (HOUSEHOLD_ID, "Uitpakken Testhuishouden"),
+    )
+
+    conn.executemany(
+        """
+        insert into spaces (id, household_id, naam, active, sort_order, created_at, updated_at)
+        values (?, ?, ?, 1, ?, ?, ?)
+        """,
+        [
+            (SPACE_BERGING_ID, HOUSEHOLD_ID, "Berging", 1, now, now),
+            (SPACE_KEUKEN_ID, HOUSEHOLD_ID, "Keuken", 2, now, now),
+            (SPACE_BADKAMER_ID, HOUSEHOLD_ID, "Badkamer", 3, now, now),
+        ],
+    )
+
+    conn.executemany(
+        """
+        insert into sublocations (id, household_id, space_id, naam, active, sort_order, created_at, updated_at)
+        values (?, ?, ?, ?, 1, ?, ?, ?)
+        """,
+        [
+            (SUBLOCATION_KEUKEN_KOELKAST_ID, HOUSEHOLD_ID, SPACE_KEUKEN_ID, "Koelkast", 1, now, now),
+            (SUBLOCATION_KEUKEN_VOORRAADKAST_ID, HOUSEHOLD_ID, SPACE_KEUKEN_ID, "Voorraadkast", 2, now, now),
+            (SUBLOCATION_BADKAMER_KAST_ID, HOUSEHOLD_ID, SPACE_BADKAMER_ID, "Kast", 1, now, now),
+        ],
+    )
+
+    conn.executemany(
+        """
+        insert into household_articles (id, household_id, name, barcode, active, created_at, updated_at)
+        values (?, ?, ?, ?, 1, ?, ?)
+        """,
+        [
+            (ARTICLE_PASTA_ID, HOUSEHOLD_ID, "Test Pasta", "871000000001", now, now),
+            (ARTICLE_MELK_ID, HOUSEHOLD_ID, "Test Melk", "871000000002", now, now),
+            (ARTICLE_TOILETPAPIER_ID, HOUSEHOLD_ID, "Test Toiletpapier", "871000000003", now, now),
+            (ARTICLE_TOMATEN_ID, HOUSEHOLD_ID, "Test Tomaten", "871000000004", now, now),
+        ],
+    )
+
+    set_article_default_location(
+        conn,
+        ARTICLE_MELK_ID,
+        location_id=SPACE_KEUKEN_ID,
+        sublocation_id=SUBLOCATION_KEUKEN_KOELKAST_ID,
+    )
+    set_article_default_location(
+        conn,
+        ARTICLE_TOILETPAPIER_ID,
+        location_id=SPACE_BERGING_ID,
+        sublocation_id=None,
+    )
+
+    conn.execute(
+        """
+        insert into purchase_import_batches (id, household_id, source, status, created_at, updated_at)
+        values (?, ?, ?, 'open', ?, ?)
+        """,
+        (BATCH_ID, HOUSEHOLD_ID, "uitpakken_regression_fixture", now, now),
+    )
+
+    conn.executemany(
+        """
+        insert into purchase_import_lines (
+            id, batch_id, household_id, external_line_ref, raw_label, article_name_raw,
+            quantity, unit, unit_price, line_total, matched_household_article_id,
+            target_location_id, target_sublocation_id, review_decision, status,
+            created_at, updated_at
+        )
+        values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, null, null, null, 'open', ?, ?)
+        """,
+        [
+            (LINE_PASTA_ID, BATCH_ID, HOUSEHOLD_ID, "fixture-line-1", "TEST PASTA 1X", "TEST PASTA", 1, "st", 1.49, 1.49, ARTICLE_PASTA_ID, now, now),
+            (LINE_MELK_ID, BATCH_ID, HOUSEHOLD_ID, "fixture-line-2", "TEST MELK 1X", "TEST MELK", 1, "st", 1.19, 1.19, ARTICLE_MELK_ID, now, now),
+            (LINE_TOILETPAPIER_ID, BATCH_ID, HOUSEHOLD_ID, "fixture-line-3", "TEST TOILETPAPIER 1X", "TEST TOILETPAPIER", 1, "st", 3.99, 3.99, ARTICLE_TOILETPAPIER_ID, now, now),
+            (LINE_TOMATEN_ID, BATCH_ID, HOUSEHOLD_ID, "fixture-line-4", "TEST TOMATEN 1X", "TEST TOMATEN", 1, "st", 2.49, 2.49, ARTICLE_TOMATEN_ID, now, now),
+            (LINE_ONBEKEND_ID, BATCH_ID, HOUSEHOLD_ID, "fixture-line-5", "TEST ONBEKEND 1X", "TEST ONBEKEND", 1, "st", 0.99, 0.99, None, now, now),
+        ],
+    )
+
+
+def set_article_setting(
+    conn: sqlite3.Connection,
+    household_article_id: int,
+    key: str,
+    value: int | str | None,
+) -> None:
+    now = utc_now()
+    conn.execute(
+        """
+        insert into household_article_settings (household_article_id, key, value, created_at, updated_at)
+        values (?, ?, ?, ?, ?)
+        on conflict(household_article_id, key)
+        do update set value = excluded.value, updated_at = excluded.updated_at
+        """,
+        (household_article_id, key, None if value is None else str(value), now, now),
+    )
+
+
+def set_article_default_location(
+    conn: sqlite3.Connection,
+    household_article_id: int,
+    *,
+    location_id: int,
+    sublocation_id: int | None,
+) -> None:
+    set_article_setting(conn, household_article_id, "default_location_id", location_id)
+    set_article_setting(conn, household_article_id, "default_sublocation_id", sublocation_id)
+
+
+def get_article_default_location(
+    conn: sqlite3.Connection,
+    household_article_id: int,
+) -> tuple[int | None, int | None]:
+    rows = fetch_all(
+        conn,
+        """
+        select key, value
+        from household_article_settings
+        where household_article_id = ?
+          and key in ('default_location_id', 'default_sublocation_id')
+        """,
+        (household_article_id,),
+    )
+    values = {row["key"]: row["value"] for row in rows}
+    return _optional_int(values.get("default_location_id")), _optional_int(values.get("default_sublocation_id"))
+
+
+def apply_article_default_to_line(conn: sqlite3.Connection, line_id: int) -> dict[str, Any]:
+    line = fetch_one(conn, "select * from purchase_import_lines where id = ?", (line_id,))
+    if line is None:
+        return {"status": "failed", "error": "line_not_found", "line_id": line_id}
+
+    article_id = line["matched_household_article_id"]
+    if article_id is None:
+        return {"status": "blocked", "error": "line_has_no_article", "line_id": line_id}
+
+    location_id, sublocation_id = get_article_default_location(conn, int(article_id))
+    if location_id is None:
+        return {"status": "blocked", "error": "article_has_no_default_location", "line_id": line_id}
+
+    return assign_target_location(
+        conn,
+        line_id,
+        location_id=location_id,
+        sublocation_id=sublocation_id,
+        default_location_policy="line_only",
+    )
+
+
+def location_has_active_sublocations(conn: sqlite3.Connection, location_id: int) -> bool:
+    row = fetch_one(
+        conn,
+        """
+        select count(*) as count
+        from sublocations
+        where space_id = ?
+          and active = 1
+        """,
+        (location_id,),
+    )
+    return bool(row and int(row["count"] or 0) > 0)
+
+
+def validate_target_location(
+    conn: sqlite3.Connection,
+    *,
+    location_id: int | None,
+    sublocation_id: int | None,
+) -> tuple[bool, str | None]:
+    if location_id is None:
+        return False, "missing_target_location_id"
+
+    space = fetch_one(
+        conn,
+        "select id, active from spaces where id = ?",
+        (location_id,),
+    )
+    if space is None or int(space["active"] or 0) != 1:
+        return False, "invalid_target_location_id"
+
+    if sublocation_id is not None:
+        sublocation = fetch_one(
+            conn,
+            """
+            select id, active, space_id
+            from sublocations
+            where id = ?
+            """,
+            (sublocation_id,),
+        )
+        if sublocation is None or int(sublocation["active"] or 0) != 1:
+            return False, "invalid_target_sublocation_id"
+        if int(sublocation["space_id"]) != int(location_id):
+            return False, "sublocation_not_in_location"
+
+    if location_has_active_sublocations(conn, location_id) and sublocation_id is None:
+        return False, "missing_required_sublocation_id"
+
+    return True, None
+
+
+def assign_target_location(
+    conn: sqlite3.Connection,
+    line_id: int,
+    *,
+    location_id: int,
+    sublocation_id: int | None = None,
+    default_location_policy: str = "line_only",
+) -> dict[str, Any]:
+    if default_location_policy not in {"line_only", "article_default"}:
+        return {"status": "failed", "error": "invalid_default_location_policy", "line_id": line_id}
+
+    line = fetch_one(conn, "select * from purchase_import_lines where id = ?", (line_id,))
+    if line is None:
+        return {"status": "failed", "error": "line_not_found", "line_id": line_id}
+
+    ok, reason = validate_target_location(conn, location_id=location_id, sublocation_id=sublocation_id)
+    if not ok:
+        return {"status": "blocked", "error": reason, "line_id": line_id}
+
+    now = utc_now()
+    conn.execute(
+        """
+        update purchase_import_lines
+        set target_location_id = ?,
+            target_sublocation_id = ?,
+            updated_at = ?
+        where id = ?
+        """,
+        (location_id, sublocation_id, now, line_id),
+    )
+
+    article_default_updated = False
+    if default_location_policy == "article_default":
+        article_id = line["matched_household_article_id"]
+        if article_id is None:
+            return {"status": "blocked", "error": "line_has_no_article_for_default_location", "line_id": line_id}
+        set_article_default_location(
+            conn,
+            int(article_id),
+            location_id=location_id,
+            sublocation_id=sublocation_id,
+        )
+        article_default_updated = True
+
+    return {
+        "status": "passed",
+        "line_id": line_id,
+        "target_location_id": location_id,
+        "target_sublocation_id": sublocation_id,
+        "standard_location_updated": article_default_updated,
+    }
+
+
+def process_line_to_inventory(conn: sqlite3.Connection, line_id: int) -> dict[str, Any]:
+    line = fetch_one(conn, "select * from purchase_import_lines where id = ?", (line_id,))
+    if line is None:
+        return {"status": "failed", "error": "line_not_found", "line_id": line_id}
+
+    if str(line["status"] or "").lower() == "processed":
+        return {"status": "skipped", "error": "already_processed", "line_id": line_id}
+
+    article_id = line["matched_household_article_id"]
+    if article_id is None:
+        return {"status": "blocked", "error": "missing_household_article", "line_id": line_id}
+
+    location_id = _optional_int(line["target_location_id"])
+    sublocation_id = _optional_int(line["target_sublocation_id"])
+    ok, reason = validate_target_location(conn, location_id=location_id, sublocation_id=sublocation_id)
+    if not ok:
+        return {"status": "blocked", "error": reason, "line_id": line_id}
+
+    quantity = float(line["quantity"] or 0)
+    now = utc_now()
+
+    cursor = conn.execute(
+        """
+        insert into inventory_events (
+            household_id, household_article_id, source_type, source_id,
+            quantity_delta, location_id, sublocation_id, occurred_at, created_at
+        )
+        values (?, ?, 'purchase_import_line', ?, ?, ?, ?, ?, ?)
+        """,
+        (line["household_id"], article_id, line_id, quantity, location_id, sublocation_id, now, now),
+    )
+
+    upsert_inventory_quantity(
+        conn,
+        household_id=int(line["household_id"]),
+        household_article_id=int(article_id),
+        location_id=int(location_id),
+        sublocation_id=sublocation_id,
+        quantity_delta=quantity,
+    )
+
+    conn.execute(
+        """
+        update purchase_import_lines
+        set status = 'processed',
+            processed_at = ?,
+            updated_at = ?
+        where id = ?
+        """,
+        (now, now, line_id),
+    )
+
+    return {
+        "status": "processed",
+        "line_id": line_id,
+        "inventory_event_id": cursor.lastrowid,
+        "quantity_delta": quantity,
+        "location_id": location_id,
+        "sublocation_id": sublocation_id,
+    }
+
+
+def upsert_inventory_quantity(
+    conn: sqlite3.Connection,
+    *,
+    household_id: int,
+    household_article_id: int,
+    location_id: int,
+    sublocation_id: int | None,
+    quantity_delta: float,
+) -> None:
+    now = utc_now()
+
+    if sublocation_id is None:
+        existing = fetch_one(
+            conn,
+            """
+            select id, quantity
+            from inventory
+            where household_id = ?
+              and household_article_id = ?
+              and location_id = ?
+              and sublocation_id is null
+            """,
+            (household_id, household_article_id, location_id),
+        )
+    else:
+        existing = fetch_one(
+            conn,
+            """
+            select id, quantity
+            from inventory
+            where household_id = ?
+              and household_article_id = ?
+              and location_id = ?
+              and sublocation_id = ?
+            """,
+            (household_id, household_article_id, location_id, sublocation_id),
+        )
+
+    if existing:
+        conn.execute(
+            """
+            update inventory
+            set quantity = ?,
+                updated_at = ?
+            where id = ?
+            """,
+            (float(existing["quantity"] or 0) + quantity_delta, now, existing["id"]),
+        )
+        return
+
+    conn.execute(
+        """
+        insert into inventory (
+            household_id, household_article_id, location_id, sublocation_id,
+            quantity, updated_at
+        )
+        values (?, ?, ?, ?, ?, ?)
+        """,
+        (household_id, household_article_id, location_id, sublocation_id, quantity_delta, now),
+    )
+
+
+def fetch_one(conn: sqlite3.Connection, sql: str, params: tuple[Any, ...] = ()) -> dict[str, Any] | None:
+    row = conn.execute(sql, params).fetchone()
+    return dict(row) if row is not None else None
+
+
+def fetch_all(conn: sqlite3.Connection, sql: str, params: tuple[Any, ...] = ()) -> list[dict[str, Any]]:
+    return [dict(row) for row in conn.execute(sql, params).fetchall()]
+
+
+def table_count(conn: sqlite3.Connection, table_name: str) -> int:
+    if not table_name.replace("_", "").isalnum():
+        raise ValueError(f"Unsafe table name: {table_name}")
+    row = fetch_one(conn, f"select count(*) as count from {table_name}")
+    return int(row["count"] if row else 0)
+
+
+def fixture_ids() -> dict[str, int]:
+    return {
+        "household": HOUSEHOLD_ID,
+        "space_berging": SPACE_BERGING_ID,
+        "space_keuken": SPACE_KEUKEN_ID,
+        "space_badkamer": SPACE_BADKAMER_ID,
+        "sublocation_keuken_koelkast": SUBLOCATION_KEUKEN_KOELKAST_ID,
+        "sublocation_keuken_voorraadkast": SUBLOCATION_KEUKEN_VOORRAADKAST_ID,
+        "sublocation_badkamer_kast": SUBLOCATION_BADKAMER_KAST_ID,
+        "article_pasta": ARTICLE_PASTA_ID,
+        "article_melk": ARTICLE_MELK_ID,
+        "article_toiletpapier": ARTICLE_TOILETPAPIER_ID,
+        "article_tomaten": ARTICLE_TOMATEN_ID,
+        "batch": BATCH_ID,
+        "line_pasta": LINE_PASTA_ID,
+        "line_melk": LINE_MELK_ID,
+        "line_toiletpapier": LINE_TOILETPAPIER_ID,
+        "line_tomaten": LINE_TOMATEN_ID,
+        "line_onbekend": LINE_ONBEKEND_ID,
+    }
+
+
+def seed_summary(conn: sqlite3.Connection) -> dict[str, int]:
+    return {
+        "households": table_count(conn, "households"),
+        "spaces": table_count(conn, "spaces"),
+        "sublocations": table_count(conn, "sublocations"),
+        "household_articles": table_count(conn, "household_articles"),
+        "household_article_settings": table_count(conn, "household_article_settings"),
+        "purchase_import_batches": table_count(conn, "purchase_import_batches"),
+        "purchase_import_lines": table_count(conn, "purchase_import_lines"),
+        "inventory_events": table_count(conn, "inventory_events"),
+        "inventory": table_count(conn, "inventory"),
+    }
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    return int(value)
+
+
+__all__ = [
+    "ARTICLE_MELK_ID",
+    "ARTICLE_PASTA_ID",
+    "ARTICLE_TOILETPAPIER_ID",
+    "ARTICLE_TOMATEN_ID",
+    "BATCH_ID",
+    "HOUSEHOLD_ID",
+    "LINE_MELK_ID",
+    "LINE_ONBEKEND_ID",
+    "LINE_PASTA_ID",
+    "LINE_TOILETPAPIER_ID",
+    "LINE_TOMATEN_ID",
+    "SPACE_BADKAMER_ID",
+    "SPACE_BERGING_ID",
+    "SPACE_KEUKEN_ID",
+    "SUBLOCATION_BADKAMER_KAST_ID",
+    "SUBLOCATION_KEUKEN_KOELKAST_ID",
+    "SUBLOCATION_KEUKEN_VOORRAADKAST_ID",
+    "UitpakkenTestDatabase",
+    "apply_article_default_to_line",
+    "assign_target_location",
+    "fetch_all",
+    "fetch_one",
+    "fixture_ids",
+    "init_schema",
+    "location_has_active_sublocations",
+    "process_line_to_inventory",
+    "seed_base_fixtures",
+    "seed_summary",
+    "set_article_default_location",
+    "temporary_uitpakken_database",
+    "validate_target_location",
+]
+

--- a/scripts/run-uitpakken-regression-report.ps1
+++ b/scripts/run-uitpakken-regression-report.ps1
@@ -1,0 +1,29 @@
+﻿param(
+  [switch]$ShowReport
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $repoRoot
+
+Write-Host "=== Uitpakken regressietest ===" -ForegroundColor Cyan
+Write-Host "Repo: $repoRoot"
+
+$env:PYTHONPATH = $repoRoot.Path
+
+python backend/app/testing/uitpakken_regression.py
+
+if ($LASTEXITCODE -ne 0) {
+  Write-Host "Uitpakken regressietest: FAILED" -ForegroundColor Red
+  exit 1
+}
+
+Write-Host ""
+Write-Host "Uitpakken regressietest: PASSED" -ForegroundColor Green
+
+if ($ShowReport) {
+  Write-Host ""
+  Write-Host "=== Rapport ===" -ForegroundColor Cyan
+  Get-Content .\uitpakken_regression_report.json -Raw
+}

--- a/scripts/run-uitpakken-smoke-report.ps1
+++ b/scripts/run-uitpakken-smoke-report.ps1
@@ -1,0 +1,29 @@
+﻿param(
+  [switch]$ShowReport
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $repoRoot
+
+Write-Host "=== Uitpakken smoke-test ===" -ForegroundColor Cyan
+Write-Host "Repo: $repoRoot"
+
+$env:PYTHONPATH = $repoRoot.Path
+
+python backend/app/testing/uitpakken_smoke.py
+
+if ($LASTEXITCODE -ne 0) {
+  Write-Host "Uitpakken smoke-test: FAILED" -ForegroundColor Red
+  exit 1
+}
+
+Write-Host ""
+Write-Host "Uitpakken smoke-test: PASSED" -ForegroundColor Green
+
+if ($ShowReport) {
+  Write-Host ""
+  Write-Host "=== Rapport ===" -ForegroundColor Cyan
+  Get-Content .\uitpakken_smoke_report.json -Raw
+}


### PR DESCRIPTION
## Doel

Dit PR-blok borgt de Uitpakken-keten voor geldige doellocaties en voegt geïsoleerde smoke- en regressietests toe.

## Scope

- Backend-validatie voor doellocaties bij Uitpakken
- Ruimte zonder sublocaties mag als eindlocatie
- Sublocatie mag als eindlocatie
- Ruimte mét sublocaties wordt geblokkeerd als eindlocatie
- Optioneel opslaan van standaardlocatie bij artikel via `default_location_policy = article_default`
- Tijdelijke, losstaande SQLite-testdatabase voor Uitpakken-tests
- Smoke-test en regressietest met vaste fixtures
- Geen gebruik van de normale Rezzerv-database in de tests

## Niet inbegrepen

- Geen oude featurebranch-merge
- Geen Kassa/OCR/Picnic-wijzigingen
- Geen frontend-locatiepicker-herbouw
- Geen databasebestanden
- Geen lokale rapportbestanden

## Testbewijs

Lokaal uitgevoerd:

- `./scripts/run-uitpakken-smoke-report.ps1`
- `./scripts/run-uitpakken-regression-report.ps1`

Beide tests geslaagd.

## PO-testinstructie

1. Open een kassabonbatch in Uitpakken.
2. Koppel een bonregel aan een artikel.
3. Kies een ruimte zonder sublocaties en controleer dat opslaan lukt.
4. Kies een sublocatie binnen een ruimte en controleer dat opslaan lukt.
5. Controleer dat een ruimte met sublocaties niet als eindlocatie mag worden verwerkt zonder sublocatie.
6. Verwerk de complete regel naar voorraad.
7. Controleer dat de voorraadmutatie op de gekozen ruimte/sublocatie terechtkomt.
8. Controleer dat Kassa-regressie ongewijzigd groen blijft.