### PR TITLE
M2C2h: clean up external databases receipt overview table

### DIFF
--- a/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
+++ b/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+﻿import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import AppShell from '../../app/AppShell'
 import ScreenCard from '../../ui/ScreenCard'
@@ -166,15 +166,7 @@ export default function ExternalDatabasesPage() {
       return (
         <div className="rz-external-databases-overview">
           {isLoadingConfig ? <div>Externe databases worden geladen...</div> : null}
-          <ReceiptItemsOverview onError={setError} />
-          <div className="rz-external-databases-overview-grid">
-            <OverviewTile title="Actieve winkelketens" value={summary?.supported_retailers ?? retailers.length} helper={(summary?.active_retailers || []).join(', ') || 'Nog geen actieve winkelketens'} />
-            <OverviewTile title="Beleid" value="Preview" helper="Alleen kandidaatmatches tonen" />
-            <OverviewTile title="Productmutaties" value="0" helper="Niet toegestaan in v1" />
-          </div>
-          <p className="rz-external-databases-muted">
-            Deze module toont kandidaatmatches uit externe bronnen. Bevestigen, GTIN-invoer en OFF-verrijking volgen pas in latere opdrachten.
-          </p>
+          <ReceiptItemsOverview onError={setError} onMessage={setError} />
         </div>
       )
     }
@@ -247,3 +239,4 @@ export default function ExternalDatabasesPage() {
     </AppShell>
   )
 }
+

--- a/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
+++ b/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom'
 import AppShell from '../../app/AppShell'
 import ScreenCard from '../../ui/ScreenCard'
 import Table from '../../ui/Table'
-import Tabs from '../../ui/Tabs'
 import Input from '../../ui/Input'
 import Button from '../../ui/Button'
 import ReceiptItemsOverview from './ReceiptItemsOverview'
@@ -54,7 +53,6 @@ function ErrorOverlay({ message, onClose }) {
 
 export default function ExternalDatabasesPage() {
   const navigate = useNavigate()
-  const [activeTab, setActiveTab] = useState(TAB_LABELS.overzicht)
   const [summary, setSummary] = useState(null)
   const [retailers, setRetailers] = useState([])
   const [receiptLineText, setReceiptLineText] = useState('Mexicaanse kruidenm.')
@@ -159,7 +157,6 @@ export default function ExternalDatabasesPage() {
   }
 
   const candidates = Array.isArray(matchResult?.candidates) ? matchResult.candidates : []
-  const tabs = [TAB_LABELS.overzicht, TAB_LABELS.test, TAB_LABELS.winkelketens]
 
   function renderTabContent(tab) {
     if (tab === TAB_LABELS.overzicht) {
@@ -231,7 +228,7 @@ export default function ExternalDatabasesPage() {
               </div>
               <Button variant="primary" type="button" onClick={() => navigate('/home')}>Terug</Button>
             </div>
-            <Tabs tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab}>{renderTabContent}</Tabs>
+            {renderTabContent(TAB_LABELS.overzicht)}
           </div>
         </ScreenCard>
       </div>
@@ -239,4 +236,5 @@ export default function ExternalDatabasesPage() {
     </AppShell>
   )
 }
+
 

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -51,7 +51,6 @@ function buildReceiptItems(candidates) {
       id: key,
       contextKey: text(candidate.context_key, ''),
       receiptLineText: text(candidate.receipt_line_text),
-      normalizedName: text(candidate.parsed_name || candidate.receipt_line_text),
       retailerCode: text(candidate.retailer_code),
       articleNumber: text(candidate.retailer_article_number || candidate.source_product_code || candidate.candidate_source_product_code),
       gtin: text(candidate.gtin || candidate.ean),
@@ -225,39 +224,36 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
         <Table dataTestId="external-receipt-items-table" tableClassName="rz-external-receipt-table">
           <colgroup>
             <col className="rz-external-receipt-col-receipt" />
-            <col className="rz-external-receipt-col-normalized" />
             <col className="rz-external-receipt-col-retailer" />
+            <col className="rz-external-receipt-col-catalog" />
             <col className="rz-external-receipt-col-code" />
             <col className="rz-external-receipt-col-gtin" />
             <col className="rz-external-receipt-col-quantity" />
             <col className="rz-external-receipt-col-price" />
             <col className="rz-external-receipt-col-amount" />
             <col className="rz-external-receipt-col-candidates" />
-            <col className="rz-external-receipt-col-catalog" />
             <col className="rz-external-receipt-col-status" />
           </colgroup>
           <thead>
             <tr className="rz-table-header">
               <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('receiptLineText')}>Bonartikel <span>{sortMark('receiptLineText')}</span></button></th>
-              <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('normalizedName')}>Genormaliseerde naam <span>{sortMark('normalizedName')}</span></button></th>
               <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('retailerCode')}>Winkelketen <span>{sortMark('retailerCode')}</span></button></th>
+              <th className="rz-check"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('catalogLinked')}>Catalogus <span>{sortMark('catalogLinked')}</span></button></th>
               <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('articleNumber')}>Artikelnummer <span>{sortMark('articleNumber')}</span></button></th>
               <th>GTIN / EAN</th>
               <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('quantity')}>Omvang / gewicht <span>{sortMark('quantity')}</span></button></th>
               <th className="rz-num">Prijs</th>
               <th className="rz-num">Aantal</th>
               <th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('candidateCount')}>Externe kandidaten <span>{sortMark('candidateCount')}</span></button></th>
