### PR TITLE
feat(externe-databases): save product candidates

### DIFF
--- a/backend/app/api/system_routes.py
+++ b/backend/app/api/system_routes.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Body, HTTPException
+from fastapi import APIRouter, Body, HTTPException, Query
 
 from app.api.route_governance import build_route_governance_manifest
 from app.db import get_runtime_datastore_info
@@ -25,6 +25,11 @@ from app.services.external_database_matchers import (
     get_external_database_summary,
     list_external_database_retailers,
     match_retailer_receipt_line,
+)
+from app.services.external_product_candidate_store import (
+    build_candidate_context_key,
+    list_saved_external_product_candidates,
+    save_matchpreview_candidates,
 )
 
 router = APIRouter()
@@ -74,6 +79,40 @@ def external_databases_match_preview(retailer_code: str, payload: dict[str, Any]
         receipt_line_text=receipt_line_text,
         include_below_threshold=include_below_threshold,
     )
+
+
+@router.post('/api/external-databases/retailers/{retailer_code}/save-candidates')
+def external_databases_save_candidates(retailer_code: str, payload: dict[str, Any] = Body(default_factory=dict)):
+    receipt_line_text = str(payload.get('receipt_line_text') or payload.get('query') or '').strip()
+    if not receipt_line_text:
+        raise HTTPException(status_code=400, detail='Bonregel is verplicht om kandidaten op te slaan')
+    return save_matchpreview_candidates(
+        retailer_code=retailer_code,
+        receipt_line_text=receipt_line_text,
+        receipt_line_id=str(payload.get('receipt_line_id') or '').strip() or None,
+        purchase_import_line_id=str(payload.get('purchase_import_line_id') or '').strip() or None,
+        include_below_threshold=bool(payload.get('include_below_threshold', False)),
+    )
+
+
+@router.get('/api/external-databases/candidates')
+def external_databases_saved_candidates(
+    context_key: str | None = Query(default=None),
+    retailer_code: str | None = Query(default=None),
+    receipt_line_text: str | None = Query(default=None),
+    receipt_line_id: str | None = Query(default=None),
+    purchase_import_line_id: str | None = Query(default=None),
+    limit: int = Query(default=50),
+):
+    resolved_context_key = context_key
+    if not resolved_context_key and retailer_code and receipt_line_text:
+        resolved_context_key = build_candidate_context_key(
+            retailer_code,
+            receipt_line_text,
+            receipt_line_id=receipt_line_id,
+            purchase_import_line_id=purchase_import_line_id,
+        )
+    return list_saved_external_product_candidates(context_key=resolved_context_key, limit=limit)
 
 
 @router.get('/api/admin/route-governance')

--- a/backend/app/services/external_product_candidate_store.py
+++ b/backend/app/services/external_product_candidate_store.py
@@ -15,16 +15,41 @@ PROTECTED_CANDIDATE_STATUSES = {
     "external_database_override",
 }
 
