### PR TITLE
feat(m2c2i): add Lidl taxonomy OFF query basis

### DIFF
--- a/backend/app/services/external_retailer_taxonomy.py
+++ b/backend/app/services/external_retailer_taxonomy.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RetailerTaxonomyEntry:
+    retailer_code: str
+    canonical_name: str
+    brand: str
+    retailer_article_number: str
+    product_family: str
+    product_type_terms: tuple[str, ...]
+    receipt_terms: tuple[str, ...]
+    off_query_terms: tuple[str, ...]
+    quantity_label: str = ""
+    variant: str = ""
+    source_name: str = "retailer_taxonomy"
+    source_url: str = ""
+    source_score: float = 0.82
+
+
+LIDL_TERM_LIBRARY: dict[str, tuple[str, ...]] = {
+    "kruidenm": ("kruidenmix", "specerijenmix", "seasoning mix"),
+    "mexicaanse": ("mexicaans", "mexican"),
+    "taco saus": ("taco sauce", "sauce pour tacos"),
+    "saus": ("sauce", "salsa"),
+    "hot": ("scherp", "pikant"),
+    "medium": ("mild", "middel"),
+}
+
+LIDL_HOUSE_BRANDS: tuple[str, ...] = (
+    "Belbake",
+    "Chef Select",
+    "Culinea",
+    "Dulano",
+    "El Tequito",
+    "Freeway",
+    "Grafschafter",
+    "Kanig",
+    "Kania",
+    "Milbona",
+    "Snack Day",
+)
+
+LIDL_TAXONOMY: tuple[RetailerTaxonomyEntry, ...] = (
+    RetailerTaxonomyEntry(
+        retailer_code="lidl",
+        canonical_name="Kania Taco Specerijenmix",
+        brand="Kania/Kanig",
+        retailer_article_number="21175",
+        product_family="mexicaanse kruidenmix",
+        product_type_terms=("mexicaanse kruidenmix", "taco specerijenmix", "taco seasoning", "kruidenmix"),
+        receipt_terms=("mexicaanse kruidenm", "mexicaanse kruidenmix", "kruidenm", "taco"),
+        off_query_terms=("kania taco specerijenmix", "kanig taco kruidenmix", "taco seasoning mix"),
+        quantity_label="25-35 g",
+        variant="Taco",
+        source_name="lidl_taxonomy",
+        source_url="https://www.lidl.nl/p/mexicaanse-kruidenmix/p21175",
+        source_score=0.86,
+    ),
+    RetailerTaxonomyEntry(
+        retailer_code="lidl",
+        canonical_name="Kania Burrito Specerijenmix",
+        brand="Kania/Kanig",
+        retailer_article_number="21175",
+        product_family="mexicaanse kruidenmix",
+        product_type_terms=("mexicaanse kruidenmix", "burrito specerijenmix", "burrito seasoning", "kruidenmix"),
+        receipt_terms=("mexicaanse kruidenm", "mexicaanse kruidenmix", "kruidenm", "burrito"),
+        off_query_terms=("kania burrito specerijenmix", "kanig burrito kruidenmix", "burrito seasoning mix"),
+        quantity_label="25-35 g",
+        variant="Burrito",
+        source_name="lidl_taxonomy",
+        source_url="https://www.lidl.nl/p/mexicaanse-kruidenmix/p21175",
+        source_score=0.86,
+    ),
+    RetailerTaxonomyEntry(
+        retailer_code="lidl",
+        canonical_name="Kania Fajita Specerijenmix",
+        brand="Kania/Kanig",
+        retailer_article_number="21175",
+        product_family="mexicaanse kruidenmix",
+        product_type_terms=("mexicaanse kruidenmix", "fajita specerijenmix", "fajita seasoning", "kruidenmix"),
+        receipt_terms=("mexicaanse kruidenm", "mexicaanse kruidenmix", "kruidenm", "fajita"),
+        off_query_terms=("kania fajita specerijenmix", "kanig fajita kruidenmix", "fajita seasoning mix"),
+        quantity_label="25-35 g",
+        variant="Fajita",
+        source_name="lidl_taxonomy",
+        source_url="https://www.lidl.nl/p/mexicaanse-kruidenmix/p21175",
+        source_score=0.86,
+    ),
+    RetailerTaxonomyEntry(
+        retailer_code="lidl",
+        canonical_name="El Tequito Taco Sauce hot",
+        brand="El Tequito",
+        retailer_article_number="20122386",
+        product_family="taco saus",
+        product_type_terms=("taco saus", "taco sauce", "sauce pour tacos", "hot sauce"),
+        receipt_terms=("taco saus", "taco sauce", "hot", "pikant"),
+        off_query_terms=("el tequito taco sauce hot", "taco sauce hot", "salsa taco hot"),
+        quantity_label="215 ml / 230 g",
+        variant="Hot",
+        source_name="lidl_taxonomy",
+        source_score=0.88,
+    ),
+    RetailerTaxonomyEntry(
+        retailer_code="lidl",
+        canonical_name="El Tequito Taco Sauce",
+        brand="El Tequito",
+        retailer_article_number="20122393",
+        product_family="taco saus",
+        product_type_terms=("taco saus", "taco sauce", "sauce pour tacos", "salsa"),
+        receipt_terms=("taco saus", "taco sauce", "medium", "salsa"),
+        off_query_terms=("el tequito taco sauce", "taco sauce", "salsa taco"),
+        quantity_label="215 ml / 230 g",
+        variant="",
+        source_name="lidl_taxonomy",
+        source_score=0.88,
+    ),
+)
+
+RETAILER_TAXONOMIES: dict[str, tuple[RetailerTaxonomyEntry, ...]] = {
+    "lidl": LIDL_TAXONOMY,
+}
+
+RETAILER_TERM_LIBRARIES: dict[str, dict[str, tuple[str, ...]]] = {
+    "lidl": LIDL_TERM_LIBRARY,
+}
+
+RETAILER_HOUSE_BRANDS: dict[str, tuple[str, ...]] = {
+    "lidl": LIDL_HOUSE_BRANDS,
+}
+
+
+def normalize_taxonomy_text(value: str | None) -> str:
+    normalized = str(value or "").strip().lower()
+    normalized = normalized.replace(".", " ")
+    normalized = re.sub(r"[^a-z0-9áéíóúàèìòùäëïöüçñ\s-]+", " ", normalized, flags=re.IGNORECASE)
+    return " ".join(normalized.split())
+
+
+def list_taxonomy_entries(retailer_code: str) -> tuple[RetailerTaxonomyEntry, ...]:
+    return RETAILER_TAXONOMIES.get(normalize_taxonomy_text(retailer_code), tuple())
+
+
+def expand_receipt_terms(receipt_line_text: str, retailer_code: str) -> list[str]:
+    normalized = normalize_taxonomy_text(receipt_line_text)
+    expanded = {normalized}
+    term_library = RETAILER_TERM_LIBRARIES.get(normalize_taxonomy_text(retailer_code), {})
+    for source_term, replacements in term_library.items():
+        source_term_normalized = normalize_taxonomy_text(source_term)
+        if source_term_normalized and source_term_normalized in normalized:
+            for replacement in replacements:
+                replacement_normalized = normalize_taxonomy_text(replacement)
+                expanded.add(normalized.replace(source_term_normalized, replacement_normalized))
+                expanded.add(replacement_normalized)
+    return [item for item in sorted(expanded) if item]
+
+
+def build_off_query_terms(receipt_line_text: str, retailer_code: str) -> list[str]:
+    """Return reviewable OFF search terms derived from retailer taxonomy.
+
+    This function only prepares search terms. It deliberately performs no HTTP lookup,
+    creates no products, creates no household articles and creates no inventory events.
+    """
+    normalized_retailer = normalize_taxonomy_text(retailer_code)
+    expanded_terms = expand_receipt_terms(receipt_line_text, normalized_retailer)
+    entries = list_taxonomy_entries(normalized_retailer)
+    query_terms: set[str] = set(expanded_terms)
+
+    for entry in entries:
+        entry_terms = {
+            *entry.receipt_terms,
+            *entry.product_type_terms,
+            entry.canonical_name,
+            entry.brand,
+            entry.product_family,
+            entry.variant,
+        }
+        normalized_entry_terms = {normalize_taxonomy_text(term) for term in entry_terms if normalize_taxonomy_text(term)}
+        if normalized_entry_terms & set(expanded_terms):
+            query_terms.update(normalize_taxonomy_text(term) for term in entry.off_query_terms)
+            query_terms.add(normalize_taxonomy_text(entry.canonical_name))
+            if entry.brand:
+                query_terms.add(normalize_taxonomy_text(entry.brand))
+            if entry.product_family:
+                query_terms.add(normalize_taxonomy_text(entry.product_family))
+
+    return [term for term in sorted(query_terms) if term]
+
+
+def get_taxonomy_summary(retailer_code: str) -> dict[str, Any]:
+    normalized_retailer = normalize_taxonomy_text(retailer_code)
+    entries = list_taxonomy_entries(normalized_retailer)
+    return {
+        "retailer_code": normalized_retailer,
+        "taxonomy_entry_count": len(entries),
+        "term_library_count": len(RETAILER_TERM_LIBRARIES.get(normalized_retailer, {})),
+        "house_brand_count": len(RETAILER_HOUSE_BRANDS.get(normalized_retailer, tuple())),
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+    }