-              <th className="rz-check"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('catalogLinked')}>Catalogus <span>{sortMark('catalogLinked')}</span></button></th>
               <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('status')}>Status <span>{sortMark('status')}</span></button></th>
             </tr>
             <tr className="rz-external-databases-filter-row">
               <th><input className="rz-table-filter" value={filters.receiptLineText} onChange={(event) => updateFilter('receiptLineText', event.target.value)} placeholder="Zoek" /></th>
-              <th></th>
               <th><input className="rz-table-filter" value={filters.retailerCode} onChange={(event) => updateFilter('retailerCode', event.target.value)} placeholder="Filter" /></th>
+              <th></th>
               <th><input className="rz-table-filter" value={filters.articleNumber} onChange={(event) => updateFilter('articleNumber', event.target.value)} placeholder="Filter" /></th>
               <th></th>
               <th><input className="rz-table-filter" value={filters.quantity} onChange={(event) => updateFilter('quantity', event.target.value)} placeholder="Filter" /></th>
-              <th></th>
               <th></th>
               <th></th>
               <th></th>
@@ -268,19 +264,18 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
             {visibleItems.length ? visibleItems.map((item) => (
               <tr key={item.id} className={selectedItem?.id === item.id ? 'rz-row-active' : ''} onDoubleClick={() => selectReceiptItem(item)}>
                 <td>{item.receiptLineText}</td>
-                <td>{item.normalizedName}</td>
                 <td>{item.retailerCode}</td>
+                <td className="rz-check"><input type="checkbox" checked={item.catalogLinked} readOnly /></td>
                 <td>{item.articleNumber}</td>
                 <td>{item.gtin}</td>
                 <td>{item.quantity}</td>
                 <td className="rz-num">{numberText(item.price)}</td>
                 <td className="rz-num">{item.amount}</td>
                 <td className="rz-num">{item.candidateCount}</td>
-                <td className="rz-check"><input type="checkbox" checked={item.catalogLinked} readOnly /></td>
                 <td>{item.status}</td>
               </tr>
-            )) : <tr><td colSpan="11">Geen bonartikelen beschikbaar voor externe herkenning.</td></tr>}
-            {Array.from({ length: emptyRows }).map((_, index) => <tr key={`empty-${index}`}><td colSpan="11"></td></tr>)}
+            )) : <tr><td colSpan="10">Geen bonartikelen beschikbaar voor externe herkenning.</td></tr>}
+            {Array.from({ length: emptyRows }).map((_, index) => <tr key={`empty-${index}`}><td colSpan="10"></td></tr>)}
           </tbody>
         </Table>
       </div>

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -39,10 +39,9 @@ function buildReceiptItems(candidates) {
       id: candidateKey(candidate),
       candidateName: text(candidate.candidate_name),
       brand: text(candidate.candidate_brand),
-      articleNumber: text(candidate.retailer_article_number || candidate.source_product_code || candidate.candidate_source_product_code),
-      gtin: text(candidate.gtin || candidate.ean),
-      quantity: text(candidate.quantity_label),
       source: text(candidate.candidate_source_name || candidate.source_name),
+      externalCode: text(candidate.candidate_source_product_code || candidate.source_product_code || candidate.retailer_article_number),
+      variant: text(candidate.variant),
       score: candidate.score,
       status: text(candidate.candidate_status),
       raw: candidate,
@@ -76,7 +75,10 @@ function buildReceiptItems(candidates) {
     grouped.set(key, current)
   })
 