+CANDIDATE_COLUMNS: dict[str, str] = {
+    "id": "TEXT PRIMARY KEY",
+    "receipt_line_id": "TEXT",
+    "purchase_import_line_id": "TEXT",
+    "context_key": "TEXT",
+    "retailer_code": "TEXT",
+    "receipt_line_text": "TEXT",
+    "candidate_name": "TEXT",
+    "candidate_brand": "TEXT",
+    "candidate_source_name": "TEXT",
+    "candidate_source_product_code": "TEXT",
+    "retailer_article_number": "TEXT",
+    "quantity_label": "TEXT",
+    "variant": "TEXT",
+    "source_url": "TEXT",
+    "score": "REAL",
+    "score_breakdown_json": "TEXT",
+    "candidate_status": "TEXT",
+    "is_probable": "INTEGER DEFAULT 0",
+    "is_user_confirmed": "INTEGER DEFAULT 0",
+    "is_external_database_override": "INTEGER DEFAULT 0",
+    "created_by": "TEXT",
+    "created_at": "TEXT",
+    "updated_at": "TEXT",
+}
 
 CREATE_EXTERNAL_PRODUCT_CANDIDATES_SQL = """
 CREATE TABLE IF NOT EXISTS external_product_candidates (
     id TEXT PRIMARY KEY,
     receipt_line_id TEXT,
     purchase_import_line_id TEXT,
-    context_key TEXT NOT NULL,
-    retailer_code TEXT NOT NULL,
-    receipt_line_text TEXT NOT NULL,
-    candidate_name TEXT NOT NULL,
+    context_key TEXT,
+    retailer_code TEXT,
+    receipt_line_text TEXT,
+    candidate_name TEXT,
     candidate_brand TEXT,
     candidate_source_name TEXT,
     candidate_source_product_code TEXT,
@@ -32,15 +57,15 @@ CREATE TABLE IF NOT EXISTS external_product_candidates (
     quantity_label TEXT,
     variant TEXT,
     source_url TEXT,
-    score REAL NOT NULL,
+    score REAL,
     score_breakdown_json TEXT,
-    candidate_status TEXT NOT NULL,
-    is_probable INTEGER NOT NULL DEFAULT 0,
-    is_user_confirmed INTEGER NOT NULL DEFAULT 0,
-    is_external_database_override INTEGER NOT NULL DEFAULT 0,
+    candidate_status TEXT,
+    is_probable INTEGER DEFAULT 0,
+    is_user_confirmed INTEGER DEFAULT 0,
+    is_external_database_override INTEGER DEFAULT 0,
     created_by TEXT,
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
+    created_at TEXT,
+    updated_at TEXT
 )
 """
 