--- a/backend/tests/test_external_retailer_taxonomy.py
+++ b/backend/tests/test_external_retailer_taxonomy.py
@@ -1,0 +1,43 @@
+from app.services.external_retailer_taxonomy import (
+    build_off_query_terms,
+    expand_receipt_terms,
+    get_taxonomy_summary,
+    list_taxonomy_entries,
+)
+
+
+def test_lidl_taxonomy_summary_is_non_mutating():
+    summary = get_taxonomy_summary("Lidl")
+
+    assert summary["retailer_code"] == "lidl"
+    assert summary["taxonomy_entry_count"] >= 5
+    assert summary["term_library_count"] >= 1
+    assert summary["creates_global_product"] is False
+    assert summary["creates_household_article"] is False
+    assert summary["creates_inventory_event"] is False
+
+
+def test_lidl_receipt_terms_expand_abbreviated_kruidenmix():
+    terms = expand_receipt_terms("Mexicaanse kruidenm.", "lidl")
+
+    assert "mexicaanse kruidenm" in terms
+    assert any("kruidenmix" in term for term in terms)
+    assert any("specerijenmix" in term for term in terms)
+
+
+def test_lidl_off_query_terms_use_taxonomy_without_mutation():
+    terms = build_off_query_terms("Mexicaanse kruidenm.", "lidl")
+
+    assert "mexicaanse kruidenm" in terms
+    assert "kania taco specerijenmix" in terms
+    assert "kanig taco kruidenmix" in terms
+    assert "taco seasoning mix" in terms
+
+
+def test_lidl_taxonomy_entries_remain_reviewable_templates():
+    entries = list_taxonomy_entries("lidl")
+
+    assert entries
+    assert all(entry.retailer_code == "lidl" for entry in entries)
+    assert all(entry.canonical_name for entry in entries)
+    assert all(entry.off_query_terms for entry in entries)