-  return Array.from(grouped.values())
+  return Array.from(grouped.values()).map((item) => ({
+    ...item,
+    candidates: [...item.candidates].sort((left, right) => Number(right.score || 0) - Number(left.score || 0)),
+  }))
 }
 
 function sortValue(item, key) {
@@ -85,13 +87,12 @@ function sortValue(item, key) {
   return String(item[key] || '').toLowerCase()
 }
 
-export default function ReceiptItemsOverview({ onError }) {
+export default function ReceiptItemsOverview({ onError, onMessage }) {
   const [items, setItems] = useState([])
   const [selectedItem, setSelectedItem] = useState(null)
   const [selectedCandidateId, setSelectedCandidateId] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [isProcessingCandidate, setIsProcessingCandidate] = useState(false)
-  const [processMessage, setProcessMessage] = useState('')
   const [filters, setFilters] = useState({ receiptLineText: '', retailerCode: '', articleNumber: '', quantity: '', status: '' })
   const [sortKey, setSortKey] = useState('receiptLineText')
   const [sortDesc, setSortDesc] = useState(false)
@@ -126,14 +127,12 @@ export default function ReceiptItemsOverview({ onError }) {
   function selectReceiptItem(item) {
     setSelectedItem(item)
     setSelectedCandidateId('')
-    setProcessMessage('')
   }
 
   async function processSelectedCandidate() {
     if (!selectedItem || !selectedCandidateId) return
 
     setIsProcessingCandidate(true)
-    setProcessMessage('')
 
     try {
       const response = await fetchJsonWithAuth('/api/external-databases/catalog/promote-highest', {
@@ -151,13 +150,13 @@ export default function ReceiptItemsOverview({ onError }) {
       if (!response.ok) throw new Error(data?.detail || 'Kandidaat verwerken is mislukt')
 
       if (data?.promoted) {
-        setProcessMessage('Kandidaat is verwerkt in de catalogus.')
+        onMessage?.('Kandidaat is verwerkt in de catalogus.')
       } else if (data?.reason === 'blocked_requires_existing_global_product') {
-        setProcessMessage('Kandidaat is gevonden, maar er bestaat nog geen passend catalogusproduct om aan te koppelen.')
+        onMessage?.('Kandidaat is gevonden, maar er bestaat nog geen passend catalogusproduct om aan te koppelen.')
       } else if (data?.reason === 'no_candidate_above_threshold') {
-        setProcessMessage('Er is geen kandidaat gevonden om te verwerken.')
+        onMessage?.('Er is geen kandidaat gevonden om te verwerken.')
       } else {
-        setProcessMessage('Catalogusverwerking is afgerond zonder catalogusmutatie.')
+        onMessage?.('Catalogusverwerking is afgerond zonder catalogusmutatie.')
       }
 
       await loadItems()
@@ -222,67 +221,69 @@ export default function ReceiptItemsOverview({ onError }) {
 
       {isLoading ? <div>Bonartikelen worden geladen...</div> : null}
 
-      <Table dataTestId="external-receipt-items-table" tableClassName="rz-external-receipt-table">
-        <colgroup>
-          <col className="rz-external-receipt-col-receipt" />
-          <col className="rz-external-receipt-col-normalized" />
-          <col className="rz-external-receipt-col-retailer" />
-          <col className="rz-external-receipt-col-code" />
-          <col className="rz-external-receipt-col-gtin" />
-          <col className="rz-external-receipt-col-quantity" />
-          <col className="rz-external-receipt-col-price" />
-          <col className="rz-external-receipt-col-amount" />
-          <col className="rz-external-receipt-col-candidates" />
-          <col className="rz-external-receipt-col-catalog" />
-          <col className="rz-external-receipt-col-status" />
-        </colgroup>
-        <thead>
-          <tr className="rz-table-header">
-            <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('receiptLineText')}>Bonartikel <span>{sortMark('receiptLineText')}</span></button></th>
-            <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('normalizedName')}>Genormaliseerde naam <span>{sortMark('normalizedName')}</span></button></th>
-            <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('retailerCode')}>Winkelketen <span>{sortMark('retailerCode')}</span></button></th>
-            <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('articleNumber')}>Artikelnummer <span>{sortMark('articleNumber')}</span></button></th>
-            <th>GTIN / EAN</th>
-            <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('quantity')}>Omvang / gewicht <span>{sortMark('quantity')}</span></button></th>
-            <th className="rz-num">Prijs</th>
-            <th className="rz-num">Aantal</th>
-            <th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('candidateCount')}>Externe kandidaten <span>{sortMark('candidateCount')}</span></button></th>
-            <th className="rz-check"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('catalogLinked')}>Catalogus <span>{sortMark('catalogLinked')}</span></button></th>
-            <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('status')}>Status <span>{sortMark('status')}</span></button></th>
-          </tr>
-          <tr className="rz-external-databases-filter-row">
-            <th><input className="rz-table-filter" value={filters.receiptLineText} onChange={(event) => updateFilter('receiptLineText', event.target.value)} placeholder="Zoek" /></th>
-            <th></th>
-            <th><input className="rz-table-filter" value={filters.retailerCode} onChange={(event) => updateFilter('retailerCode', event.target.value)} placeholder="Filter" /></th>
-            <th><input className="rz-table-filter" value={filters.articleNumber} onChange={(event) => updateFilter('articleNumber', event.target.value)} placeholder="Filter" /></th>
-            <th></th>
-            <th><input className="rz-table-filter" value={filters.quantity} onChange={(event) => updateFilter('quantity', event.target.value)} placeholder="Filter" /></th>
-            <th></th>
-            <th></th>
-            <th></th>
-            <th></th>
-            <th><input className="rz-table-filter" value={filters.status} onChange={(event) => updateFilter('status', event.target.value)} placeholder="Filter" /></th>
-          </tr>
-        </thead>
-        <tbody>
-          {visibleItems.length ? visibleItems.map((item) => (
-            <tr key={item.id} className={selectedItem?.id === item.id ? 'rz-row-active' : ''} onDoubleClick={() => selectReceiptItem(item)}>
-              <td>{item.receiptLineText}</td>
-              <td>{item.normalizedName}</td>
-              <td>{item.retailerCode}</td>
-              <td>{item.articleNumber}</td>
-              <td>{item.gtin}</td>
-              <td>{item.quantity}</td>
-              <td className="rz-num">{numberText(item.price)}</td>
-              <td className="rz-num">{item.amount}</td>
-              <td className="rz-num">{item.candidateCount}</td>
-              <td className="rz-check"><input type="checkbox" checked={item.catalogLinked} readOnly /></td>
-              <td>{item.status}</td>
+      <div className="rz-table-scroll rz-table-scroll--wide">
+        <Table dataTestId="external-receipt-items-table" tableClassName="rz-external-receipt-table">
+          <colgroup>
+            <col className="rz-external-receipt-col-receipt" />
+            <col className="rz-external-receipt-col-normalized" />
+            <col className="rz-external-receipt-col-retailer" />
+            <col className="rz-external-receipt-col-code" />
+            <col className="rz-external-receipt-col-gtin" />
+            <col className="rz-external-receipt-col-quantity" />
+            <col className="rz-external-receipt-col-price" />
+            <col className="rz-external-receipt-col-amount" />
+            <col className="rz-external-receipt-col-candidates" />
+            <col className="rz-external-receipt-col-catalog" />
+            <col className="rz-external-receipt-col-status" />
+          </colgroup>
+          <thead>
+            <tr className="rz-table-header">
+              <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('receiptLineText')}>Bonartikel <span>{sortMark('receiptLineText')}</span></button></th>
+              <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('normalizedName')}>Genormaliseerde naam <span>{sortMark('normalizedName')}</span></button></th>
+              <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('retailerCode')}>Winkelketen <span>{sortMark('retailerCode')}</span></button></th>
+              <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('articleNumber')}>Artikelnummer <span>{sortMark('articleNumber')}</span></button></th>
+              <th>GTIN / EAN</th>
+              <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('quantity')}>Omvang / gewicht <span>{sortMark('quantity')}</span></button></th>
+              <th className="rz-num">Prijs</th>
+              <th className="rz-num">Aantal</th>
+              <th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('candidateCount')}>Externe kandidaten <span>{sortMark('candidateCount')}</span></button></th>
+              <th className="rz-check"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('catalogLinked')}>Catalogus <span>{sortMark('catalogLinked')}</span></button></th>
+              <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('status')}>Status <span>{sortMark('status')}</span></button></th>
             </tr>