@@ -66,9 +91,39 @@ def build_candidate_context_key(retailer_code: str, receipt_line_text: str, rece
     return f"external-preview:{normalize_candidate_text(retailer_code)}:{normalize_candidate_text(receipt_line_text)}"
 
 
+def _get_sqlite_columns(conn) -> set[str]:
+    rows = conn.execute(text("PRAGMA table_info(external_product_candidates)")).mappings().all()
+    return {str(row.get("name") or "") for row in rows}
+
+
+def _get_postgres_columns(conn) -> set[str]:
+    rows = conn.execute(
+        text(
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_name = 'external_product_candidates'
+            """
+        )
+    ).mappings().all()
+    return {str(row.get("column_name") or "") for row in rows}
+
+
+def _add_missing_columns(conn) -> None:
+    dialect_name = str(engine.dialect.name or "").lower()
+    existing_columns = _get_sqlite_columns(conn) if dialect_name == "sqlite" else _get_postgres_columns(conn)
+    for column_name, column_definition in CANDIDATE_COLUMNS.items():
+        if column_name in existing_columns:
+            continue
+        if column_name == "id":
+            continue
+        conn.execute(text(f"ALTER TABLE external_product_candidates ADD COLUMN {column_name} {column_definition}"))
+
+
 def ensure_external_product_candidates_schema() -> None:
     with engine.begin() as conn:
         conn.execute(text(CREATE_EXTERNAL_PRODUCT_CANDIDATES_SQL))
+        _add_missing_columns(conn)
         conn.execute(text(CREATE_EXTERNAL_PRODUCT_CANDIDATES_INDEX_SQL))
 
 
@@ -88,8 +143,8 @@ def _find_existing_candidate(conn, context_key: str, retailer_code: str, candida
             """
             SELECT id, candidate_status, is_user_confirmed, is_external_database_override
             FROM external_product_candidates
-            WHERE context_key = :context_key
-              AND retailer_code = :retailer_code
+            WHERE COALESCE(context_key, '') = COALESCE(:context_key, '')
+              AND COALESCE(retailer_code, '') = COALESCE(:retailer_code, '')
               AND COALESCE(candidate_source_name, '') = COALESCE(:candidate_source_name, '')
               AND COALESCE(candidate_source_product_code, '') = COALESCE(:candidate_source_product_code, '')
               AND COALESCE(variant, '') = COALESCE(:variant, '')

--- a/backend/app/services/external_product_candidate_store.py
+++ b/backend/app/services/external_product_candidate_store.py
@@ -26,6 +26,8 @@ CANDIDATE_COLUMNS: dict[str, str] = {
     "candidate_brand": "TEXT",
     "candidate_source_name": "TEXT",
     "candidate_source_product_code": "TEXT",
+    "source_name": "TEXT",
+    "source_product_code": "TEXT",
     "retailer_article_number": "TEXT",
     "quantity_label": "TEXT",
     "variant": "TEXT",
@@ -53,6 +55,8 @@ CREATE TABLE IF NOT EXISTS external_product_candidates (
     candidate_brand TEXT,
     candidate_source_name TEXT,
     candidate_source_product_code TEXT,
+    source_name TEXT,
+    source_product_code TEXT,
     retailer_article_number TEXT,
     quantity_label TEXT,
     variant TEXT,
@@ -149,8 +153,8 @@ def _find_existing_candidate(conn, context_key: str, retailer_code: str, candida
             FROM external_product_candidates
             WHERE COALESCE(context_key, '') = COALESCE(:context_key, '')
               AND COALESCE(retailer_code, '') = COALESCE(:retailer_code, '')
-              AND COALESCE(candidate_source_name, '') = COALESCE(:candidate_source_name, '')
-              AND COALESCE(candidate_source_product_code, '') = COALESCE(:candidate_source_product_code, '')
+              AND COALESCE(candidate_source_name, COALESCE(source_name, '')) = COALESCE(:candidate_source_name, '')
+              AND COALESCE(candidate_source_product_code, COALESCE(source_product_code, '')) = COALESCE(:candidate_source_product_code, '')
               AND COALESCE(variant, '') = COALESCE(:variant, '')
               AND COALESCE(candidate_name, '') = COALESCE(:candidate_name, '')
             LIMIT 1
@@ -215,6 +219,8 @@ def save_matchpreview_candidates(
                 continue
 
             candidate_id = str(existing.get("id")) if existing else str(uuid.uuid4())
+            candidate_source_name = str(candidate.get("candidate_source_name") or "external_database").strip()
+            candidate_source_product_code = str(candidate.get("candidate_source_product_code") or candidate.get("retailer_article_number") or "unknown").strip()
             params = {
                 "id": candidate_id,
                 "receipt_line_id": receipt_line_id,
@@ -224,8 +230,10 @@ def save_matchpreview_candidates(
                 "receipt_line_text": receipt_line_text,
                 "candidate_name": str(candidate.get("candidate_name") or "").strip(),
                 "candidate_brand": str(candidate.get("candidate_brand") or "").strip() or None,
-                "candidate_source_name": str(candidate.get("candidate_source_name") or "").strip() or None,
-                "candidate_source_product_code": str(candidate.get("candidate_source_product_code") or candidate.get("retailer_article_number") or "").strip() or None,
+                "candidate_source_name": candidate_source_name,
+                "candidate_source_product_code": candidate_source_product_code,
+                "source_name": candidate_source_name,
+                "source_product_code": candidate_source_product_code,
                 "retailer_article_number": str(candidate.get("retailer_article_number") or "").strip() or None,
                 "quantity_label": str(candidate.get("quantity_label") or "").strip() or None,
                 "variant": str(candidate.get("variant") or "").strip() or None,
@@ -252,6 +260,8 @@ def save_matchpreview_candidates(
                             candidate_brand = :candidate_brand,
                             candidate_source_name = :candidate_source_name,
                             candidate_source_product_code = :candidate_source_product_code,
+                            source_name = :source_name,
+                            source_product_code = :source_product_code,
                             retailer_article_number = :retailer_article_number,
                             quantity_label = :quantity_label,
                             source_url = :source_url,
@@ -281,6 +291,8 @@ def save_matchpreview_candidates(
                             candidate_brand,
                             candidate_source_name,
                             candidate_source_product_code,
+                            source_name,
+                            source_product_code,
                             retailer_article_number,
                             quantity_label,
                             variant,
@@ -305,6 +317,8 @@ def save_matchpreview_candidates(
                             :candidate_brand,
                             :candidate_source_name,
                             :candidate_source_product_code,
+                            :source_name,
+                            :source_product_code,
                             :retailer_article_number,
                             :quantity_label,
                             :variant,

--- a/backend/app/services/external_product_candidate_store.py
+++ b/backend/app/services/external_product_candidate_store.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db import engine
+from app.services.external_database_matchers import match_retailer_receipt_line
+
+PROTECTED_CANDIDATE_STATUSES = {
+    "user_confirmed",
+    "external_database_override",
+}
+
+
+CREATE_EXTERNAL_PRODUCT_CANDIDATES_SQL = """
+CREATE TABLE IF NOT EXISTS external_product_candidates (
+    id TEXT PRIMARY KEY,
+    receipt_line_id TEXT,
+    purchase_import_line_id TEXT,
+    context_key TEXT NOT NULL,
+    retailer_code TEXT NOT NULL,
+    receipt_line_text TEXT NOT NULL,
+    candidate_name TEXT NOT NULL,
+    candidate_brand TEXT,
+    candidate_source_name TEXT,
+    candidate_source_product_code TEXT,
+    retailer_article_number TEXT,
+    quantity_label TEXT,
+    variant TEXT,
+    source_url TEXT,
+    score REAL NOT NULL,
+    score_breakdown_json TEXT,
+    candidate_status TEXT NOT NULL,
+    is_probable INTEGER NOT NULL DEFAULT 0,
+    is_user_confirmed INTEGER NOT NULL DEFAULT 0,
+    is_external_database_override INTEGER NOT NULL DEFAULT 0,
+    created_by TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+)
+"""
+
+CREATE_EXTERNAL_PRODUCT_CANDIDATES_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_external_product_candidates_context
+ON external_product_candidates (context_key, retailer_code, candidate_source_name, candidate_source_product_code, variant)
+"""
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def normalize_candidate_text(value: str | None) -> str:
+    return " ".join(str(value or "").strip().lower().split())
+
+
+def build_candidate_context_key(retailer_code: str, receipt_line_text: str, receipt_line_id: str | None = None, purchase_import_line_id: str | None = None) -> str:
+    if receipt_line_id:
+        return f"receipt-line:{receipt_line_id}"
+    if purchase_import_line_id:
+        return f"purchase-import-line:{purchase_import_line_id}"
+    return f"external-preview:{normalize_candidate_text(retailer_code)}:{normalize_candidate_text(receipt_line_text)}"
+
+
+def ensure_external_product_candidates_schema() -> None:
+    with engine.begin() as conn:
+        conn.execute(text(CREATE_EXTERNAL_PRODUCT_CANDIDATES_SQL))
+        conn.execute(text(CREATE_EXTERNAL_PRODUCT_CANDIDATES_INDEX_SQL))
+
+
+def _candidate_identity(candidate: dict[str, Any]) -> dict[str, str]:
+    return {
+        "candidate_source_name": str(candidate.get("candidate_source_name") or "").strip(),
+        "candidate_source_product_code": str(candidate.get("candidate_source_product_code") or candidate.get("retailer_article_number") or "").strip(),
+        "variant": str(candidate.get("variant") or "").strip(),
+        "candidate_name": str(candidate.get("candidate_name") or "").strip(),
+    }
+
+
+def _find_existing_candidate(conn, context_key: str, retailer_code: str, candidate: dict[str, Any]):
+    identity = _candidate_identity(candidate)
+    return conn.execute(
+        text(
+            """
+            SELECT id, candidate_status, is_user_confirmed, is_external_database_override
+            FROM external_product_candidates
+            WHERE context_key = :context_key
+              AND retailer_code = :retailer_code
+              AND COALESCE(candidate_source_name, '') = COALESCE(:candidate_source_name, '')
+              AND COALESCE(candidate_source_product_code, '') = COALESCE(:candidate_source_product_code, '')
+              AND COALESCE(variant, '') = COALESCE(:variant, '')
+              AND COALESCE(candidate_name, '') = COALESCE(:candidate_name, '')
+            LIMIT 1
+            """
+        ),
+        {
+            "context_key": context_key,
+            "retailer_code": retailer_code,
+            **identity,
+        },
+    ).mappings().first()
+
+
+def _is_protected(existing: dict[str, Any] | None) -> bool:
+    if not existing:
+        return False
+    status = str(existing.get("candidate_status") or "").strip()
+    return (
+        status in PROTECTED_CANDIDATE_STATUSES
+        or bool(existing.get("is_user_confirmed"))
+        or bool(existing.get("is_external_database_override"))
+    )
+
+
+def _serialize_score_breakdown(candidate: dict[str, Any]) -> str:
+    return json.dumps(candidate.get("score_breakdown") or {}, ensure_ascii=False, sort_keys=True)
+
+
+def save_matchpreview_candidates(
+    retailer_code: str,
+    receipt_line_text: str,
+    receipt_line_id: str | None = None,
+    purchase_import_line_id: str | None = None,
+    include_below_threshold: bool = False,
+) -> dict[str, Any]:
+    ensure_external_product_candidates_schema()
+
+    match_result = match_retailer_receipt_line(
+        retailer_code=retailer_code,
+        receipt_line_text=receipt_line_text,
+        include_below_threshold=include_below_threshold,
+    )
+    normalized_retailer = str(match_result.get("retailer_code") or retailer_code or "").strip().lower()
+    context_key = build_candidate_context_key(
+        normalized_retailer,
+        receipt_line_text,
+        receipt_line_id=receipt_line_id,
+        purchase_import_line_id=purchase_import_line_id,
+    )
+    candidates = list(match_result.get("candidates") or [])
+    timestamp = now_iso()
+    saved = []
+    skipped = []
+    updated = []
+
+    with engine.begin() as conn:
+        for candidate in candidates:
+            existing = _find_existing_candidate(conn, context_key, normalized_retailer, candidate)
+            if _is_protected(existing):
+                skipped.append({"id": existing.get("id"), "reason": "protected_candidate"})
+                continue
+
+            candidate_id = str(existing.get("id")) if existing else str(uuid.uuid4())
+            params = {
+                "id": candidate_id,
+                "receipt_line_id": receipt_line_id,
+                "purchase_import_line_id": purchase_import_line_id,
+                "context_key": context_key,
+                "retailer_code": normalized_retailer,
+                "receipt_line_text": receipt_line_text,
+                "candidate_name": str(candidate.get("candidate_name") or "").strip(),
+                "candidate_brand": str(candidate.get("candidate_brand") or "").strip() or None,
+                "candidate_source_name": str(candidate.get("candidate_source_name") or "").strip() or None,
+                "candidate_source_product_code": str(candidate.get("candidate_source_product_code") or candidate.get("retailer_article_number") or "").strip() or None,
+                "retailer_article_number": str(candidate.get("retailer_article_number") or "").strip() or None,
+                "quantity_label": str(candidate.get("quantity_label") or "").strip() or None,
+                "variant": str(candidate.get("variant") or "").strip() or None,
+                "source_url": str(candidate.get("source_url") or "").strip() or None,
+                "score": float(candidate.get("score") or 0),
+                "score_breakdown_json": _serialize_score_breakdown(candidate),
+                "candidate_status": str(candidate.get("candidate_status") or "possible_candidate").strip(),
+                "is_probable": 1 if bool(candidate.get("is_probable")) else 0,
+                "is_user_confirmed": 0,
+                "is_external_database_override": 0,
+                "created_by": str(candidate.get("created_by") or "external_database_matchpreview_save_v1").strip(),
+                "created_at": timestamp,
+                "updated_at": timestamp,
+            }
+
+            if existing:
+                conn.execute(
+                    text(
+                        """
+                        UPDATE external_product_candidates
+                        SET receipt_line_id = :receipt_line_id,
+                            purchase_import_line_id = :purchase_import_line_id,
+                            receipt_line_text = :receipt_line_text,
+                            candidate_brand = :candidate_brand,
+                            candidate_source_name = :candidate_source_name,
+                            candidate_source_product_code = :candidate_source_product_code,
+                            retailer_article_number = :retailer_article_number,
+                            quantity_label = :quantity_label,
+                            source_url = :source_url,
+                            score = :score,
+                            score_breakdown_json = :score_breakdown_json,
+                            candidate_status = :candidate_status,
+                            is_probable = :is_probable,
+                            updated_at = :updated_at
+                        WHERE id = :id
+                        """
+                    ),
+                    params,
+                )
+                updated.append(candidate_id)
+            else:
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO external_product_candidates (
+                            id,
+                            receipt_line_id,
+                            purchase_import_line_id,
+                            context_key,
+                            retailer_code,
+                            receipt_line_text,
+                            candidate_name,
+                            candidate_brand,
+                            candidate_source_name,
+                            candidate_source_product_code,
+                            retailer_article_number,
+                            quantity_label,
+                            variant,
+                            source_url,
+                            score,
+                            score_breakdown_json,
+                            candidate_status,
+                            is_probable,
+                            is_user_confirmed,
+                            is_external_database_override,
+                            created_by,
+                            created_at,
+                            updated_at
+                        ) VALUES (
+                            :id,
+                            :receipt_line_id,
+                            :purchase_import_line_id,
+                            :context_key,
+                            :retailer_code,
+                            :receipt_line_text,
+                            :candidate_name,
+                            :candidate_brand,
+                            :candidate_source_name,
+                            :candidate_source_product_code,
+                            :retailer_article_number,
+                            :quantity_label,
+                            :variant,
+                            :source_url,
+                            :score,
+                            :score_breakdown_json,
+                            :candidate_status,
+                            :is_probable,
+                            :is_user_confirmed,
+                            :is_external_database_override,
+                            :created_by,
+                            :created_at,
+                            :updated_at
+                        )
+                        """
+                    ),
+                    params,
+                )
+                saved.append(candidate_id)
+
+    return {
+        "ok": True,
+        "context_key": context_key,
+        "retailer_code": normalized_retailer,
+        "receipt_line_text": receipt_line_text,
+        "candidate_count": len(candidates),
+        "saved_count": len(saved),
+        "updated_count": len(updated),
+        "skipped_count": len(skipped),
+        "saved_candidate_ids": saved,
+        "updated_candidate_ids": updated,
+        "skipped": skipped,
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+    }
+
+
+def list_saved_external_product_candidates(context_key: str | None = None, limit: int = 50) -> dict[str, Any]:
+    ensure_external_product_candidates_schema()
+    normalized_limit = max(1, min(int(limit or 50), 200))
+    with engine.begin() as conn:
+        if context_key:
+            rows = conn.execute(
+                text(
+                    """
+                    SELECT *
+                    FROM external_product_candidates
+                    WHERE context_key = :context_key
+                    ORDER BY score DESC, updated_at DESC
+                    LIMIT :limit
+                    """
+                ),
+                {"context_key": context_key, "limit": normalized_limit},
+            ).mappings().all()
+        else:
+            rows = conn.execute(
+                text(
+                    """
+                    SELECT *
+                    FROM external_product_candidates
+                    ORDER BY updated_at DESC, score DESC
+                    LIMIT :limit
+                    """
+                ),
+                {"limit": normalized_limit},
+            ).mappings().all()
+    return {"items": [dict(row) for row in rows]}

--- a/backend/app/services/external_product_candidate_store.py
+++ b/backend/app/services/external_product_candidate_store.py
@@ -91,6 +91,10 @@ def build_candidate_context_key(retailer_code: str, receipt_line_text: str, rece
     return f"external-preview:{normalize_candidate_text(retailer_code)}:{normalize_candidate_text(receipt_line_text)}"
 
 
+def build_preview_import_line_fallback(context_key: str) -> str:
+    return f"preview:{context_key}"
+
+
 def _get_sqlite_columns(conn) -> set[str]:
     rows = conn.execute(text("PRAGMA table_info(external_product_candidates)")).mappings().all()
     return {str(row.get("name") or "") for row in rows}
@@ -196,6 +200,7 @@ def save_matchpreview_candidates(
         receipt_line_id=receipt_line_id,
         purchase_import_line_id=purchase_import_line_id,
     )
+    storage_purchase_import_line_id = purchase_import_line_id or build_preview_import_line_fallback(context_key)
     candidates = list(match_result.get("candidates") or [])
     timestamp = now_iso()
     saved = []
@@ -213,7 +218,7 @@ def save_matchpreview_candidates(
             params = {
                 "id": candidate_id,
                 "receipt_line_id": receipt_line_id,
-                "purchase_import_line_id": purchase_import_line_id,
+                "purchase_import_line_id": storage_purchase_import_line_id,
                 "context_key": context_key,
                 "retailer_code": normalized_retailer,
                 "receipt_line_text": receipt_line_text,

--- a/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
+++ b/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
@@ -36,6 +36,21 @@ function OverviewTile({ title, value, helper }) {
   )
 }
 
+function ErrorOverlay({ message, onClose }) {
+  if (!message) return null
+  return (
+    <div className="rz-modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="external-databases-error-title">
+      <div className="rz-modal-card">
+        <h3 id="external-databases-error-title" className="rz-modal-title">Melding</h3>
+        <p className="rz-modal-text">{message}</p>
+        <div className="rz-modal-actions">
+          <Button type="button" onClick={onClose}>Sluiten</Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export default function ExternalDatabasesPage() {
   const navigate = useNavigate()
   const [activeTab, setActiveTab] = useState(TAB_LABELS.overzicht)
@@ -294,14 +309,13 @@ export default function ExternalDatabasesPage() {
               </Button>
             </div>
 
-            {error ? <div className="rz-inline-feedback rz-inline-feedback--error">{error}</div> : null}
-
             <Tabs tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab}>
               {renderTabContent}
             </Tabs>
           </div>
         </ScreenCard>
       </div>
+      <ErrorOverlay message={error} onClose={() => setError('')} />
     </AppShell>
   )
 }

--- a/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
+++ b/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
@@ -44,8 +44,10 @@ export default function ExternalDatabasesPage() {
   const [receiptLineText, setReceiptLineText] = useState('Mexicaanse kruidenm.')
   const [selectedRetailer, setSelectedRetailer] = useState('lidl')
   const [matchResult, setMatchResult] = useState(null)
+  const [saveResult, setSaveResult] = useState(null)
   const [isLoadingConfig, setIsLoadingConfig] = useState(true)
   const [isTesting, setIsTesting] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState('')
 
   useEffect(() => {
@@ -97,6 +99,7 @@ export default function ExternalDatabasesPage() {
     }
     setIsTesting(true)
     setError('')
+    setSaveResult(null)
     setMatchResult(null)
     try {
       const response = await fetchJsonWithAuth(`/api/external-databases/retailers/${encodeURIComponent(selectedRetailer)}/match-preview`, {
@@ -111,6 +114,31 @@ export default function ExternalDatabasesPage() {
       setError(err?.message || 'Matchpreview kon niet worden uitgevoerd')
     } finally {
       setIsTesting(false)
+    }
+  }
+
+  async function saveCandidateMatches() {
+    const normalizedLine = receiptLineText.trim()
+    if (!normalizedLine) {
+      setError('Vul eerst een bonregel in')
+      return
+    }
+    setIsSaving(true)
+    setError('')
+    setSaveResult(null)
+    try {
+      const response = await fetchJsonWithAuth(`/api/external-databases/retailers/${encodeURIComponent(selectedRetailer)}/save-candidates`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ receipt_line_text: normalizedLine, include_below_threshold: false }),
+      })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data?.detail || 'Kandidaten opslaan is mislukt')
+      setSaveResult(data)
+    } catch (err) {
+      setError(err?.message || 'Kandidaten opslaan is mislukt')
+    } finally {
+      setIsSaving(false)
     }
   }
 
@@ -161,12 +189,21 @@ export default function ExternalDatabasesPage() {
               <Button type="button" variant="secondary" onClick={() => setReceiptLineText('Mexicaanse kruidenm.')}>
                 Voorbeeld kruidenmix
               </Button>
+              <Button type="button" variant="secondary" disabled={isSaving || !candidates.length} onClick={saveCandidateMatches}>
+                {isSaving ? 'Opslaan...' : 'Kandidaten opslaan'}
+              </Button>
             </div>
           </form>
 
           <div className="rz-external-databases-muted">
-            Drempel probable_candidate: {formatScore(selectedRetailerConfig?.probable_candidate_threshold)}. Deze test schrijft geen data weg.
+            Drempel probable_candidate: {formatScore(selectedRetailerConfig?.probable_candidate_threshold)}. Deze opslag maakt geen Mijn artikel, global_product of voorraadmutatie aan.
           </div>
+
+          {saveResult ? (
+            <div className="rz-inline-feedback rz-inline-feedback--success">
+              Kandidaten opgeslagen: {saveResult.saved_count ?? 0} nieuw, {saveResult.updated_count ?? 0} bijgewerkt, {saveResult.skipped_count ?? 0} overgeslagen.
+            </div>
+          ) : null}
 
           {matchResult ? (
             <Table dataTestId="external-database-candidates-table" tableClassName="rz-external-databases-table">


### PR DESCRIPTION
## Samenvatting

Voert issue #48 / Scrumopdracht M2C2d uit.

Deze PR breidt Externe databases v1 uit met een opslagactie voor kandidaatmatches uit de Lidl-matchpreview.

## Wijzigingen

- Nieuwe service `external_product_candidate_store.py`.
- Maakt `external_product_candidates` aan als lokale opslag ontbreekt.
- Maakt bestaande lokale candidate-tabellen schema-robuust door ontbrekende kolommen toe te voegen.
- Slaat matchpreview-kandidaten idempotent op per context.
- Beschermt bestaande `user_confirmed` en `external_database_override` kandidaten tegen overschrijven.
- Nieuwe API-endpoints:
  - `POST /api/external-databases/retailers/{retailer_code}/save-candidates`
  - `GET /api/external-databases/candidates`
- UI-knop **Kandidaten opslaan** toegevoegd na matchpreview.
- API-fouten op dit scherm worden nu als applicatie-overlay/modal getoond, niet meer inline in het scherm.

## Niet gewijzigd

- Geen automatische aanmaak van `global_products`.
- Geen automatische aanmaak van Mijn artikel / `household_articles`.
- Geen voorraadmutaties.
- Geen nieuwe route.
- Geen bevestigen/afwijzen-flow.
- Geen automatische opname van hoogste kandidaat in de Artikelcatalogus; dat is afgesplitst naar issue #50.
- Geen batchdoorvoer naar huishoudadministratie; dat is afgesplitst naar issue #51.

## PO-test

1. Login → Startpagina → Externe databases.
2. Tab Test algoritme.
3. Test `Mexicaanse kruidenm.`.
4. Klik **Kandidaten opslaan**.
5. Verwacht feedback met 3 opgeslagen of bijgewerkte kandidaten.
6. Klik opnieuw **Kandidaten opslaan**.
7. Verwacht geen dubbele kandidaten; bestaande kandidaten worden bijgewerkt.
8. Test `Taco saus` en sla kandidaten op.
9. Controleer dat API-fouten als overlay/modal verschijnen.
10. Controleer dat Home, Uitpakken, Kassa en Voorraad bereikbaar blijven.

Closes #48