### PR TITLE
Uitpakken: verbeter artikel-labelopmaak

### DIFF
--- a/frontend/src/features/stores/storeImportShared.jsx
+++ b/frontend/src/features/stores/storeImportShared.jsx
@@ -77,7 +77,9 @@ export const articleFallbackOptions = sortOptionObjects(demoData.articles.map((a
 })), (article) => articleLabel(article))
 
 export function articleLabel(article) {
-  return article.brand ? `${article.name} — ${article.brand}` : article.name
+  const name = String(article?.name || '').trim()
+  const brand = String(article?.brand || '').trim()
+  return brand ? `${name} - ${brand}` : name
 }
 
 export function StoreArticleSelector({


### PR DESCRIPTION
## Doel

Kleine UI-fix voor de artikel-labelweergave in Uitpakken.

## Scope

- Normaliseert artikelnaam en merk met `trim()`
- Voorkomt rommelige labels bij lege waarden
- Vervangt de lange scheidingsteken-weergave door een eenvoudige `naam - merk` notatie

## Niet inbegrepen

- Geen backendwijzigingen
- Geen Kassa/OCR-wijzigingen
- Geen oude featurebranch-merge
- Geen locatiepicker-wijzigingen

## Test / controle

Lokaal gecontroleerd:

- Diff bevat exact één frontendbestand: `frontend/src/features/stores/storeImportShared.jsx`
- Wijziging beperkt tot `articleLabel(article)`

## PO-testinstructie

1. Open Uitpakken.
2. Controleer een artikelkeuze waar een artikelnaam en merk zichtbaar zijn.
3. Controleer dat het label leesbaar is als `Artikelnaam - Merk`.
4. Controleer dat lege merkwaarden geen rare streepjes of kapotte tekens tonen.