-          )) : <tr><td colSpan="11">Geen bonartikelen beschikbaar voor externe herkenning.</td></tr>}
-          {Array.from({ length: emptyRows }).map((_, index) => <tr key={`empty-${index}`}><td colSpan="11"></td></tr>)}
-        </tbody>
-      </Table>
+            <tr className="rz-external-databases-filter-row">
+              <th><input className="rz-table-filter" value={filters.receiptLineText} onChange={(event) => updateFilter('receiptLineText', event.target.value)} placeholder="Zoek" /></th>
+              <th></th>
+              <th><input className="rz-table-filter" value={filters.retailerCode} onChange={(event) => updateFilter('retailerCode', event.target.value)} placeholder="Filter" /></th>
+              <th><input className="rz-table-filter" value={filters.articleNumber} onChange={(event) => updateFilter('articleNumber', event.target.value)} placeholder="Filter" /></th>
+              <th></th>
+              <th><input className="rz-table-filter" value={filters.quantity} onChange={(event) => updateFilter('quantity', event.target.value)} placeholder="Filter" /></th>
+              <th></th>
+              <th></th>
+              <th></th>
+              <th></th>
+              <th><input className="rz-table-filter" value={filters.status} onChange={(event) => updateFilter('status', event.target.value)} placeholder="Filter" /></th>
+            </tr>
+          </thead>
+          <tbody>
+            {visibleItems.length ? visibleItems.map((item) => (
+              <tr key={item.id} className={selectedItem?.id === item.id ? 'rz-row-active' : ''} onDoubleClick={() => selectReceiptItem(item)}>
+                <td>{item.receiptLineText}</td>
+                <td>{item.normalizedName}</td>
+                <td>{item.retailerCode}</td>
+                <td>{item.articleNumber}</td>
+                <td>{item.gtin}</td>
+                <td>{item.quantity}</td>
+                <td className="rz-num">{numberText(item.price)}</td>
+                <td className="rz-num">{item.amount}</td>
+                <td className="rz-num">{item.candidateCount}</td>
+                <td className="rz-check"><input type="checkbox" checked={item.catalogLinked} readOnly /></td>
+                <td>{item.status}</td>
+              </tr>
+            )) : <tr><td colSpan="11">Geen bonartikelen beschikbaar voor externe herkenning.</td></tr>}
+            {Array.from({ length: emptyRows }).map((_, index) => <tr key={`empty-${index}`}><td colSpan="11"></td></tr>)}
+          </tbody>
+        </Table>
+      </div>
 
       <div className="rz-external-databases-pagination">
         <Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => setPage((value) => Math.max(1, value - 1))}>Vorige</Button>