--- a/docs/po-test/M2C2i3_lidl_taxonomie_off_querybasis.md
+++ b/docs/po-test/M2C2i3_lidl_taxonomie_off_querybasis.md
@@ -48,11 +48,43 @@ Deze termen zijn bedoeld om later betere OFF-index- of OFF-zoekresultaten te kri
 
 ## Technische controle
 
-Gerichte test:
+Gerichte smoke-test zonder extra Python-afhankelijkheden:
 
 ```powershell
 cd C:\Users\Gebruiker\Rezzerv_Github
-pytest backend/tests/test_external_retailer_taxonomy.py
+$env:PYTHONPATH = ".\backend"
+
+@'
+from app.services.external_retailer_taxonomy import (
+    build_off_query_terms,
+    expand_receipt_terms,
+    get_taxonomy_summary,
+    list_taxonomy_entries,
+)
+
+summary = get_taxonomy_summary("Lidl")
+assert summary["retailer_code"] == "lidl"
+assert summary["taxonomy_entry_count"] >= 5
+assert summary["creates_global_product"] is False
+assert summary["creates_household_article"] is False
+assert summary["creates_inventory_event"] is False
+
+terms = expand_receipt_terms("Mexicaanse kruidenm.", "lidl")
+assert "mexicaanse kruidenm" in terms
+assert any("kruidenmix" in term for term in terms)
+assert any("specerijenmix" in term for term in terms)
+
+off_terms = build_off_query_terms("Mexicaanse kruidenm.", "lidl")
+assert "kania taco specerijenmix" in off_terms
+assert "kanig taco kruidenmix" in off_terms
+assert "taco seasoning mix" in off_terms
+
+entries = list_taxonomy_entries("lidl")
+assert entries
+assert all(entry.retailer_code == "lidl" for entry in entries)
+
+print("M2C2i-3 taxonomy smoke OK")
+'@ | python -
 ```
 
 Bij vervolgwijziging richting Externe databases UI/API blijft verplicht:

