### PR TITLE
feat(m2c2h): add receipt-item driven external databases overview

### DIFF
--- a/docs/technical/M2C2h_po_test.md
+++ b/docs/technical/M2C2h_po_test.md
@@ -1,0 +1,39 @@
+# PO-test M2C2h-1
+
+## Doel
+
+Controleer dat Externe databases start met een hoofdtabel Bonartikelen voor externe herkenning.
+
+## Voorbereiding
+
+```powershell
+git fetch origin
+git switch m2c2h-bonartikelen-hoofdtabel
+git pull --ff-only origin m2c2h-bonartikelen-hoofdtabel
+
+docker compose down
+docker compose up -d --build
+Start-Sleep -Seconds 90
+curl.exe http://localhost:8011/api/health
+Start-Process "http://localhost:5174/externe-databases"
+```
+
+## Testpunten
+
+1. Externe databases opent zonder foutmelding.
+2. Op tab Overzicht staat de tabel Bonartikelen voor externe herkenning.
+3. De tabel toont kolommen voor bonartikel, genormaliseerde naam, winkelketen, artikelnummer, GTIN/EAN, omvang/gewicht, prijs, aantal, externe kandidaten, catalogus en status.
+4. De tabel heeft een filterrij onder de kolomkoppen.
+5. De tabel heeft sortering en paginering.
+6. De rijhoogte is 28 px.
+7. De kolom Catalogus toont een groene status-checkbox.
+8. Dubbelklik op een rij opent het detailframe onder de tabel.
+9. Het detailframe toont context van het gekozen bonartikel.
+10. Er wordt geen catalogusverwerking uitgevoerd.
+11. Er wordt geen huishoudartikel aangemaakt.
+12. Er wordt geen voorraadmutatie aangemaakt.
+13. Bestaande tabs Test algoritme en Winkelketens blijven beschikbaar.
+
+## Acceptatie
+
+M2C2h-1 is akkoord als alle testpunten groen zijn.

--- a/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
+++ b/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
@@ -6,6 +6,7 @@ import Table from '../../ui/Table'
 import Tabs from '../../ui/Tabs'
 import Input from '../../ui/Input'
 import Button from '../../ui/Button'
+import ReceiptItemsOverview from './ReceiptItemsOverview'
 import { fetchJsonWithAuth } from '../../lib/authSession'
 import './externalDatabases.css'
 