@@ -293,68 +294,57 @@ export default function ReceiptItemsOverview({ onError }) {
       <div className="rz-external-receipt-detail">
         {selectedItem ? (
           <>
-            <h3>Bonartikel verwerken</h3>
-            <dl>
-              <dt>Bonartikel</dt><dd>{selectedItem.receiptLineText}</dd>
-              <dt>Winkelketen</dt><dd>{selectedItem.retailerCode}</dd>
-              <dt>Artikelnummer</dt><dd>{selectedItem.articleNumber}</dd>
-              <dt>GTIN / EAN</dt><dd>{selectedItem.gtin}</dd>
-              <dt>Omvang / gewicht</dt><dd>{selectedItem.quantity}</dd>
-              <dt>Externe kandidaten</dt><dd>{selectedItem.candidateCount}</dd>
-              <dt>Catalogus</dt><dd>{selectedItem.catalogLinked ? 'Kandidaat aanwezig' : 'Nog geen kandidaat'}</dd>
-            </dl>
-
             <h3>Externe kandidaten voor dit bonartikel</h3>
-            <Table dataTestId="external-receipt-item-candidates-table" tableClassName="rz-external-candidate-detail-table">
-              <colgroup>
-                <col className="rz-external-candidate-col-choice" />
-                <col className="rz-external-candidate-col-name" />
-                <col className="rz-external-candidate-col-brand" />
-                <col className="rz-external-candidate-col-code" />
-                <col className="rz-external-candidate-col-gtin" />
-                <col className="rz-external-candidate-col-quantity" />
-                <col className="rz-external-candidate-col-source" />
-                <col className="rz-external-candidate-col-score" />
-                <col className="rz-external-candidate-col-status" />
-              </colgroup>
-              <thead>
-                <tr className="rz-table-header">
-                  <th>Keuze</th>
-                  <th>Kandidaat</th>
-                  <th>Merk</th>
-                  <th>Artikelnummer</th>
-                  <th>GTIN / EAN</th>
-                  <th>Omvang / gewicht</th>
-                  <th>Bron</th>
-                  <th className="rz-num">Score</th>
-                  <th>Status</th>
-                </tr>
-              </thead>
-              <tbody>
-                {selectedCandidates.length ? selectedCandidates.map((candidate) => (
-                  <tr key={candidate.id}>
-                    <td className="rz-check">
-                      <input
-                        type="radio"
-                        name="external-candidate-choice"
-                        checked={selectedCandidateId === candidate.id}
-                        onChange={() => setSelectedCandidateId(candidate.id)}
-                      />
-                    </td>
-                    <td>{candidate.candidateName}</td>
-                    <td>{candidate.brand}</td>
-                    <td>{candidate.articleNumber}</td>
-                    <td>{candidate.gtin}</td>
-                    <td>{candidate.quantity}</td>
-                    <td>{candidate.source}</td>
-                    <td className="rz-num">{scoreText(candidate.score)}</td>
-                    <td>{candidate.status}</td>
-                  </tr>
-                )) : <tr><td colSpan="9">Geen externe kandidaten gevonden voor dit bonartikel.</td></tr>}
-              </tbody>
-            </Table>
 
-                        <div className="rz-external-databases-actions">
+            <div className="rz-table-scroll">
+              <Table dataTestId="external-receipt-item-candidates-table" tableClassName="rz-external-candidate-detail-table">
+                <colgroup>
+                  <col className="rz-external-candidate-col-choice" />
+                  <col className="rz-external-candidate-col-name" />
+                  <col className="rz-external-candidate-col-brand" />
+                  <col className="rz-external-candidate-col-source" />
+                  <col className="rz-external-candidate-col-code" />
+                  <col className="rz-external-candidate-col-variant" />
+                  <col className="rz-external-candidate-col-score" />
+                  <col className="rz-external-candidate-col-status" />
+                </colgroup>
+                <thead>
+                  <tr className="rz-table-header">
+                    <th>Keuze</th>
+                    <th>Kandidaat</th>
+                    <th>Merk</th>
+                    <th>Bron</th>
+                    <th>Externe code</th>
+                    <th>Variant</th>
+                    <th className="rz-num">Score</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {selectedCandidates.length ? selectedCandidates.map((candidate) => (
+                    <tr key={candidate.id}>
+                      <td className="rz-check">
+                        <input
+                          type="radio"
+                          name="external-candidate-choice"
+                          checked={selectedCandidateId === candidate.id}
+                          onChange={() => setSelectedCandidateId(candidate.id)}
+                        />
+                      </td>
+                      <td>{candidate.candidateName}</td>
+                      <td>{candidate.brand}</td>
+                      <td>{candidate.source}</td>
+                      <td>{candidate.externalCode}</td>
+                      <td>{candidate.variant}</td>
+                      <td className="rz-num">{scoreText(candidate.score)}</td>
+                      <td>{candidate.status}</td>
+                    </tr>
+                  )) : <tr><td colSpan="8">Geen externe kandidaten gevonden voor dit bonartikel.</td></tr>}
+                </tbody>
+              </Table>
+            </div>
+
+            <div className="rz-external-databases-actions">
               <Button
                 type="button"
                 disabled={!selectedCandidateId || isProcessingCandidate}
@@ -363,12 +353,9 @@ export default function ReceiptItemsOverview({ onError }) {
                 {isProcessingCandidate ? 'Verwerken...' : 'Verwerk gekozen kandidaat in catalogus'}
               </Button>
             </div>
-
-            {processMessage ? <div className="rz-inline-feedback rz-inline-feedback--success">{processMessage}</div> : null}
           </>
-        ) : <p className="rz-external-databases-muted">Dubbelklik op een bonartikel om de detailcontext te openen.</p>}
+        ) : <p className="rz-external-databases-muted">Dubbelklik op een bonartikel om de externe kandidaten te bekijken.</p>}
       </div>
     </div>
   )
 }
