### PR TITLE
fix(externe-databases): isolate candidates and remove receipt status column

### DIFF
--- a/backend/app/services/external_database_matchers.py
+++ b/backend/app/services/external_database_matchers.py
@@ -576,6 +576,21 @@ def match_retailer_receipt_line(retailer_code: str, receipt_line_text: str, incl
             "creates_inventory_event": False,
         }
 
+    if normalized_retailer != "lidl":
+        return {
+            "retailer_code": normalized_retailer,
+            "receipt_line_text": receipt_line_text,
+            "expanded_terms": [normalize_match_text(receipt_line_text)],
+            "probable_candidate_threshold": PROBABLE_CANDIDATE_THRESHOLD,
+            "possible_candidate_threshold": POSSIBLE_CANDIDATE_THRESHOLD,
+            "candidates": [],
+            "candidate_source": "no_retailer_specific_legacy_candidates",
+            "uses_legacy_fallback": False,
+            "creates_global_product": False,
+            "creates_household_article": False,
+            "creates_inventory_event": False,
+        }
+
     legacy = _m2c2i_legacy_match_retailer_receipt_line(
         retailer_code=retailer_code,
         receipt_line_text=receipt_line_text,
@@ -681,7 +696,7 @@ def _m2c2i2_score_candidate(receipt_line_text: str, row: dict[str, Any]) -> dict
 
 def match_retailer_receipt_line(retailer_code: str, receipt_line_text: str, include_below_threshold: bool = True) -> dict[str, Any]:
     normalized_retailer = normalize_match_text(retailer_code)
-    index_rows = search_external_product_index_candidates(receipt_line_text, limit=120)
+    index_rows = search_external_product_index_candidates(receipt_line_text, limit=120, retailer_code=normalized_retailer)
 
     scored = [_m2c2i2_score_candidate(receipt_line_text, row) for row in index_rows]
     if not include_below_threshold:
@@ -699,6 +714,21 @@ def match_retailer_receipt_line(retailer_code: str, receipt_line_text: str, incl
             "possible_candidate_threshold": POSSIBLE_CANDIDATE_THRESHOLD,
             "candidates": scored,
             "candidate_source": "external_product_index",
+            "uses_legacy_fallback": False,
+            "creates_global_product": False,
+            "creates_household_article": False,
+            "creates_inventory_event": False,
+        }
+
+    if normalized_retailer != "lidl":
+        return {
+            "retailer_code": normalized_retailer,
+            "receipt_line_text": receipt_line_text,
+            "expanded_terms": [normalize_match_text(receipt_line_text)],
+            "probable_candidate_threshold": PROBABLE_CANDIDATE_THRESHOLD,
+            "possible_candidate_threshold": POSSIBLE_CANDIDATE_THRESHOLD,
+            "candidates": [],
+            "candidate_source": "no_retailer_specific_legacy_candidates",
             "uses_legacy_fallback": False,
             "creates_global_product": False,
             "creates_household_article": False,

--- a/backend/app/services/external_product_candidate_store.py
+++ b/backend/app/services/external_product_candidate_store.py
@@ -1168,6 +1168,18 @@ def _m2c2i_fix7b_dedupe_top_receipt_items(items: list[dict[str, Any]]) -> list[d
 
     return list(best_by_key.values())
 
+
+def _m2c2i_fix7c_same_retailer_for_projection(placeholder: dict[str, object], candidate: dict[str, object]) -> bool:
+    """Alleen candidates van dezelfde retailer mogen op een bonartikelrij worden geprojecteerd."""
+    placeholder_retailer = str(placeholder.get("retailer_code") or "").strip().lower()
+    candidate_retailer = str(candidate.get("retailer_code") or "").strip().lower()
+
+    if not placeholder_retailer or not candidate_retailer:
+        return False
+
+    return placeholder_retailer == candidate_retailer
+
+
 def _m2c2i_fix7a3_apply_catalog_status_to_placeholders(
     placeholders: list[dict[str, Any]],
     candidates: list[dict[str, Any]],
@@ -1229,6 +1241,12 @@ def _m2c2i_fix7a3_apply_catalog_status_to_placeholders(
         )
         matching_candidates.extend(by_receipt_key.get(key, []))
 
+        matching_candidates = [
+            candidate
+            for candidate in matching_candidates
+            if _m2c2i_fix7c_same_retailer_for_projection(placeholder, candidate)
+        ]
+
         # Ontdubbel detailkandidaten op kandidaatidentiteit.
         unique: dict[str, dict[str, Any]] = {}
         for candidate in matching_candidates:
@@ -1273,10 +1291,6 @@ def _m2c2i_fix7a3_apply_catalog_status_to_placeholders(
             elif detail_candidates:
                 placeholder["status"] = "candidate"
                 placeholder["candidate_status"] = "candidate"
-                placeholder["retailer_article_number"] = (
-                    str(best.get("retailer_article_number") or best.get("candidate_source_product_code") or best.get("source_product_code") or "").strip()
-                    or placeholder.get("retailer_article_number")
-                )
         else:
             placeholder = dict(placeholder)
             placeholder["candidates"] = []

--- a/backend/app/services/external_product_index_store.py
+++ b/backend/app/services/external_product_index_store.py
@@ -331,7 +331,7 @@ def ensure_external_product_index_seeded(minimum_rows: int = 100) -> dict[str, A
     return {"ok": True, "seeded": True, "inserted": inserted}
 
 
-def search_external_product_index_candidates(receipt_line_text: str, limit: int = 120) -> list[dict[str, Any]]:
+def search_external_product_index_candidates(receipt_line_text: str, limit: int = 120, retailer_code: str | None = None) -> list[dict[str, Any]]:
     ensure_external_product_index_seeded()
 
     normalized = normalize_index_text(receipt_line_text)
@@ -349,13 +349,19 @@ def search_external_product_index_candidates(receipt_line_text: str, limit: int 
 
     where_sql = " OR ".join(where_parts)
 
+    retailer_filter_sql = ""
+    normalized_retailer = normalize_index_text(retailer_code)
+    if normalized_retailer:
+        params["retailer_code"] = normalized_retailer
+        retailer_filter_sql = " AND (COALESCE(retailer_code, '') = :retailer_code OR COALESCE(retailer_code, '') = '')"
+
     with engine.begin() as conn:
         rows = conn.execute(
             text(
                 f"""
                 SELECT *
                 FROM external_product_index
-                WHERE {where_sql}
+                WHERE ({where_sql}){retailer_filter_sql}
                 LIMIT :limit
                 """
             ),

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+﻿import { useEffect, useMemo, useRef, useState } from 'react'
 import Table from '../../ui/Table'
 import Button from '../../ui/Button'
 import { fetchJsonWithAuth } from '../../lib/authSession'
@@ -243,7 +243,7 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   const [isProcessingCandidate, setIsProcessingCandidate] = useState(false)
   const [isUnlinking, setIsUnlinking] = useState(false)
   const [confirmOverwrite, setConfirmOverwrite] = useState(false)
-  const [filters, setFilters] = useState({ receiptLineText: '', retailerCode: '', catalogLinked: 'all', articleNumber: '', gtin: '', quantity: '', price: '', amount: '', candidateCount: '', status: '' })
+  const [filters, setFilters] = useState({ receiptLineText: '', retailerCode: '', catalogLinked: 'all', articleNumber: '', gtin: '', quantity: '', price: '', amount: '', candidateCount: '' })
   const [sortKey, setSortKey] = useState('receiptLineText')
   const [sortDesc, setSortDesc] = useState(false)
   const [page, setPage] = useState(1)
@@ -290,8 +290,7 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
       item.quantity.toLowerCase().includes(filters.quantity.toLowerCase()) &&
       numberText(item.price).toLowerCase().includes(filters.price.toLowerCase()) &&
       String(item.amount || '').toLowerCase().includes(filters.amount.toLowerCase()) &&
-      String(item.candidateCount || '').toLowerCase().includes(filters.candidateCount.toLowerCase()) &&
-      item.status.toLowerCase().includes(filters.status.toLowerCase())
+      String(item.candidateCount || '').toLowerCase().includes(filters.candidateCount.toLowerCase())
     ))
 
     rows.sort((leftItem, rightItem) => {
@@ -305,7 +304,7 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
     return rows
   }, [items, filters, sortKey, sortDesc])
 
-  // De backend levert één rij per bonartikelcontext.
+  // De backend levert Ã©Ã©n rij per bonartikelcontext.
   // Niet extra ontdubbelen op artikeltekst: gelijke omschrijvingen met andere artikelcode zijn aparte bonartikelen.
   const dedupedItems = filteredItems
 
@@ -407,12 +406,12 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   function exportSelectedItems() {
     const selectedRows = items.filter((item) => selectedItemIds.includes(item.id))
     if (!selectedRows.length) {
-      onMessage?.('Selecteer eerst één of meer bonartikelen om te exporteren.')
+      onMessage?.('Selecteer eerst Ã©Ã©n of meer bonartikelen om te exporteren.')
       return
     }
 
     const rows = [
-      ['Bonartikel', 'Winkelketen', 'Catalogus', 'Artikelnummer', 'GTIN / EAN', 'Omvang / gewicht', 'Prijs', 'Aantal', 'Externe kandidaten', 'Status'],
+      ['Bonartikel', 'Winkelketen', 'Catalogus', 'Artikelnummer', 'GTIN / EAN', 'Omvang / gewicht', 'Prijs', 'Aantal', 'Externe kandidaten'],
       ...selectedRows.map((item) => [
         item.receiptLineText,
         item.retailerCode,
@@ -423,7 +422,6 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
         numberText(item.price),
         item.amount,
         item.candidateCount,
-        item.status,
       ]),
     ]
 
@@ -625,7 +623,6 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
             <col className="rz-external-receipt-col-price" />
             <col className="rz-external-receipt-col-amount" />
             <col className="rz-external-receipt-col-candidates" />
-            <col className="rz-external-receipt-col-status" />
           </colgroup>
           <thead>
             <tr className="rz-table-header">
@@ -639,7 +636,6 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
               <th className="rz-num">Prijs</th>
               <th className="rz-num">Aantal</th>
               <th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('candidateCount')}>Externe kandidaten <span>{sortMark('candidateCount')}</span></button></th>
-              <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('status')}>Status <span>{sortMark('status')}</span></button></th>
             </tr>
             <tr className="rz-external-databases-filter-row">
               <th></th>
@@ -658,7 +654,6 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
               <th><input className="rz-table-filter" value={filters.price} onChange={(event) => updateFilter('price', event.target.value)} placeholder="Filter" /></th>
               <th><input className="rz-table-filter" value={filters.amount} onChange={(event) => updateFilter('amount', event.target.value)} placeholder="Filter" /></th>
               <th><input className="rz-table-filter" value={filters.candidateCount} onChange={(event) => updateFilter('candidateCount', event.target.value)} placeholder="Filter" /></th>
-              <th><input className="rz-table-filter" value={filters.status} onChange={(event) => updateFilter('status', event.target.value)} placeholder="Filter" /></th>
             </tr>
           </thead>
           <tbody>
@@ -674,10 +669,9 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
                 <td className="rz-num">{numberText(item.price)}</td>
                 <td className="rz-num">{item.amount}</td>
                 <td className="rz-num">{item.candidateCount}</td>
-                <td>{item.status}</td>
               </tr>
-            )) : <tr><td colSpan="11">Geen bonartikelen beschikbaar voor externe herkenning.</td></tr>}
-            {Array.from({ length: emptyRows }).map((_, index) => <tr key={`empty-${index}`}><td colSpan="11"></td></tr>)}
+            )) : <tr><td colSpan="10">Geen bonartikelen beschikbaar voor externe herkenning.</td></tr>}
+            {Array.from({ length: emptyRows }).map((_, index) => <tr key={`empty-${index}`}><td colSpan="10"></td></tr>)}
           </tbody>
         </Table>
       </div>
@@ -764,3 +758,4 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
     </div>
   )
 }
+


### PR DESCRIPTION
Verwerkt twee goedgekeurde fixes op de juiste Externe-databasesbasis:

1. Fix7c — retailer-isolatie voor externe kandidaten
- voorkomt dat AH/Jumbo/Picnic Lidl-kandidaten tonen;
- beperkt legacy Lidl-testset tot retailer Lidl;
- beperkt projectie van kandidaat-artikelnummers tot dezelfde retailer.

2. Fix7d — statuskolom verwijderd uit bovenste bonartikelen-tabel
- verwijdert Status uit de hoofdtabel;
- verwijdert bijbehorende filter, sortering en exportkolom;
- laat kandidaatstatus in de detailtabel intact.

Getest:
- smoke-test retailer-isolatie geslaagd;
- app-check Externe databases geslaagd;
- frontend build geslaagd.

Belangrijk:
- Base is bewust niet main, omdat main de Externe-databasesmodule nog niet bevat.
- Deze PR target de directe Externe-databasesbasis: fix/m2c2i-2a-fix6-ssot-linkstatus.