### PR TITLE
Uitpakken: maak kassabonregelkoppen sticky

### DIFF
--- a/frontend/src/features/stores/StoreBatchDetailPage.jsx
+++ b/frontend/src/features/stores/StoreBatchDetailPage.jsx
@@ -723,7 +723,7 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
 
           {error ? <div className="rz-inline-feedback rz-inline-feedback--error" data-testid="receipt-feedback">{error}</div> : null}
           {status ? <div className="rz-inline-feedback rz-inline-feedback--success" data-testid="receipt-feedback">{status}</div> : null}
-          <Table wrapperClassName="rz-store-batch-table-wrapper" tableClassName="rz-store-workbench-table" dataTestId="receipt-lines-table" tableStyle={{ tableLayout: 'fixed', width: buildTableWidth(lineColumnWidths), minWidth: buildTableWidth(lineColumnWidths) }}>
+          <Table wrapperClassName="rz-store-batch-table-wrapper" tableClassName="rz-store-workbench-table rz-data-table--sticky-header rz-data-table--sticky-filters" dataTestId="receipt-lines-table" tableStyle={{ tableLayout: 'fixed', width: buildTableWidth(lineColumnWidths), minWidth: buildTableWidth(lineColumnWidths), '--rz-sticky-header-offset': '36px' }}>
               <colgroup>
                 <col style={{ width: `${lineColumnWidths.select}px` }} />
                 <col style={{ width: `${lineColumnWidths.bonartikel}px` }} />

--- a/frontend/src/ui/base.css
+++ b/frontend/src/ui/base.css
@@ -1637,3 +1637,18 @@ button.rz-tab.rz-tab-active {
   color: #667085;
   overflow-wrap: anywhere;
 }
+/* Uitpakken sticky table headers */
+.rz-table[data-testid="receipts-table"] thead tr.rz-table-header th,
+.rz-store-batch-table-wrapper .rz-table thead tr.rz-table-header th {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.rz-table[data-testid="receipts-table"] thead tr.rz-table-filters th,
+.rz-store-batch-table-wrapper .rz-table thead tr.rz-table-filters th {
+  position: sticky;
+  top: 42px;
+  z-index: 4;
+  background: var(--rz-surface, #fff);
+}


### PR DESCRIPTION
## Doel

Kleine UI-fix voor Uitpakken: de kop- en filterrij van de kassabonregel-tabel blijven zichtbaar tijdens scrollen.

## Scope

- Voegt sticky table classes toe aan de Uitpakken-kassabonregeltabel
- Voegt gerichte CSS toe voor sticky header- en filterrijen
- Beperkt tot twee frontendbestanden

## Niet inbegrepen

- Geen backendwijzigingen
- Geen kolomherindeling
- Geen locatiepicker-wijzigingen
- Geen oude featurebranch-merge

## Test / controle

Lokaal gecontroleerd:

- Diff bevat exact twee frontendbestanden:
  - `frontend/src/features/stores/StoreBatchDetailPage.jsx`
  - `frontend/src/ui/base.css`
- Commit bevat 16 insertions en 1 deletion

## PO-testinstructie

1. Open Uitpakken met een kassabonbatch met meerdere regels.
2. Scroll in de kassabonregeltabel.
3. Controleer dat de tabelkop zichtbaar blijft.
4. Controleer dat de filterrij zichtbaar blijft onder de tabelkop.
5. Controleer dat bestaande artikel-, locatie- en selectiefunctionaliteit ongewijzigd werkt.