-

--- a/frontend/src/features/externalDatabases/externalDatabases.css
+++ b/frontend/src/features/externalDatabases/externalDatabases.css
@@ -224,3 +224,45 @@
     grid-template-columns: 1fr;
   }
 }
+
+.rz-table-scroll {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.rz-table-scroll--wide {
+  border: 1px solid var(--color-table-border, #6bbf7a);
+}
+
+.rz-table-scroll table {
+  resize: horizontal;
+}
+
+.rz-external-receipt-table {
+  min-width: 1500px;
+}
+
+.rz-external-receipt-table th,
+.rz-external-receipt-table td,
+.rz-external-candidate-detail-table th,
+.rz-external-candidate-detail-table td {
+  resize: horizontal;
+  overflow: hidden;
+}
+
+.rz-external-candidate-detail-table {
+  width: 100%;
+  min-width: 880px;
+  table-layout: fixed;
+}
+
+.rz-external-candidate-col-choice { width: 72px; }
+.rz-external-candidate-col-name { width: 220px; }
+.rz-external-candidate-col-brand { width: 140px; }
+.rz-external-candidate-col-source { width: 150px; }
+.rz-external-candidate-col-code { width: 150px; }
+.rz-external-candidate-col-variant { width: 140px; }
+.rz-external-candidate-col-score { width: 90px; }
+.rz-external-candidate-col-status { width: 150px; }

--- a/frontend/src/features/externalDatabases/externalDatabases.css
+++ b/frontend/src/features/externalDatabases/externalDatabases.css
@@ -266,3 +266,33 @@
 .rz-external-candidate-col-variant { width: 140px; }
 .rz-external-candidate-col-score { width: 90px; }
 .rz-external-candidate-col-status { width: 150px; }
+
+
+/* M2C2h-4 table cleanup */
+.rz-external-databases .rz-table th,
+.rz-external-databases .rz-table td {
+  border-left: 0;
+  border-right: 0;
+}
+
+.rz-external-databases .rz-table th,
+.rz-external-databases .rz-table th button,
+.rz-external-databases .rz-table td {
+  white-space: nowrap;
+  text-overflow: clip;
+}
+
+.rz-external-databases .rz-table th {
+  overflow: visible;
+}
+
+.rz-external-receipt-col-receipt { width: 360px; }
+.rz-external-receipt-col-retailer { width: 150px; }
+.rz-external-receipt-col-catalog { width: 120px; }
+.rz-external-receipt-col-code { width: 170px; }
+.rz-external-receipt-col-gtin { width: 160px; }
+.rz-external-receipt-col-quantity { width: 170px; }
+.rz-external-receipt-col-price { width: 110px; }
+.rz-external-receipt-col-amount { width: 110px; }
+.rz-external-receipt-col-candidates { width: 170px; }
+.rz-external-receipt-col-status { width: 190px; }


### PR DESCRIPTION
## Samenvatting

Deze PR ruimt de externe databases / bonartikelen-overzichtstabel op.

## Wijzigingen

- Verwijdert de tabweergave op de externe databases-pagina en toont direct het overzicht.
- Verwijdert de kolom `Genormaliseerde naam` uit het bonartikelen-overzicht.
- Verplaatst `Catalogus` naar voren in de tabel.
- Corrigeert kolombreedtes en `colSpan` van 11 naar 10.
- Voegt tabel-CSS toe voor compactere, schonere weergave.
- Verwijdert ongebruikte tab-state en tab-import.

## Controle

Lokaal uitgevoerd:

```powershell
npm --prefix frontend run build
```

Resultaat:

```text
✓ 346 modules transformed.
✓ built in 4.19s
```

De Vite chunk-size melding is een waarschuwing en blokkeert de build niet.

## Scope

Alleen frontend UI-correctie. Geen backendwijziging en geen wijziging in baseline V10.