### PR TITLE
feat(m2c2e): link highest candidate to existing catalog product

### DIFF
--- a/backend/app/api/system_routes.py
+++ b/backend/app/api/system_routes.py
@@ -31,6 +31,10 @@ from app.services.external_product_candidate_store import (
     list_saved_external_product_candidates,
     save_matchpreview_candidates,
 )
+from app.services.external_product_catalog_store import (
+    list_catalog_products,
+    promote_highest_candidate_to_catalog,
+)
 
 router = APIRouter()
 logger = logging.getLogger('rezzerv.api')
@@ -113,6 +117,27 @@ def external_databases_saved_candidates(
             purchase_import_line_id=purchase_import_line_id,
         )
     return list_saved_external_product_candidates(context_key=resolved_context_key, limit=limit)
+
+
+@router.post('/api/external-databases/catalog/promote-highest')
+def external_databases_promote_highest_candidate(payload: dict[str, Any] = Body(default_factory=dict)):
+    receipt_line_text = str(payload.get('receipt_line_text') or '').strip() or None
+    retailer_code = str(payload.get('retailer_code') or '').strip() or None
+    context_key = str(payload.get('context_key') or '').strip() or None
+    threshold = float(payload.get('threshold') or 0.85)
+    if not context_key and not (retailer_code and receipt_line_text):
+        raise HTTPException(status_code=400, detail='Context of retailer_code + bonregel is verplicht voor catalogusopname')
+    return promote_highest_candidate_to_catalog(
+        context_key=context_key,
+        retailer_code=retailer_code,
+        receipt_line_text=receipt_line_text,
+        threshold=threshold,
+    )
+
+
+@router.get('/api/external-databases/catalog/products')
+def external_databases_catalog_products(limit: int = Query(default=50)):
+    return list_catalog_products(limit=limit)
 
 
 @router.get('/api/admin/route-governance')