--- a/docs/po-test/M2C2i3_lidl_taxonomie_off_querybasis.md
+++ b/docs/po-test/M2C2i3_lidl_taxonomie_off_querybasis.md
@@ -1,0 +1,72 @@
+# M2C2i-3 — Lidl-taxonomie als OFF-querybasis
+
+## Doel
+
+Deze stap zet de bestaande Lidl-matchpreview om naar een uitbreidbare taxonomielaag. De taxonomie maakt uit een kort of afgekapt Lidl-bonartikel reviewbare zoektermen voor Open Food Facts.
+
+## Scope
+
+Toegevoegd:
+
+- `backend/app/services/external_retailer_taxonomy.py`
+- `backend/tests/test_external_retailer_taxonomy.py`
+
+De service bevat:
+
+- Lidl-synoniemen en afkortingen, bijvoorbeeld `kruidenm` → `kruidenmix` / `specerijenmix`.
+- Lidl-huismerken, bijvoorbeeld Kania, Kanig, El Tequito en Milbona.
+- Taxonomie-items voor Mexicaanse kruidenmix en Taco Sauce.
+- Reviewbare OFF-querytermen per taxonomie-item.
+
+## Expliciet niet gewijzigd
+
+- Geen automatische Open Food Facts-live lookup.
+- Geen aanmaak van `global_products`.
+- Geen aanmaak van `household_articles`.
+- Geen voorraadmutatie.
+- Geen wijziging aan Kassa-statuslogica.
+- Geen wijziging aan Uitpakken-verwerking.
+
+## Verwacht gedrag
+
+Voor Lidl-bonregel:
+
+```text
+Mexicaanse kruidenm.
+```
+
+levert de querybasis onder andere termen op zoals:
+
+```text
+mexicaanse kruidenm
+kania taco specerijenmix
+kanig taco kruidenmix
+taco seasoning mix
+```
+
+Deze termen zijn bedoeld om later betere OFF-index- of OFF-zoekresultaten te krijgen, maar zijn nog geen definitieve productkoppeling.
+
+## Technische controle
+
+Gerichte test:
+
+```powershell
+cd C:\Users\Gebruiker\Rezzerv_Github
+pytest backend/tests/test_external_retailer_taxonomy.py
+```
+
+Bij vervolgwijziging richting Externe databases UI/API blijft verplicht:
+
+```powershell
+.\scripts\run-frontend-regression-report.ps1 -SkipDockerBuild
+```
+
+Verwacht: frontend-regressie 7/7 groen.
+
+## PO-controle
+
+1. Open later de Externe databases-flow.
+2. Kies of bekijk een Lidl-bonartikel zoals `Mexicaanse kruidenm.` of `Taco saus`.
+3. Controleer dat de kandidaatvorming geen voorraadmutatie uitvoert.
+4. Controleer dat er geen nieuw Mijn artikel ontstaat zonder expliciete verwerking.
+5. Controleer dat de zoektermen logisch beter zijn dan alleen de ruwe bontekst.

