### PR TITLE
M2C2h-4b: refine external databases table filters and confirmation

### DIFF
--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import Table from '../../ui/Table'
 import Button from '../../ui/Button'
 import { fetchJsonWithAuth } from '../../lib/authSession'
@@ -92,7 +92,8 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   const [selectedCandidateId, setSelectedCandidateId] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [isProcessingCandidate, setIsProcessingCandidate] = useState(false)
-  const [filters, setFilters] = useState({ receiptLineText: '', retailerCode: '', articleNumber: '', quantity: '', status: '' })
+  const [confirmOverwrite, setConfirmOverwrite] = useState(false)
+  const [filters, setFilters] = useState({ receiptLineText: '', retailerCode: '', catalogLinked: 'all', articleNumber: '', gtin: '', quantity: '', price: '', amount: '', candidateCount: '', status: '' })
   const [sortKey, setSortKey] = useState('receiptLineText')
   const [sortDesc, setSortDesc] = useState(false)
   const [page, setPage] = useState(1)
@@ -126,11 +127,18 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   function selectReceiptItem(item) {
     setSelectedItem(item)
     setSelectedCandidateId('')
+    setConfirmOverwrite(false)
   }
 
-  async function processSelectedCandidate() {
+  async function processSelectedCandidate(options = {}) {
     if (!selectedItem || !selectedCandidateId) return
 
+    if (selectedItem.catalogLinked && !options.forceOverwrite) {
+      setConfirmOverwrite(true)
+      return
+    }
+
+    setConfirmOverwrite(false)
     setIsProcessingCandidate(true)
 
     try {
@@ -189,8 +197,13 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
     const rows = items.filter((item) => (
       item.receiptLineText.toLowerCase().includes(filters.receiptLineText.toLowerCase()) &&
       item.retailerCode.toLowerCase().includes(filters.retailerCode.toLowerCase()) &&
+      ((filters.catalogLinked === 'all') || (filters.catalogLinked === 'linked' && item.catalogLinked) || (filters.catalogLinked === 'unlinked' && !item.catalogLinked)) &&
       item.articleNumber.toLowerCase().includes(filters.articleNumber.toLowerCase()) &&
+      item.gtin.toLowerCase().includes(filters.gtin.toLowerCase()) &&
       item.quantity.toLowerCase().includes(filters.quantity.toLowerCase()) &&
+      numberText(item.price).toLowerCase().includes(filters.price.toLowerCase()) &&
+      String(item.amount || '').toLowerCase().includes(filters.amount.toLowerCase()) &&
+      String(item.candidateCount || '').toLowerCase().includes(filters.candidateCount.toLowerCase()) &&
       item.status.toLowerCase().includes(filters.status.toLowerCase())
     ))
 
@@ -250,13 +263,19 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
             <tr className="rz-external-databases-filter-row">
               <th><input className="rz-table-filter" value={filters.receiptLineText} onChange={(event) => updateFilter('receiptLineText', event.target.value)} placeholder="Zoek" /></th>
               <th><input className="rz-table-filter" value={filters.retailerCode} onChange={(event) => updateFilter('retailerCode', event.target.value)} placeholder="Filter" /></th>
-              <th></th>
+              <th>
+                <select className="rz-table-filter" value={filters.catalogLinked} onChange={(event) => updateFilter('catalogLinked', event.target.value)} aria-label="Catalogus filter">
+                  <option value="all">Alle</option>
+                  <option value="linked">Gekoppeld</option>
+                  <option value="unlinked">Niet gekoppeld</option>
+                </select>
+              </th>
               <th><input className="rz-table-filter" value={filters.articleNumber} onChange={(event) => updateFilter('articleNumber', event.target.value)} placeholder="Filter" /></th>
-              <th></th>
+              <th><input className="rz-table-filter" value={filters.gtin} onChange={(event) => updateFilter('gtin', event.target.value)} placeholder="Filter" /></th>
               <th><input className="rz-table-filter" value={filters.quantity} onChange={(event) => updateFilter('quantity', event.target.value)} placeholder="Filter" /></th>
-              <th></th>
-              <th></th>
-              <th></th>
+              <th><input className="rz-table-filter" value={filters.price} onChange={(event) => updateFilter('price', event.target.value)} placeholder="Filter" /></th>
+              <th><input className="rz-table-filter" value={filters.amount} onChange={(event) => updateFilter('amount', event.target.value)} placeholder="Filter" /></th>
+              <th><input className="rz-table-filter" value={filters.candidateCount} onChange={(event) => updateFilter('candidateCount', event.target.value)} placeholder="Filter" /></th>
               <th><input className="rz-table-filter" value={filters.status} onChange={(event) => updateFilter('status', event.target.value)} placeholder="Filter" /></th>
             </tr>
           </thead>
@@ -285,6 +304,20 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
         <span className="rz-external-databases-page-indicator">Pagina {currentPage} van {pageCount}</span>
         <Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => setPage((value) => Math.min(pageCount, value + 1))}>Volgende</Button>
       </div>
+
+      {confirmOverwrite ? (
+        <div className="rz-modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="external-overwrite-title">
+          <div className="rz-modal-card">
+            <h3 id="external-overwrite-title" className="rz-modal-title">Cataloguskoppeling overschrijven?</h3>
+            <p className="rz-modal-text">Dit bonartikel is al gekoppeld aan een catalogusartikel.</p>
+            <p className="rz-modal-text">Wil je de bestaande koppeling overschrijven?</p>
+            <div className="rz-modal-actions">
+              <Button type="button" variant="primary" disabled={isProcessingCandidate} onClick={() => processSelectedCandidate({ forceOverwrite: true })}>Overschrijven</Button>
+              <Button type="button" variant="secondary" disabled={isProcessingCandidate} onClick={() => setConfirmOverwrite(false)}>Annuleren</Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
 
       <div className="rz-external-receipt-detail">
         {selectedItem ? (

--- a/frontend/src/features/externalDatabases/externalDatabases.css
+++ b/frontend/src/features/externalDatabases/externalDatabases.css
@@ -296,3 +296,109 @@
 .rz-external-receipt-col-amount { width: 110px; }
 .rz-external-receipt-col-candidates { width: 170px; }
 .rz-external-receipt-col-status { width: 190px; }
+
+
+/* M2C2h-4b table style alignment */
+.rz-external-databases .rz-table-scroll,
+.rz-external-databases .rz-table-scroll--wide {
+  border: 1px solid var(--color-table-border, #6bbf7a);
+  border-radius: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.rz-external-databases .rz-table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+.rz-external-databases .rz-table th,
+.rz-external-databases .rz-table td {
+  border: 1px solid var(--color-table-border, #6bbf7a);
+  height: 26px;
+  line-height: 22px;
+  padding: 2px 10px;
+  vertical-align: middle;
+  resize: none;
+}
+
+.rz-external-databases .rz-table thead th {
+  height: 30px;
+  line-height: 24px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+}
+
+.rz-external-databases .rz-table tbody tr {
+  height: 26px;
+}
+
+.rz-external-databases .rz-table tbody tr:nth-child(even) td {
+  background: #f7f7f7;
+}
+
+.rz-external-databases .rz-table tbody tr.rz-row-active td {
+  background: #d8f0dc;
+  outline: 0;
+}
+
+.rz-external-databases-filter-row th {
+  background: #d8f0dc;
+  padding: 3px 10px;
+}
+
+.rz-external-databases .rz-table-filter {
+  width: 100%;
+  height: 25px;
+  min-height: 25px;
+  padding: 2px 8px;
+  border: 1px solid var(--color-table-border, #6bbf7a);
+  border-radius: 4px;
+  font: inherit;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+.rz-external-databases .rz-external-databases-sort {
+  min-height: 22px;
+  line-height: 22px;
+  font-weight: 600;
+}
+
+.rz-external-databases .rz-external-receipt-table {
+  width: 100%;
+  min-width: 1260px;
+  table-layout: fixed;
+}
+
+.rz-external-databases .rz-external-candidate-detail-table {
+  width: 100%;
+  min-width: 920px;
+  table-layout: fixed;
+}
+
+.rz-external-receipt-col-receipt { width: 260px; }
+.rz-external-receipt-col-retailer { width: 120px; }
+.rz-external-receipt-col-catalog { width: 90px; }
+.rz-external-receipt-col-code { width: 140px; }
+.rz-external-receipt-col-gtin { width: 130px; }
+.rz-external-receipt-col-quantity { width: 145px; }
+.rz-external-receipt-col-price { width: 90px; }
+.rz-external-receipt-col-amount { width: 90px; }
+.rz-external-receipt-col-candidates { width: 150px; }
+.rz-external-receipt-col-status { width: 155px; }
+
+.rz-external-candidate-col-choice { width: 70px; }
+.rz-external-candidate-col-name { width: 230px; }
+.rz-external-candidate-col-brand { width: 140px; }
+.rz-external-candidate-col-source { width: 145px; }
+.rz-external-candidate-col-code { width: 145px; }
+.rz-external-candidate-col-variant { width: 120px; }
+.rz-external-candidate-col-score { width: 90px; }
+.rz-external-candidate-col-status { width: 130px; }
+
+.rz-external-receipt-detail {
+  border: 1px solid var(--color-table-border, #6bbf7a);
+  border-radius: 8px;
+  padding: 14px 16px;
+}


### PR DESCRIPTION
## Samenvatting

Deze PR verfijnt de pagina **Externe databases** op basis van PO-testfeedback.

## Wijzigingen

- Hoofdtabel en detailtabel visueel meer in lijn gebracht met het tabel-format van Uitpakken / Kassabonnen.
- Groene rasterlijnen en compactere rijhoogtes toegevoegd.
- Filtervelden toegevoegd voor alle kolommen in de hoofdtabel.
- Catalogusfilter gewijzigd naar 3 standen:
  - Alle
  - Gekoppeld
  - Niet gekoppeld
- Bevestigingsdialoog toegevoegd wanneer een al gekoppeld bonartikel opnieuw verwerkt wordt:
  - Overschrijven
  - Annuleren

## Niet gewijzigd

- Geen backendwijziging.
- Geen wijziging in Kassa-parser.
- Geen wijziging in baseline V10.
- Geen wijziging in voorraadverwerking.

## Controle

Lokaal uitgevoerd:

```powershell
npm --prefix frontend run build
```

Resultaat:

```text
✓ 346 modules transformed.
✓ built in 2.52s
```

De Vite chunk-size melding is een waarschuwing en blokkeert de build niet.

## PO-testscope

- Externe databases openen.
- Hoofdtabel vergelijken met Uitpakken / Kassabonnen.
- Controleren dat alle hoofdtabelkolommen een filterveld hebben.
- Catalogusfilter testen op Alle / Gekoppeld / Niet gekoppeld.
- Dubbelklik op bonartikel.
- Kandidaat selecteren.
- Controleren dat bij bestaande koppeling Overschrijven / Annuleren verschijnt.