@@ -165,6 +166,7 @@ export default function ExternalDatabasesPage() {
       return (
         <div className="rz-external-databases-overview">
           {isLoadingConfig ? <div>Externe databases worden geladen...</div> : null}
+          <ReceiptItemsOverview onError={setError} />
           <div className="rz-external-databases-overview-grid">
             <OverviewTile title="Actieve winkelketens" value={summary?.supported_retailers ?? retailers.length} helper={(summary?.active_retailers || []).join(', ') || 'Nog geen actieve winkelketens'} />
             <OverviewTile title="Beleid" value="Preview" helper="Alleen kandidaatmatches tonen" />
@@ -198,62 +200,18 @@ export default function ExternalDatabasesPage() {
               <Button type="submit" disabled={isTesting || !selectedRetailer}>
                 {isTesting ? 'Test loopt...' : 'Test kandidaat'}
               </Button>
-              <Button type="button" variant="secondary" onClick={() => setReceiptLineText('Taco saus')}>
-                Voorbeeld Taco saus
-              </Button>
-              <Button type="button" variant="secondary" onClick={() => setReceiptLineText('Mexicaanse kruidenm.')}>
-                Voorbeeld kruidenmix
-              </Button>
-              <Button type="button" variant="secondary" disabled={isSaving || !candidates.length} onClick={saveCandidateMatches}>
-                {isSaving ? 'Opslaan...' : 'Kandidaten opslaan'}
-              </Button>
+              <Button type="button" variant="secondary" onClick={() => setReceiptLineText('Taco saus')}>Voorbeeld Taco saus</Button>
+              <Button type="button" variant="secondary" onClick={() => setReceiptLineText('Mexicaanse kruidenm.')}>Voorbeeld kruidenmix</Button>
+              <Button type="button" variant="secondary" disabled={isSaving || !candidates.length} onClick={saveCandidateMatches}>{isSaving ? 'Opslaan...' : 'Kandidaten opslaan'}</Button>
             </div>
           </form>
-
-          <div className="rz-external-databases-muted">
-            Drempel probable_candidate: {formatScore(selectedRetailerConfig?.probable_candidate_threshold)}. Deze opslag maakt geen Mijn artikel, global_product of voorraadmutatie aan.
-          </div>
-
-          {saveResult ? (
-            <div className="rz-inline-feedback rz-inline-feedback--success">
-              Kandidaten opgeslagen: {saveResult.saved_count ?? 0} nieuw, {saveResult.updated_count ?? 0} bijgewerkt, {saveResult.skipped_count ?? 0} overgeslagen.
-            </div>
-          ) : null}
-
+          <div className="rz-external-databases-muted">Drempel probable_candidate: {formatScore(selectedRetailerConfig?.probable_candidate_threshold)}. Deze opslag maakt geen Mijn artikel, global_product of voorraadmutatie aan.</div>
+          {saveResult ? <div className="rz-inline-feedback rz-inline-feedback--success">Kandidaten opgeslagen: {saveResult.saved_count ?? 0} nieuw, {saveResult.updated_count ?? 0} bijgewerkt, {saveResult.skipped_count ?? 0} overgeslagen.</div> : null}
           {matchResult ? (
             <Table dataTestId="external-database-candidates-table" tableClassName="rz-external-databases-table">
-              <colgroup>
-                <col className="rz-external-databases-col-candidate" />
-                <col className="rz-external-databases-col-brand" />
-                <col className="rz-external-databases-col-code" />
-                <col className="rz-external-databases-col-variant" />
-                <col className="rz-external-databases-col-score" />
-                <col className="rz-external-databases-col-status" />
-              </colgroup>
-              <thead>
-                <tr className="rz-table-header">
-                  <th>Kandidaat</th>
-                  <th>Merk</th>
-                  <th>Artikelnummer</th>
-                  <th>Variant</th>
-                  <th className="rz-num">Score</th>
-                  <th>Status</th>
-                </tr>
-              </thead>
-              <tbody>
-                {candidates.length ? candidates.map((candidate) => (
-                  <tr key={`${candidate.candidate_name}-${candidate.retailer_article_number}-${candidate.variant}`}>
-                    <td>{candidate.candidate_name}</td>
-                    <td>{candidate.candidate_brand}</td>
-                    <td>{candidate.retailer_article_number}</td>
-                    <td>{candidate.variant || '-'}</td>
-                    <td className="rz-num">{formatScore(candidate.score)}</td>
-                    <td><StatusBadge status={candidate.candidate_status} /></td>
-                  </tr>
-                )) : (
-                  <tr><td colSpan="6">Geen kandidaten gevonden boven de drempel.</td></tr>
-                )}
-              </tbody>
+              <colgroup><col className="rz-external-databases-col-candidate" /><col className="rz-external-databases-col-brand" /><col className="rz-external-databases-col-code" /><col className="rz-external-databases-col-variant" /><col className="rz-external-databases-col-score" /><col className="rz-external-databases-col-status" /></colgroup>
+              <thead><tr className="rz-table-header"><th>Kandidaat</th><th>Merk</th><th>Artikelnummer</th><th>Variant</th><th className="rz-num">Score</th><th>Status</th></tr></thead>
+              <tbody>{candidates.length ? candidates.map((candidate) => <tr key={`${candidate.candidate_name}-${candidate.retailer_article_number}-${candidate.variant}`}><td>{candidate.candidate_name}</td><td>{candidate.candidate_brand}</td><td>{candidate.retailer_article_number}</td><td>{candidate.variant || '-'}</td><td className="rz-num">{formatScore(candidate.score)}</td><td><StatusBadge status={candidate.candidate_status} /></td></tr>) : <tr><td colSpan="6">Geen kandidaten gevonden boven de drempel.</td></tr>}</tbody>
             </Table>
           ) : null}
         </div>
@@ -262,32 +220,9 @@ export default function ExternalDatabasesPage() {
 
     return (
       <Table dataTestId="external-database-retailers-table" tableClassName="rz-external-databases-retailer-table">
-        <colgroup>
-          <col className="rz-external-databases-col-retailer" />
-          <col className="rz-external-databases-col-retailer-status" />
-          <col className="rz-external-databases-col-retailer-threshold" />
-          <col className="rz-external-databases-col-retailer-examples" />
-        </colgroup>
-        <thead>
-          <tr className="rz-table-header">
-            <th>Winkelketen</th>
-            <th>Status</th>
-            <th className="rz-num">Drempel</th>
-            <th>Voorbeelden</th>
-          </tr>
-        </thead>
-        <tbody>
-          {retailers.length ? retailers.map((retailer) => (
-            <tr key={retailer.retailer_code}>
-              <td>{retailer.retailer_name}</td>
-              <td>{retailer.status}</td>
-              <td className="rz-num">{formatScore(retailer.probable_candidate_threshold)}</td>
-              <td>{(retailer.supported_examples || []).join(', ')}</td>
-            </tr>
-          )) : (
-            <tr><td colSpan="4">Geen winkelketens gevonden.</td></tr>
-          )}
-        </tbody>
+        <colgroup><col className="rz-external-databases-col-retailer" /><col className="rz-external-databases-col-retailer-status" /><col className="rz-external-databases-col-retailer-threshold" /><col className="rz-external-databases-col-retailer-examples" /></colgroup>
+        <thead><tr className="rz-table-header"><th>Winkelketen</th><th>Status</th><th className="rz-num">Drempel</th><th>Voorbeelden</th></tr></thead>
+        <tbody>{retailers.length ? retailers.map((retailer) => <tr key={retailer.retailer_code}><td>{retailer.retailer_name}</td><td>{retailer.status}</td><td className="rz-num">{formatScore(retailer.probable_candidate_threshold)}</td><td>{(retailer.supported_examples || []).join(', ')}</td></tr>) : <tr><td colSpan="4">Geen winkelketens gevonden.</td></tr>}</tbody>
       </Table>
     )
   }
@@ -300,18 +235,11 @@ export default function ExternalDatabasesPage() {
             <div className="rz-external-databases-header">
               <div className="rz-external-databases-title-group">
                 <h2 className="rz-external-databases-title">Externe databases</h2>
-                <p className="rz-external-databases-subtitle">
-                  Eerste versie voor externe productkandidaten. Deze preview maakt geen Mijn artikel, product of voorraadmutatie aan.
-                </p>
+                <p className="rz-external-databases-subtitle">Eerste versie voor externe productkandidaten. Deze preview maakt geen Mijn artikel, product of voorraadmutatie aan.</p>
               </div>
-              <Button variant="primary" type="button" onClick={() => navigate('/home')}>
-                Terug
-              </Button>
+              <Button variant="primary" type="button" onClick={() => navigate('/home')}>Terug</Button>
             </div>
-
-            <Tabs tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab}>
-              {renderTabContent}
-            </Tabs>
+            <Tabs tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab}>{renderTabContent}</Tabs>
           </div>
         </ScreenCard>
       </div>

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -1,0 +1,216 @@
+import { useEffect, useMemo, useState } from 'react'
+import Table from '../../ui/Table'
+import Button from '../../ui/Button'
+import { fetchJsonWithAuth } from '../../lib/authSession'
+
+const PAGE_SIZE = 10
+
+function text(value, fallback = '-') {
+  const normalized = String(value || '').trim()
+  return normalized || fallback
+}
+
+function numberText(value) {
+  const number = Number(value)
+  if (!Number.isFinite(number)) return '-'
+  return number.toLocaleString('nl-NL', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+function rowKey(item) {
+  return text(item.context_key || item.receipt_line_id || item.purchase_import_line_id || item.receipt_line_text, 'receipt-item')
+}
+
+function buildReceiptItems(candidates) {
+  const grouped = new Map()
+  candidates.forEach((candidate) => {
+    const key = rowKey(candidate)
+    const current = grouped.get(key) || {
+      id: key,
+      receiptLineText: text(candidate.receipt_line_text),
+      normalizedName: text(candidate.parsed_name || candidate.receipt_line_text),
+      retailerCode: text(candidate.retailer_code),
+      articleNumber: text(candidate.retailer_article_number || candidate.source_product_code || candidate.candidate_source_product_code),
+      gtin: text(candidate.gtin || candidate.ean),
+      quantity: text(candidate.quantity_label),
+      price: '-',
+      amount: '-',
+      candidateCount: 0,
+      catalogLinked: false,
+      status: 'Nog niet verwerkt',
+    }
+    current.candidateCount += 1
+    if (candidate.global_product_id || candidate.product_identity_id || candidate.candidate_status === 'user_confirmed') {
+      current.catalogLinked = true
+      current.status = 'Catalogus kandidaat'
+    }
+    grouped.set(key, current)
+  })
+  return Array.from(grouped.values())
+}
+
+function sortValue(item, key) {
+  if (key === 'candidateCount') return Number(item.candidateCount || 0)
+  if (key === 'catalogLinked') return item.catalogLinked ? 1 : 0
+  return String(item[key] || '').toLowerCase()
+}
+
+export default function ReceiptItemsOverview({ onError }) {
+  const [items, setItems] = useState([])
+  const [selectedItem, setSelectedItem] = useState(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [filters, setFilters] = useState({ receiptLineText: '', retailerCode: '', articleNumber: '', quantity: '', status: '' })
+  const [sortKey, setSortKey] = useState('receiptLineText')
+  const [sortDesc, setSortDesc] = useState(false)
+  const [page, setPage] = useState(1)
+
+  async function loadItems() {
+    setIsLoading(true)
+    try {
+      const response = await fetchJsonWithAuth('/api/external-databases/candidates?limit=200', { method: 'GET' })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data?.detail || 'Bonartikelen konden niet worden geladen')
+      const candidates = Array.isArray(data?.items) ? data.items : []
+      setItems(buildReceiptItems(candidates))
+      setPage(1)
+    } catch (err) {
+      onError?.(err?.message || 'Bonartikelen konden niet worden geladen')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadItems()
+  }, [])
+
+  function updateFilter(key, value) {
+    setFilters((current) => ({ ...current, [key]: value }))
+    setPage(1)
+  }
+
+  function updateSort(key) {
+    if (sortKey === key) setSortDesc((value) => !value)
+    else { setSortKey(key); setSortDesc(false) }
+    setPage(1)
+  }
+
+  function sortMark(key) {
+    if (sortKey !== key) return 'v'
+    return sortDesc ? 'v' : '^'
+  }
+
+  const filteredItems = useMemo(() => {
+    const rows = items.filter((item) => (
+      item.receiptLineText.toLowerCase().includes(filters.receiptLineText.toLowerCase()) &&
+      item.retailerCode.toLowerCase().includes(filters.retailerCode.toLowerCase()) &&
+      item.articleNumber.toLowerCase().includes(filters.articleNumber.toLowerCase()) &&
+      item.quantity.toLowerCase().includes(filters.quantity.toLowerCase()) &&
+      item.status.toLowerCase().includes(filters.status.toLowerCase())
+    ))
+    rows.sort((leftItem, rightItem) => {
+      const left = sortValue(leftItem, sortKey)
+      const right = sortValue(rightItem, sortKey)
+      if (left < right) return sortDesc ? 1 : -1
+      if (left > right) return sortDesc ? -1 : 1
+      return 0
+    })
+    return rows
+  }, [items, filters, sortKey, sortDesc])
+
+  const pageCount = Math.max(1, Math.ceil(filteredItems.length / PAGE_SIZE))
+  const currentPage = Math.min(page, pageCount)
+  const visibleItems = filteredItems.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
+  const emptyRows = Math.max(0, 3 - visibleItems.length)
+
+  return (
+    <div className="rz-external-receipt-overview">
+      <div className="rz-external-databases-section-header">
+        <h3>Bonartikelen voor externe herkenning</h3>
+        <Button type="button" variant="secondary" disabled={isLoading} onClick={loadItems}>Vernieuwen</Button>
+      </div>
+      {isLoading ? <div>Bonartikelen worden geladen...</div> : null}
+      <Table dataTestId="external-receipt-items-table" tableClassName="rz-external-receipt-table">
+        <colgroup>
+          <col className="rz-external-receipt-col-receipt" />
+          <col className="rz-external-receipt-col-normalized" />
+          <col className="rz-external-receipt-col-retailer" />
+          <col className="rz-external-receipt-col-code" />
+          <col className="rz-external-receipt-col-gtin" />
+          <col className="rz-external-receipt-col-quantity" />
+          <col className="rz-external-receipt-col-price" />
+          <col className="rz-external-receipt-col-amount" />
+          <col className="rz-external-receipt-col-candidates" />
+          <col className="rz-external-receipt-col-catalog" />
+          <col className="rz-external-receipt-col-status" />
+        </colgroup>
+        <thead>
+          <tr className="rz-table-header">
+            <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('receiptLineText')}>Bonartikel <span>{sortMark('receiptLineText')}</span></button></th>
+            <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('normalizedName')}>Genormaliseerde naam <span>{sortMark('normalizedName')}</span></button></th>
+            <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('retailerCode')}>Winkelketen <span>{sortMark('retailerCode')}</span></button></th>
+            <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('articleNumber')}>Artikelnummer <span>{sortMark('articleNumber')}</span></button></th>
+            <th>GTIN / EAN</th>
+            <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('quantity')}>Omvang / gewicht <span>{sortMark('quantity')}</span></button></th>
+            <th className="rz-num">Prijs</th>
+            <th className="rz-num">Aantal</th>
+            <th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('candidateCount')}>Externe kandidaten <span>{sortMark('candidateCount')}</span></button></th>
+            <th className="rz-check"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('catalogLinked')}>Catalogus <span>{sortMark('catalogLinked')}</span></button></th>
+            <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('status')}>Status <span>{sortMark('status')}</span></button></th>
+          </tr>
+          <tr className="rz-external-databases-filter-row">
+            <th><input className="rz-table-filter" value={filters.receiptLineText} onChange={(event) => updateFilter('receiptLineText', event.target.value)} placeholder="Zoek" /></th>
+            <th></th>
+            <th><input className="rz-table-filter" value={filters.retailerCode} onChange={(event) => updateFilter('retailerCode', event.target.value)} placeholder="Filter" /></th>
+            <th><input className="rz-table-filter" value={filters.articleNumber} onChange={(event) => updateFilter('articleNumber', event.target.value)} placeholder="Filter" /></th>
+            <th></th>
+            <th><input className="rz-table-filter" value={filters.quantity} onChange={(event) => updateFilter('quantity', event.target.value)} placeholder="Filter" /></th>
+            <th></th>
+            <th></th>
+            <th></th>
+            <th></th>
+            <th><input className="rz-table-filter" value={filters.status} onChange={(event) => updateFilter('status', event.target.value)} placeholder="Filter" /></th>
+          </tr>
+        </thead>
+        <tbody>
+          {visibleItems.length ? visibleItems.map((item) => (
+            <tr key={item.id} className={selectedItem?.id === item.id ? 'rz-row-active' : ''} onDoubleClick={() => setSelectedItem(item)}>
+              <td>{item.receiptLineText}</td>
+              <td>{item.normalizedName}</td>
+              <td>{item.retailerCode}</td>
+              <td>{item.articleNumber}</td>
+              <td>{item.gtin}</td>
+              <td>{item.quantity}</td>
+              <td className="rz-num">{numberText(item.price)}</td>
+              <td className="rz-num">{item.amount}</td>
+              <td className="rz-num">{item.candidateCount}</td>
+              <td className="rz-check"><input type="checkbox" checked={item.catalogLinked} readOnly /></td>
+              <td>{item.status}</td>
+            </tr>
+          )) : <tr><td colSpan="11">Geen bonartikelen beschikbaar voor externe herkenning.</td></tr>}
+          {Array.from({ length: emptyRows }).map((_, index) => <tr key={`empty-${index}`}><td colSpan="11"></td></tr>)}
+        </tbody>
+      </Table>
+      <div className="rz-external-databases-pagination">
+        <Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => setPage((value) => Math.max(1, value - 1))}>Vorige</Button>
+        <span className="rz-external-databases-page-indicator">Pagina {currentPage} van {pageCount}</span>
+        <Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => setPage((value) => Math.min(pageCount, value + 1))}>Volgende</Button>
+      </div>
+      <div className="rz-external-receipt-detail">
+        {selectedItem ? (
+          <>
+            <h3>Bonartikel verwerken</h3>
+            <dl>
+              <dt>Bonartikel</dt><dd>{selectedItem.receiptLineText}</dd>
+              <dt>Winkelketen</dt><dd>{selectedItem.retailerCode}</dd>
+              <dt>Artikelnummer</dt><dd>{selectedItem.articleNumber}</dd>
+              <dt>Omvang / gewicht</dt><dd>{selectedItem.quantity}</dd>
+              <dt>Externe kandidaten</dt><dd>{selectedItem.candidateCount}</dd>
+              <dt>Catalogus</dt><dd>{selectedItem.catalogLinked ? 'Kandidaat aanwezig' : 'Nog geen kandidaat'}</dd>
+            </dl>
+            <p className="rz-external-databases-muted">Detailfunctionaliteit volgt in M2C2h-2.</p>
+          </>
+        ) : <p className="rz-external-databases-muted">Dubbelklik op een bonartikel om de detailcontext te openen.</p>}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/externalDatabases/externalDatabases.css
+++ b/frontend/src/features/externalDatabases/externalDatabases.css
@@ -8,11 +8,21 @@
   gap: 18px;
 }
 