--- a/backend/app/api/system_routes.py
+++ b/backend/app/api/system_routes.py
@@ -126,7 +126,7 @@ def external_databases_promote_highest_candidate(payload: dict[str, Any] = Body(
     context_key = str(payload.get('context_key') or '').strip() or None
     threshold = float(payload.get('threshold') or 0.85)
     if not context_key and not (retailer_code and receipt_line_text):
-        raise HTTPException(status_code=400, detail='Context of retailer_code + bonregel is verplicht voor catalogusopname')
+        raise HTTPException(status_code=400, detail='Context of retailer_code + bonregel is verplicht voor cataloguskoppeling')
     return promote_highest_candidate_to_catalog(
         context_key=context_key,
         retailer_code=retailer_code,

--- a/backend/app/services/external_product_catalog_store.py
+++ b/backend/app/services/external_product_catalog_store.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db import engine
+from app.services.external_product_candidate_store import ensure_external_product_candidates_schema
+
+DEFAULT_PROMOTION_THRESHOLD = 0.85
+
+GLOBAL_PRODUCT_COLUMNS: dict[str, str] = {
+    "id": "TEXT PRIMARY KEY",
+    "canonical_name": "TEXT",
+    "brand": "TEXT",
+    "product_type": "TEXT",
+    "category": "TEXT",
+    "retailer_article_number": "TEXT",
+    "gtin": "TEXT",
+    "source_name": "TEXT",
+    "source_product_code": "TEXT",
+    "source_url": "TEXT",
+    "promotion_status": "TEXT",
+    "created_by": "TEXT",
+    "created_at": "TEXT",
+    "updated_at": "TEXT",
+}
+
+PRODUCT_ENRICHMENT_COLUMNS: dict[str, str] = {
+    "id": "TEXT PRIMARY KEY",
+    "global_product_id": "TEXT",
+    "external_product_candidate_id": "TEXT",
+    "context_key": "TEXT",
+    "source_name": "TEXT",
+    "source_product_code": "TEXT",
+    "retailer_code": "TEXT",
+    "retailer_article_number": "TEXT",
+    "candidate_name": "TEXT",
+    "candidate_brand": "TEXT",
+    "variant": "TEXT",
+    "quantity_label": "TEXT",
+    "source_url": "TEXT",
+    "score": "REAL",
+    "promotion_threshold": "REAL",
+    "promotion_status": "TEXT",
+    "relationship_status": "TEXT",
+    "created_by": "TEXT",
+    "created_at": "TEXT",
+    "updated_at": "TEXT",
+}
+
+CREATE_GLOBAL_PRODUCTS_SQL = """
+CREATE TABLE IF NOT EXISTS global_products (
+    id TEXT PRIMARY KEY,
+    canonical_name TEXT,
+    brand TEXT,
+    product_type TEXT,
+    category TEXT,
+    retailer_article_number TEXT,
+    gtin TEXT,
+    source_name TEXT,
+    source_product_code TEXT,
+    source_url TEXT,
+    promotion_status TEXT,
+    created_by TEXT,
+    created_at TEXT,
+    updated_at TEXT
+)
+"""
+
+CREATE_PRODUCT_ENRICHMENTS_SQL = """
+CREATE TABLE IF NOT EXISTS product_enrichments (
+    id TEXT PRIMARY KEY,
+    global_product_id TEXT,
+    external_product_candidate_id TEXT,
+    context_key TEXT,
+    source_name TEXT,
+    source_product_code TEXT,
+    retailer_code TEXT,
+    retailer_article_number TEXT,
+    candidate_name TEXT,
+    candidate_brand TEXT,
+    variant TEXT,
+    quantity_label TEXT,
+    source_url TEXT,
+    score REAL,
+    promotion_threshold REAL,
+    promotion_status TEXT,
+    relationship_status TEXT,
+    created_by TEXT,
+    created_at TEXT,
+    updated_at TEXT
+)
+"""
+
+GLOBAL_PRODUCTS_SOURCE_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_global_products_source
+ON global_products (source_name, source_product_code, retailer_article_number)
+"""
+
+PRODUCT_ENRICHMENTS_SOURCE_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_product_enrichments_source
+ON product_enrichments (source_name, source_product_code, context_key, variant)
+"""
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _get_sqlite_columns(conn, table_name: str) -> set[str]:
+    rows = conn.execute(text(f"PRAGMA table_info({table_name})")).mappings().all()
+    return {str(row.get("name") or "") for row in rows}
+
+
+def _get_postgres_columns(conn, table_name: str) -> set[str]:
+    rows = conn.execute(
+        text(
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_name = :table_name
+            """
+        ),
+        {"table_name": table_name},
+    ).mappings().all()
+    return {str(row.get("column_name") or "") for row in rows}
+
+
+def _add_missing_columns(conn, table_name: str, columns: dict[str, str]) -> None:
+    dialect_name = str(engine.dialect.name or "").lower()
+    existing_columns = _get_sqlite_columns(conn, table_name) if dialect_name == "sqlite" else _get_postgres_columns(conn, table_name)
+    for column_name, column_definition in columns.items():
+        if column_name in existing_columns or column_name == "id":
+            continue
+        conn.execute(text(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {column_definition}"))
+
+
+def ensure_catalog_schema() -> None:
+    ensure_external_product_candidates_schema()
+    with engine.begin() as conn:
+        conn.execute(text(CREATE_GLOBAL_PRODUCTS_SQL))
+        conn.execute(text(CREATE_PRODUCT_ENRICHMENTS_SQL))
+        _add_missing_columns(conn, "global_products", GLOBAL_PRODUCT_COLUMNS)
+        _add_missing_columns(conn, "product_enrichments", PRODUCT_ENRICHMENT_COLUMNS)
+        conn.execute(text(GLOBAL_PRODUCTS_SOURCE_INDEX_SQL))
+        conn.execute(text(PRODUCT_ENRICHMENTS_SOURCE_INDEX_SQL))
+
+
+def _candidate_source_name(candidate: dict[str, Any]) -> str:
+    return str(candidate.get("candidate_source_name") or candidate.get("source_name") or "external_database").strip()
+
+
+def _candidate_source_product_code(candidate: dict[str, Any]) -> str:
+    return str(
+        candidate.get("candidate_source_product_code")
+        or candidate.get("source_product_code")
+        or candidate.get("retailer_article_number")
+        or "unknown"
+    ).strip()
+
+
+def _find_highest_candidate(conn, context_key: str | None, retailer_code: str | None, receipt_line_text: str | None, threshold: float):
+    params: dict[str, Any] = {"threshold": threshold}
+    where_parts = ["COALESCE(score, 0) >= :threshold"]
+    if context_key:
+        where_parts.append("context_key = :context_key")
+        params["context_key"] = context_key
+    if retailer_code:
+        where_parts.append("retailer_code = :retailer_code")
+        params["retailer_code"] = retailer_code.strip().lower()
+    if receipt_line_text:
+        where_parts.append("receipt_line_text = :receipt_line_text")
+        params["receipt_line_text"] = receipt_line_text
+    where_sql = " AND ".join(where_parts)
+    return conn.execute(
+        text(
+            f"""
+            SELECT *
+            FROM external_product_candidates
+            WHERE {where_sql}
+            ORDER BY score DESC, updated_at DESC, created_at DESC
+            LIMIT 1
+            """
+        ),
+        params,
+    ).mappings().first()
+
+
+def _find_existing_enrichment(conn, candidate: dict[str, Any]):
+    source_name = _candidate_source_name(candidate)
+    source_product_code = _candidate_source_product_code(candidate)
+    return conn.execute(
+        text(
+            """
+            SELECT *
+            FROM product_enrichments
+            WHERE COALESCE(source_name, '') = COALESCE(:source_name, '')
+              AND COALESCE(source_product_code, '') = COALESCE(:source_product_code, '')
+              AND COALESCE(context_key, '') = COALESCE(:context_key, '')
+              AND COALESCE(variant, '') = COALESCE(:variant, '')
+            LIMIT 1
+            """
+        ),
+        {
+            "source_name": source_name,
+            "source_product_code": source_product_code,
+            "context_key": str(candidate.get("context_key") or "").strip(),
+            "variant": str(candidate.get("variant") or "").strip(),
+        },
+    ).mappings().first()
+
+
+def _find_existing_global_product(conn, source_name: str, source_product_code: str, retailer_article_number: str | None):
+    return conn.execute(
+        text(
+            """
+            SELECT *
+            FROM global_products
+            WHERE COALESCE(source_name, '') = COALESCE(:source_name, '')
+              AND COALESCE(source_product_code, '') = COALESCE(:source_product_code, '')
+              AND COALESCE(retailer_article_number, '') = COALESCE(:retailer_article_number, '')
+            LIMIT 1
+            """
+        ),
+        {
+            "source_name": source_name,
+            "source_product_code": source_product_code,
+            "retailer_article_number": str(retailer_article_number or "").strip(),
+        },
+    ).mappings().first()
+
+
+def promote_highest_candidate_to_catalog(
+    context_key: str | None = None,
+    retailer_code: str | None = None,
+    receipt_line_text: str | None = None,
+    threshold: float = DEFAULT_PROMOTION_THRESHOLD,
+) -> dict[str, Any]:
+    ensure_catalog_schema()
+    normalized_threshold = float(threshold or DEFAULT_PROMOTION_THRESHOLD)
+    timestamp = now_iso()
+
+    with engine.begin() as conn:
+        candidate_row = _find_highest_candidate(
+            conn,
+            context_key=context_key,
+            retailer_code=retailer_code,
+            receipt_line_text=receipt_line_text,
+            threshold=normalized_threshold,
+        )
+        if not candidate_row:
+            return {
+                "ok": True,
+                "promoted": False,
+                "reason": "no_candidate_above_threshold",
+                "promotion_threshold": normalized_threshold,
+                "creates_household_article": False,
+                "creates_inventory_event": False,
+            }
+
+        candidate = dict(candidate_row)
+        source_name = _candidate_source_name(candidate)
+        source_product_code = _candidate_source_product_code(candidate)
+        retailer_article_number = str(candidate.get("retailer_article_number") or "").strip() or None
+        existing_enrichment = _find_existing_enrichment(conn, candidate)
+        existing_product = _find_existing_global_product(conn, source_name, source_product_code, retailer_article_number)
+        global_product_id = str(existing_product.get("id")) if existing_product else str(uuid.uuid4())
+        enrichment_id = str(existing_enrichment.get("id")) if existing_enrichment else str(uuid.uuid4())
+
+        product_params = {
+            "id": global_product_id,
+            "canonical_name": str(candidate.get("candidate_name") or "").strip(),
+            "brand": str(candidate.get("candidate_brand") or "").strip() or None,
+            "product_type": None,
+            "category": None,
+            "retailer_article_number": retailer_article_number,
+            "gtin": None,
+            "source_name": source_name,
+            "source_product_code": source_product_code,
+            "source_url": str(candidate.get("source_url") or "").strip() or None,
+            "promotion_status": "catalog_promoted_from_external_candidate",
+            "created_by": "external_database_catalog_promotion_v1",
+            "created_at": timestamp,
+            "updated_at": timestamp,
+        }
+        enrichment_params = {
+            "id": enrichment_id,
+            "global_product_id": global_product_id,
+            "external_product_candidate_id": str(candidate.get("id") or "").strip(),
+            "context_key": str(candidate.get("context_key") or "").strip(),
+            "source_name": source_name,
+            "source_product_code": source_product_code,
+            "retailer_code": str(candidate.get("retailer_code") or "").strip() or None,
+            "retailer_article_number": retailer_article_number,
+            "candidate_name": str(candidate.get("candidate_name") or "").strip(),
+            "candidate_brand": str(candidate.get("candidate_brand") or "").strip() or None,
+            "variant": str(candidate.get("variant") or "").strip() or None,
+            "quantity_label": str(candidate.get("quantity_label") or "").strip() or None,
+            "source_url": str(candidate.get("source_url") or "").strip() or None,
+            "score": float(candidate.get("score") or 0),
+            "promotion_threshold": normalized_threshold,
+            "promotion_status": "catalog_promoted",
+            "relationship_status": "proposed_by_external_database",
+            "created_by": "external_database_catalog_promotion_v1",
+            "created_at": timestamp,
+            "updated_at": timestamp,
+        }
+
+        if existing_product:
+            conn.execute(
+                text(
+                    """
+                    UPDATE global_products
+                    SET canonical_name = :canonical_name,
+                        brand = :brand,
+                        retailer_article_number = :retailer_article_number,
+                        source_url = :source_url,
+                        promotion_status = :promotion_status,
+                        updated_at = :updated_at
+                    WHERE id = :id
+                    """
+                ),
+                product_params,
+            )
+            product_action = "updated"
+        else:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO global_products (
+                        id, canonical_name, brand, product_type, category, retailer_article_number, gtin,
+                        source_name, source_product_code, source_url, promotion_status, created_by, created_at, updated_at
+                    ) VALUES (
+                        :id, :canonical_name, :brand, :product_type, :category, :retailer_article_number, :gtin,
+                        :source_name, :source_product_code, :source_url, :promotion_status, :created_by, :created_at, :updated_at
+                    )
+                    """
+                ),
+                product_params,
+            )
+            product_action = "created"
+
+        if existing_enrichment:
+            conn.execute(
+                text(
+                    """
+                    UPDATE product_enrichments
+                    SET global_product_id = :global_product_id,
+                        external_product_candidate_id = :external_product_candidate_id,
+                        candidate_name = :candidate_name,
+                        candidate_brand = :candidate_brand,
+                        quantity_label = :quantity_label,
+                        source_url = :source_url,
+                        score = :score,
+                        promotion_threshold = :promotion_threshold,
+                        promotion_status = :promotion_status,
+                        relationship_status = :relationship_status,
+                        updated_at = :updated_at
+                    WHERE id = :id
+                    """
+                ),
+                enrichment_params,
+            )
+            enrichment_action = "updated"
+        else:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO product_enrichments (
+                        id, global_product_id, external_product_candidate_id, context_key, source_name, source_product_code,
+                        retailer_code, retailer_article_number, candidate_name, candidate_brand, variant, quantity_label,
+                        source_url, score, promotion_threshold, promotion_status, relationship_status,
+                        created_by, created_at, updated_at
+                    ) VALUES (
+                        :id, :global_product_id, :external_product_candidate_id, :context_key, :source_name, :source_product_code,
+                        :retailer_code, :retailer_article_number, :candidate_name, :candidate_brand, :variant, :quantity_label,
+                        :source_url, :score, :promotion_threshold, :promotion_status, :relationship_status,
+                        :created_by, :created_at, :updated_at
+                    )
+                    """
+                ),
+                enrichment_params,
+            )
+            enrichment_action = "created"
+
+    return {
+        "ok": True,
+        "promoted": True,
+        "global_product_id": global_product_id,
+        "product_enrichment_id": enrichment_id,
+        "product_action": product_action,
+        "enrichment_action": enrichment_action,
+        "candidate_id": str(candidate.get("id") or ""),
+        "candidate_name": str(candidate.get("candidate_name") or ""),
+        "candidate_brand": str(candidate.get("candidate_brand") or ""),
+        "score": float(candidate.get("score") or 0),
+        "promotion_threshold": normalized_threshold,
+        "source_name": source_name,
+        "source_product_code": source_product_code,
+        "retailer_article_number": retailer_article_number,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+    }
+
+
+def list_catalog_products(limit: int = 50) -> dict[str, Any]:
+    ensure_catalog_schema()
+    normalized_limit = max(1, min(int(limit or 50), 200))
+    with engine.begin() as conn:
+        rows = conn.execute(
+            text(
+                """
+                SELECT *
+                FROM global_products
+                ORDER BY updated_at DESC, canonical_name ASC
+                LIMIT :limit
+                """
+            ),
+            {"limit": normalized_limit},
+        ).mappings().all()
+    return {"items": [dict(row) for row in rows]}

--- a/backend/app/services/external_product_catalog_store.py
+++ b/backend/app/services/external_product_catalog_store.py
@@ -51,11 +51,23 @@ def _find_highest_candidate(conn, context_key: str | None, retailer_code: str | 
 
 
 def _find_existing_global_product(conn, candidate: dict[str, Any]):
-    candidate_name = str(candidate.get("candidate_name") or "").strip()
-    candidate_brand = str(candidate.get("candidate_brand") or "").strip()
-    candidate_variant = str(candidate.get("variant") or "").strip()
-    source_product_code = _candidate_source_product_code(candidate)
+    explicit_global_product_id = str(candidate.get("global_product_id") or "").strip()
+    if explicit_global_product_id:
+        direct_match = conn.execute(
+            text(
+                """
+                SELECT *
+                FROM global_products
+                WHERE id = :global_product_id
+                LIMIT 1
+                """
+            ),
+            {"global_product_id": explicit_global_product_id},
+        ).mappings().first()
+        if direct_match:
+            return direct_match
 
+    source_product_code = _candidate_source_product_code(candidate)
     if source_product_code and source_product_code != "unknown":
         identity_match = conn.execute(
             text(
@@ -64,6 +76,7 @@ def _find_existing_global_product(conn, candidate: dict[str, Any]):
                 FROM product_identities pi
                 JOIN global_products gp ON gp.id = pi.global_product_id
                 WHERE pi.identity_value = :identity_value
+                  AND pi.global_product_id IS NOT NULL
                 LIMIT 1
                 """
             ),
@@ -72,6 +85,9 @@ def _find_existing_global_product(conn, candidate: dict[str, Any]):
         if identity_match:
             return identity_match
 
+    candidate_name = str(candidate.get("candidate_name") or "").strip()
+    candidate_brand = str(candidate.get("candidate_brand") or "").strip()
+    candidate_variant = str(candidate.get("variant") or "").strip()
     if candidate_name:
         return conn.execute(
             text(

--- a/backend/app/services/external_product_catalog_store.py
+++ b/backend/app/services/external_product_catalog_store.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import uuid
-from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy import text
@@ -10,143 +8,6 @@ from app.db import engine
 from app.services.external_product_candidate_store import ensure_external_product_candidates_schema
 
 DEFAULT_PROMOTION_THRESHOLD = 0.85
-
-GLOBAL_PRODUCT_COLUMNS: dict[str, str] = {
-    "id": "TEXT PRIMARY KEY",
-    "canonical_name": "TEXT",
-    "brand": "TEXT",
-    "product_type": "TEXT",
-    "category": "TEXT",
-    "retailer_article_number": "TEXT",
-    "gtin": "TEXT",
-    "source_name": "TEXT",
-    "source_product_code": "TEXT",
-    "source_url": "TEXT",
-    "promotion_status": "TEXT",
-    "created_by": "TEXT",
-    "created_at": "TEXT",
-    "updated_at": "TEXT",
-}
-
-PRODUCT_ENRICHMENT_COLUMNS: dict[str, str] = {
-    "id": "TEXT PRIMARY KEY",
-    "global_product_id": "TEXT",
-    "external_product_candidate_id": "TEXT",
-    "context_key": "TEXT",
-    "source_name": "TEXT",
-    "source_product_code": "TEXT",
-    "retailer_code": "TEXT",
-    "retailer_article_number": "TEXT",
-    "candidate_name": "TEXT",
-    "candidate_brand": "TEXT",
-    "variant": "TEXT",
-    "quantity_label": "TEXT",
-    "source_url": "TEXT",
-    "score": "REAL",
-    "promotion_threshold": "REAL",
-    "promotion_status": "TEXT",
-    "relationship_status": "TEXT",
-    "created_by": "TEXT",
-    "created_at": "TEXT",
-    "updated_at": "TEXT",
-}
-
-CREATE_GLOBAL_PRODUCTS_SQL = """
-CREATE TABLE IF NOT EXISTS global_products (
-    id TEXT PRIMARY KEY,
-    canonical_name TEXT,
-    brand TEXT,
-    product_type TEXT,
-    category TEXT,
-    retailer_article_number TEXT,
-    gtin TEXT,
-    source_name TEXT,
-    source_product_code TEXT,
-    source_url TEXT,
-    promotion_status TEXT,
-    created_by TEXT,
-    created_at TEXT,
-    updated_at TEXT
-)
-"""
-
-CREATE_PRODUCT_ENRICHMENTS_SQL = """
-CREATE TABLE IF NOT EXISTS product_enrichments (
-    id TEXT PRIMARY KEY,
-    global_product_id TEXT,
-    external_product_candidate_id TEXT,
-    context_key TEXT,
-    source_name TEXT,
-    source_product_code TEXT,
-    retailer_code TEXT,
-    retailer_article_number TEXT,
-    candidate_name TEXT,
-    candidate_brand TEXT,
-    variant TEXT,
-    quantity_label TEXT,
-    source_url TEXT,
-    score REAL,
-    promotion_threshold REAL,
-    promotion_status TEXT,
-    relationship_status TEXT,
-    created_by TEXT,
-    created_at TEXT,
-    updated_at TEXT
-)
-"""
-
-GLOBAL_PRODUCTS_SOURCE_INDEX_SQL = """
-CREATE INDEX IF NOT EXISTS idx_global_products_source
-ON global_products (source_name, source_product_code, retailer_article_number)
-"""
-
-PRODUCT_ENRICHMENTS_SOURCE_INDEX_SQL = """
-CREATE INDEX IF NOT EXISTS idx_product_enrichments_source
-ON product_enrichments (source_name, source_product_code, context_key, variant)
-"""
-
-
-def now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
-
-
-def _get_sqlite_columns(conn, table_name: str) -> set[str]:
-    rows = conn.execute(text(f"PRAGMA table_info({table_name})")).mappings().all()
-    return {str(row.get("name") or "") for row in rows}
-
-
-def _get_postgres_columns(conn, table_name: str) -> set[str]:
-    rows = conn.execute(
-        text(
-            """
-            SELECT column_name
-            FROM information_schema.columns
-            WHERE table_name = :table_name
-            """
-        ),
-        {"table_name": table_name},
-    ).mappings().all()
-    return {str(row.get("column_name") or "") for row in rows}
-
-
-def _add_missing_columns(conn, table_name: str, columns: dict[str, str]) -> None:
-    dialect_name = str(engine.dialect.name or "").lower()
-    existing_columns = _get_sqlite_columns(conn, table_name) if dialect_name == "sqlite" else _get_postgres_columns(conn, table_name)
-    for column_name, column_definition in columns.items():
-        if column_name in existing_columns or column_name == "id":
-            continue
-        conn.execute(text(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {column_definition}"))
-
-
-def ensure_catalog_schema() -> None:
-    ensure_external_product_candidates_schema()
-    with engine.begin() as conn:
-        conn.execute(text(CREATE_GLOBAL_PRODUCTS_SQL))
-        conn.execute(text(CREATE_PRODUCT_ENRICHMENTS_SQL))
-        _add_missing_columns(conn, "global_products", GLOBAL_PRODUCT_COLUMNS)
-        _add_missing_columns(conn, "product_enrichments", PRODUCT_ENRICHMENT_COLUMNS)
-        conn.execute(text(GLOBAL_PRODUCTS_SOURCE_INDEX_SQL))
-        conn.execute(text(PRODUCT_ENRICHMENTS_SOURCE_INDEX_SQL))
 
 
 def _candidate_source_name(candidate: dict[str, Any]) -> str:
@@ -189,48 +50,48 @@ def _find_highest_candidate(conn, context_key: str | None, retailer_code: str | 
     ).mappings().first()
 
 
-def _find_existing_enrichment(conn, candidate: dict[str, Any]):
-    source_name = _candidate_source_name(candidate)
+def _find_existing_global_product(conn, candidate: dict[str, Any]):
+    candidate_name = str(candidate.get("candidate_name") or "").strip()
+    candidate_brand = str(candidate.get("candidate_brand") or "").strip()
+    candidate_variant = str(candidate.get("variant") or "").strip()
     source_product_code = _candidate_source_product_code(candidate)
-    return conn.execute(
-        text(
-            """
-            SELECT *
-            FROM product_enrichments
-            WHERE COALESCE(source_name, '') = COALESCE(:source_name, '')
-              AND COALESCE(source_product_code, '') = COALESCE(:source_product_code, '')
-              AND COALESCE(context_key, '') = COALESCE(:context_key, '')
-              AND COALESCE(variant, '') = COALESCE(:variant, '')
-            LIMIT 1
-            """
-        ),
-        {
-            "source_name": source_name,
-            "source_product_code": source_product_code,
-            "context_key": str(candidate.get("context_key") or "").strip(),
-            "variant": str(candidate.get("variant") or "").strip(),
-        },
-    ).mappings().first()
 
+    if source_product_code and source_product_code != "unknown":
+        identity_match = conn.execute(
+            text(
+                """
+                SELECT gp.*
+                FROM product_identities pi
+                JOIN global_products gp ON gp.id = pi.global_product_id
+                WHERE pi.identity_value = :identity_value
+                LIMIT 1
+                """
+            ),
+            {"identity_value": source_product_code},
+        ).mappings().first()
+        if identity_match:
+            return identity_match
 
-def _find_existing_global_product(conn, source_name: str, source_product_code: str, retailer_article_number: str | None):
-    return conn.execute(
-        text(
-            """
-            SELECT *
-            FROM global_products
-            WHERE COALESCE(source_name, '') = COALESCE(:source_name, '')
-              AND COALESCE(source_product_code, '') = COALESCE(:source_product_code, '')
-              AND COALESCE(retailer_article_number, '') = COALESCE(:retailer_article_number, '')
-            LIMIT 1
-            """
-        ),
-        {
-            "source_name": source_name,
-            "source_product_code": source_product_code,
-            "retailer_article_number": str(retailer_article_number or "").strip(),
-        },
-    ).mappings().first()
+    if candidate_name:
+        return conn.execute(
+            text(
+                """
+                SELECT *
+                FROM global_products
+                WHERE lower(name) = lower(:name)
+                  AND COALESCE(lower(brand), '') = COALESCE(lower(:brand), '')
+                  AND COALESCE(lower(variant), '') = COALESCE(lower(:variant), '')
+                LIMIT 1
+                """
+            ),
+            {
+                "name": candidate_name,
+                "brand": candidate_brand,
+                "variant": candidate_variant,
+            },
+        ).mappings().first()
+
+    return None
 
 
 def promote_highest_candidate_to_catalog(
@@ -239,9 +100,14 @@ def promote_highest_candidate_to_catalog(
     receipt_line_text: str | None = None,
     threshold: float = DEFAULT_PROMOTION_THRESHOLD,
 ) -> dict[str, Any]:
-    ensure_catalog_schema()
+    """Link the highest external candidate to an existing global product only.
+
+    M2C2e deliberately does not create global_products and does not write
+    product_enrichments from standalone preview context, because the current
+    runtime product_enrichments table requires a household_article_id.
+    """
+    ensure_external_product_candidates_schema()
     normalized_threshold = float(threshold or DEFAULT_PROMOTION_THRESHOLD)
-    timestamp = now_iso()
 
     with engine.begin() as conn:
         candidate_row = _find_highest_candidate(
@@ -257,157 +123,65 @@ def promote_highest_candidate_to_catalog(
                 "promoted": False,
                 "reason": "no_candidate_above_threshold",
                 "promotion_threshold": normalized_threshold,
+                "creates_global_product": False,
                 "creates_household_article": False,
                 "creates_inventory_event": False,
             }
 
         candidate = dict(candidate_row)
-        source_name = _candidate_source_name(candidate)
-        source_product_code = _candidate_source_product_code(candidate)
-        retailer_article_number = str(candidate.get("retailer_article_number") or "").strip() or None
-        existing_enrichment = _find_existing_enrichment(conn, candidate)
-        existing_product = _find_existing_global_product(conn, source_name, source_product_code, retailer_article_number)
-        global_product_id = str(existing_product.get("id")) if existing_product else str(uuid.uuid4())
-        enrichment_id = str(existing_enrichment.get("id")) if existing_enrichment else str(uuid.uuid4())
+        existing_global_product = _find_existing_global_product(conn, candidate)
+        if not existing_global_product:
+            return {
+                "ok": True,
+                "promoted": False,
+                "reason": "blocked_requires_existing_global_product",
+                "candidate_id": str(candidate.get("id") or ""),
+                "candidate_name": str(candidate.get("candidate_name") or ""),
+                "candidate_brand": str(candidate.get("candidate_brand") or ""),
+                "source_name": _candidate_source_name(candidate),
+                "source_product_code": _candidate_source_product_code(candidate),
+                "score": float(candidate.get("score") or 0),
+                "promotion_threshold": normalized_threshold,
+                "creates_global_product": False,
+                "creates_household_article": False,
+                "creates_inventory_event": False,
+            }
 
-        product_params = {
-            "id": global_product_id,
-            "canonical_name": str(candidate.get("candidate_name") or "").strip(),
-            "brand": str(candidate.get("candidate_brand") or "").strip() or None,
-            "product_type": None,
-            "category": None,
-            "retailer_article_number": retailer_article_number,
-            "gtin": None,
-            "source_name": source_name,
-            "source_product_code": source_product_code,
-            "source_url": str(candidate.get("source_url") or "").strip() or None,
-            "promotion_status": "catalog_promoted_from_external_candidate",
-            "created_by": "external_database_catalog_promotion_v1",
-            "created_at": timestamp,
-            "updated_at": timestamp,
-        }
-        enrichment_params = {
-            "id": enrichment_id,
-            "global_product_id": global_product_id,
-            "external_product_candidate_id": str(candidate.get("id") or "").strip(),
-            "context_key": str(candidate.get("context_key") or "").strip(),
-            "source_name": source_name,
-            "source_product_code": source_product_code,
-            "retailer_code": str(candidate.get("retailer_code") or "").strip() or None,
-            "retailer_article_number": retailer_article_number,
-            "candidate_name": str(candidate.get("candidate_name") or "").strip(),
-            "candidate_brand": str(candidate.get("candidate_brand") or "").strip() or None,
-            "variant": str(candidate.get("variant") or "").strip() or None,
-            "quantity_label": str(candidate.get("quantity_label") or "").strip() or None,
-            "source_url": str(candidate.get("source_url") or "").strip() or None,
-            "score": float(candidate.get("score") or 0),
-            "promotion_threshold": normalized_threshold,
-            "promotion_status": "catalog_promoted",
-            "relationship_status": "proposed_by_external_database",
-            "created_by": "external_database_catalog_promotion_v1",
-            "created_at": timestamp,
-            "updated_at": timestamp,
-        }
-
-        if existing_product:
-            conn.execute(
-                text(
-                    """
-                    UPDATE global_products
-                    SET canonical_name = :canonical_name,
-                        brand = :brand,
-                        retailer_article_number = :retailer_article_number,
-                        source_url = :source_url,
-                        promotion_status = :promotion_status,
-                        updated_at = :updated_at
-                    WHERE id = :id
-                    """
-                ),
-                product_params,
-            )
-            product_action = "updated"
-        else:
-            conn.execute(
-                text(
-                    """
-                    INSERT INTO global_products (
-                        id, canonical_name, brand, product_type, category, retailer_article_number, gtin,
-                        source_name, source_product_code, source_url, promotion_status, created_by, created_at, updated_at
-                    ) VALUES (
-                        :id, :canonical_name, :brand, :product_type, :category, :retailer_article_number, :gtin,
-                        :source_name, :source_product_code, :source_url, :promotion_status, :created_by, :created_at, :updated_at
-                    )
-                    """
-                ),
-                product_params,
-            )
-            product_action = "created"
-
-        if existing_enrichment:
-            conn.execute(
-                text(
-                    """
-                    UPDATE product_enrichments
-                    SET global_product_id = :global_product_id,
-                        external_product_candidate_id = :external_product_candidate_id,
-                        candidate_name = :candidate_name,
-                        candidate_brand = :candidate_brand,
-                        quantity_label = :quantity_label,
-                        source_url = :source_url,
-                        score = :score,
-                        promotion_threshold = :promotion_threshold,
-                        promotion_status = :promotion_status,
-                        relationship_status = :relationship_status,
-                        updated_at = :updated_at
-                    WHERE id = :id
-                    """
-                ),
-                enrichment_params,
-            )
-            enrichment_action = "updated"
-        else:
-            conn.execute(
-                text(
-                    """
-                    INSERT INTO product_enrichments (
-                        id, global_product_id, external_product_candidate_id, context_key, source_name, source_product_code,
-                        retailer_code, retailer_article_number, candidate_name, candidate_brand, variant, quantity_label,
-                        source_url, score, promotion_threshold, promotion_status, relationship_status,
-                        created_by, created_at, updated_at
-                    ) VALUES (
-                        :id, :global_product_id, :external_product_candidate_id, :context_key, :source_name, :source_product_code,
-                        :retailer_code, :retailer_article_number, :candidate_name, :candidate_brand, :variant, :quantity_label,
-                        :source_url, :score, :promotion_threshold, :promotion_status, :relationship_status,
-                        :created_by, :created_at, :updated_at
-                    )
-                    """
-                ),
-                enrichment_params,
-            )
-            enrichment_action = "created"
+        global_product_id = str(existing_global_product.get("id") or "")
+        candidate_id = str(candidate.get("id") or "")
+        conn.execute(
+            text(
+                """
+                UPDATE external_product_candidates
+                SET global_product_id = :global_product_id,
+                    status = 'linked_to_catalog',
+                    candidate_status = 'linked_to_catalog',
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE id = :candidate_id
+                """
+            ),
+            {"global_product_id": global_product_id, "candidate_id": candidate_id},
+        )
 
     return {
         "ok": True,
         "promoted": True,
+        "reason": "linked_to_existing_global_product",
         "global_product_id": global_product_id,
-        "product_enrichment_id": enrichment_id,
-        "product_action": product_action,
-        "enrichment_action": enrichment_action,
-        "candidate_id": str(candidate.get("id") or ""),
+        "candidate_id": candidate_id,
         "candidate_name": str(candidate.get("candidate_name") or ""),
         "candidate_brand": str(candidate.get("candidate_brand") or ""),
         "score": float(candidate.get("score") or 0),
         "promotion_threshold": normalized_threshold,
-        "source_name": source_name,
-        "source_product_code": source_product_code,
-        "retailer_article_number": retailer_article_number,
+        "source_name": _candidate_source_name(candidate),
+        "source_product_code": _candidate_source_product_code(candidate),
+        "creates_global_product": False,
         "creates_household_article": False,
         "creates_inventory_event": False,
     }
 
 
 def list_catalog_products(limit: int = 50) -> dict[str, Any]:
-    ensure_catalog_schema()
     normalized_limit = max(1, min(int(limit or 50), 200))
     with engine.begin() as conn:
         rows = conn.execute(
@@ -415,7 +189,7 @@ def list_catalog_products(limit: int = 50) -> dict[str, Any]:
                 """
                 SELECT *
                 FROM global_products
-                ORDER BY updated_at DESC, canonical_name ASC
+                ORDER BY updated_at DESC, name ASC
                 LIMIT :limit
                 """
             ),


### PR DESCRIPTION
## Samenvatting

Herwerkte uitvoering van issue #50 / Scrumopdracht M2C2e.

Deze PR is aangepast na analyse van het runtime database-schema. De bestaande Rezzerv-cataloguslaag is leidend:

- `global_products` bestaat al en bevat catalogusproducten.
- `product_identities` bestaat al en kan identities aan `global_product_id` koppelen.
- `product_enrichments` vereist momenteel `household_article_id` en is daarom niet geschikt voor standalone Externe-databases-preview zonder huishoudcontext.
- `external_product_candidates` heeft al `global_product_id` en is de juiste plek om een kandidaat voorlopig aan een bestaand catalogusproduct te koppelen.

## Wijzigingen

- Nieuwe service `external_product_catalog_store.py`.
- Nieuwe API-endpoints:
  - `POST /api/external-databases/catalog/promote-highest`
  - `GET /api/external-databases/catalog/products`
- Selecteert de hoogste kandidaat boven drempel uit `external_product_candidates`.
- Koppelt alleen als een bestaand `global_product` aantoonbaar matcht via:
  - bestaande `external_product_candidates.global_product_id`, of
  - `product_identities.identity_value` met niet-lege `global_product_id`, of
  - exacte match op `global_products.name + brand + variant`.
- Bij match wordt alleen `external_product_candidates.global_product_id` gezet en status naar `linked_to_catalog` bijgewerkt.
- Als er geen bestaand catalogusproduct gevonden wordt, antwoordt de API met `blocked_requires_existing_global_product`.

## Niet gewijzigd

- Geen nieuwe `global_products`.
- Geen nieuwe `product_enrichments` vanuit standalone preview.
- Geen `household_articles`.
- Geen huishoudadministratie-mutatie.
- Geen voorraadmutatie.
- Geen batchdoorvoer naar huishoudadministratie.
- Geen frontend-knop in deze PR; eerst backend/API controleren.

## PO-test via API

Vooraf: zorg dat M2C2d kandidaatmatches heeft opgeslagen via de UI:

1. Login → Startpagina → Externe databases.
2. Test algoritme → `Mexicaanse kruidenm.`.
3. Klik **Test kandidaat**.
4. Klik **Kandidaten opslaan**.

Daarna API-test:

```powershell
$body = @{ retailer_code = "lidl"; receipt_line_text = "Mexicaanse kruidenm."; threshold = 0.85 } | ConvertTo-Json
Invoke-RestMethod -Method Post -Uri "http://localhost:8011/api/external-databases/catalog/promote-highest" -ContentType "application/json" -Body $body
```

Verwachting in huidige dataset is waarschijnlijk:

- `promoted: false`
- `reason: blocked_requires_existing_global_product`
- `creates_global_product: false`
- `creates_household_article: false`
- `creates_inventory_event: false`

Als de kandidaat vooraf expliciet aan een bestaand `global_product_id` is gekoppeld, dan wordt verwacht:

- `promoted: true`
- `reason: linked_to_existing_global_product`
- kandidaat krijgt/blijft `global_product_id`
- geen nieuwe catalogus- of huishoudrecords.

Cataloguslijst controleren:

```powershell
Invoke-RestMethod "http://localhost:8011/api/external-databases/catalog/products"
```

Closes #50