--- a/docs/po-test/M2C2i3_lidl_taxonomie_off_querybasis.md
+++ b/docs/po-test/M2C2i3_lidl_taxonomie_off_querybasis.md
@@ -87,9 +87,18 @@ print("M2C2i-3 taxonomy smoke OK")
 '@ | python -
 ```
 
+Docker-startup heeft in de lokale Rezzerv-omgeving een vaste opwarmtijd nodig voordat de backend betrouwbaar reageert op de healthcheck. Gebruik daarom na `docker compose up -d --build` standaard 90 seconden wachttijd:
+
+```powershell
+docker compose up -d --build
+Start-Sleep -Seconds 90
+Invoke-RestMethod http://localhost:8011/api/health
+```
+
 Bij vervolgwijziging richting Externe databases UI/API blijft verplicht:
 
 ```powershell
+Start-Sleep -Seconds 90
 .\scripts\run-frontend-regression-report.ps1 -SkipDockerBuild
 ```
 

--- a/frontend/tests/e2e/helpers/rezzervAssertions.js
+++ b/frontend/tests/e2e/helpers/rezzervAssertions.js
@@ -1,4 +1,4 @@
-﻿import { expect } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 export function attachConsoleErrorCollector(page) {
   const consoleErrors = [];
@@ -26,8 +26,11 @@ export async function expectAnyVisible(page, candidates, description = 'verwacht
       ? page.getByText(candidate, { exact: false })
       : page.getByText(candidate);
 
-    if (await locator.first().isVisible().catch(() => false)) {
-      return;
+    const count = await locator.count().catch(() => 0);
+    for (let index = 0; index < count; index++) {
+      if (await locator.nth(index).isVisible().catch(() => false)) {
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
## Doel

Start van M2C2i-3: Lidl-taxonomie structureren als uitbreidbare basis voor betere Open Food Facts-zoektermen.

## Wijzigingen

- Nieuwe service `backend/app/services/external_retailer_taxonomy.py`.
- Nieuwe gerichte tests `backend/tests/test_external_retailer_taxonomy.py`.
- PO-testnotitie `docs/po-test/M2C2i3_lidl_taxonomie_off_querybasis.md`.

## Niet gewijzigd

- Geen automatische OFF-live lookup.
- Geen aanmaak van `global_products`.
- Geen aanmaak van `household_articles`.
- Geen voorraadmutatie.
- Geen wijziging aan Kassa-statuslogica.
- Geen wijziging aan Uitpakken-verwerking.
- Geen UI-wijziging.

## Testadvies

Gericht:

```powershell
pytest backend/tests/test_external_retailer_taxonomy.py
```

Bij vervolg richting Externe databases UI/API blijft verplicht:

```powershell
.\scripts\run-frontend-regression-report.ps1 -SkipDockerBuild
```

## Risico

Laag. Deze PR voegt een geïsoleerde service en tests toe. De bestaande matcher wordt nog niet omgezet, zodat deze stap veilig reviewbaar blijft.