-.rz-external-databases-header {
+.rz-external-databases-header,
+.rz-external-databases-section-header {
   display: flex;
   justify-content: space-between;
   gap: var(--space-md);
   align-items: flex-start;
+}
+
+.rz-external-databases-section-header {
+  align-items: center;
+}
+
+.rz-external-databases-section-header h3 {
+  margin: 0;
+  color: var(--color-brand-primary);
 }
 
 .rz-external-databases-title-group {
@@ -31,7 +41,8 @@
   color: #5f7a68;
 }
 
-.rz-external-databases-overview {
+.rz-external-databases-overview,
+.rz-external-receipt-overview {
   display: grid;
   gap: 14px;
 }
@@ -42,13 +53,34 @@
   gap: 12px;
 }
 
-.rz-external-databases-summary-card {
+.rz-external-databases-summary-card,
+.rz-external-receipt-detail {
   border: 2px solid #dfe7e1;
   border-radius: 14px;
   padding: 16px 18px;
   background: #ffffff;
   display: grid;
   gap: 6px;
+}
+
+.rz-external-receipt-detail h3 {
+  margin: 0;
+  color: var(--color-brand-primary);
+}
+
+.rz-external-receipt-detail dl {
+  display: grid;
+  grid-template-columns: 180px 1fr;
+  gap: 6px 12px;
+  margin: 0;
+}
+
+.rz-external-receipt-detail dt {
+  color: #5f7a68;
+}
+
+.rz-external-receipt-detail dd {
+  margin: 0;
 }
 
 .rz-external-databases-summary-label {
@@ -80,10 +112,12 @@
   align-items: end;
 }
 
-.rz-external-databases-actions {
+.rz-external-databases-actions,
+.rz-external-databases-pagination {
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
+  align-items: center;
 }
 
 .rz-external-databases-test {
@@ -96,16 +130,66 @@
   padding: 3px 8px;
 }
 
+.rz-external-databases input[type='radio'],
+.rz-external-databases input[type='checkbox'] {
+  accent-color: var(--color-brand-primary);
+}
+
 .rz-external-databases-table {
   table-layout: fixed;
   width: 100%;
   min-width: 860px;
 }
 
+.rz-external-receipt-table {
+  table-layout: fixed;
+  width: 100%;
+  min-width: 1480px;
+}
+
 .rz-external-databases-retailer-table {
   table-layout: fixed;
   width: 100%;
   min-width: 720px;
+}
+
+.rz-external-receipt-table th,
+.rz-external-receipt-table td {
+  height: 28px;
+  padding-top: 0;
+  padding-bottom: 0;
+  line-height: 28px;
+  vertical-align: middle;
+}
+
+.rz-row-active td {
+  outline: 2px solid var(--color-brand-primary);
+  outline-offset: -2px;
+}
+
+.rz-table-filter {
+  width: 100%;
+  height: 24px;
+  box-sizing: border-box;
+  font: inherit;
+  font-weight: 400;
+}
+
+.rz-external-databases-sort {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0;
+}
+
+.rz-external-databases-page-indicator {
+  min-width: 110px;
+  text-align: center;
 }
 
 .rz-external-databases-col-candidate { width: 260px; }
@@ -120,8 +204,21 @@
 .rz-external-databases-col-retailer-threshold { width: 140px; }
 .rz-external-databases-col-retailer-examples { width: 320px; }
 
+.rz-external-receipt-col-receipt { width: 220px; }
+.rz-external-receipt-col-normalized { width: 220px; }
+.rz-external-receipt-col-retailer { width: 120px; }
+.rz-external-receipt-col-code { width: 150px; }
+.rz-external-receipt-col-gtin { width: 140px; }
+.rz-external-receipt-col-quantity { width: 150px; }
+.rz-external-receipt-col-price { width: 90px; }
+.rz-external-receipt-col-amount { width: 90px; }
+.rz-external-receipt-col-candidates { width: 150px; }
+.rz-external-receipt-col-catalog { width: 110px; }
+.rz-external-receipt-col-status { width: 160px; }
+
 @media (max-width: 720px) {
   .rz-external-databases-header,
+  .rz-external-databases-section-header,
   .rz-external-databases-form-grid {
     display: grid;
     grid-template-columns: 1fr;


### PR DESCRIPTION
M2C2h-1 — Hoofdtabel Bonartikelen voor externe herkenning.

Scope:
- centrale bonartikelen-tabel bovenaan Externe databases
- catalogusstatus als status-checkbox
- dubbelklik op bonartikel opent leeg detailframe met context
- geen catalogusverwerking
- geen huishoudartikel-aanmaak
- geen voorraadmutatie

Deze PR is draft totdat lokale build en PO-test groen zijn.