### PR TITLE
feat(m2c2i): show Lidl candidate preview in external databases

### DIFF
--- a/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
+++ b/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import AppShell from '../../app/AppShell'
 import ScreenCard from '../../ui/ScreenCard'
@@ -157,6 +157,7 @@ export default function ExternalDatabasesPage() {
   }
 
   const candidates = Array.isArray(matchResult?.candidates) ? matchResult.candidates : []
+  const offQueryTerms = Array.isArray(matchResult?.off_query_terms) ? matchResult.off_query_terms : []
 
   function renderTabContent(tab) {
     if (tab === TAB_LABELS.overzicht) {
@@ -171,6 +172,10 @@ export default function ExternalDatabasesPage() {
     if (tab === TAB_LABELS.test) {
       return (
         <div className="rz-external-databases-test">
+          <div className="rz-external-databases-section-header">
+            <h3>Lidl-kandidaatpreview</h3>
+            <span className="rz-external-databases-muted">Preview-only: geen Mijn artikel, product of voorraadmutatie.</span>
+          </div>
           <form onSubmit={testCandidateMatch} className="rz-external-databases-form">
             <div className="rz-external-databases-form-grid">
               <label className="rz-input-field">
@@ -195,6 +200,18 @@ export default function ExternalDatabasesPage() {
             </div>
           </form>
           <div className="rz-external-databases-muted">Drempel probable_candidate: {formatScore(selectedRetailerConfig?.probable_candidate_threshold)}. Deze opslag maakt geen Mijn artikel, global_product of voorraadmutatie aan.</div>
+          {matchResult ? (
+            <div className="rz-external-databases-preview-meta" data-testid="external-database-preview-meta">
+              <span>Bron: {matchResult.candidate_source || '-'}</span>
+              <span>Taxonomiepreview: {matchResult.uses_retailer_taxonomy_preview ? 'ja' : 'nee'}</span>
+              <span>Productmutatie: nee</span>
+            </div>
+          ) : null}
+          {offQueryTerms.length ? (
+            <div className="rz-external-databases-off-terms" data-testid="external-database-off-query-terms">
+              <strong>OFF-zoektermen:</strong> {offQueryTerms.join(', ')}
+            </div>
+          ) : null}
           {saveResult ? <div className="rz-inline-feedback rz-inline-feedback--success">Kandidaten opgeslagen: {saveResult.saved_count ?? 0} nieuw, {saveResult.updated_count ?? 0} bijgewerkt, {saveResult.skipped_count ?? 0} overgeslagen.</div> : null}
           {matchResult ? (
             <Table dataTestId="external-database-candidates-table" tableClassName="rz-external-databases-table">
@@ -229,6 +246,7 @@ export default function ExternalDatabasesPage() {
               <Button variant="primary" type="button" onClick={() => navigate('/home')}>Terug</Button>
             </div>
             {renderTabContent(TAB_LABELS.overzicht)}
+            {renderTabContent(TAB_LABELS.test)}
           </div>
         </ScreenCard>
       </div>

--- a/frontend/src/features/externalDatabases/externalDatabases.css
+++ b/frontend/src/features/externalDatabases/externalDatabases.css
@@ -463,3 +463,27 @@
   margin-top: 14px;
   flex-wrap: wrap;
 }
+
+
+.rz-external-databases-preview-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  border: 2px solid #dfe7e1;
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: #ffffff;
+}
+
+.rz-external-databases-preview-meta span {
+  color: var(--color-brand-primary);
+}
+
+.rz-external-databases-off-terms {
+  border: 2px solid #dfe7e1;
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: #ffffff;
+  color: var(--color-text-primary);
+  line-height: 1.5;
+}

--- a/frontend/tests/e2e/external-databases.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases.frontend-regression.spec.js
@@ -1,4 +1,4 @@
-﻿import { test, expect } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import {
   attachConsoleErrorCollector,
   expectAnyVisible,
@@ -25,6 +25,19 @@ test.describe('Externe databases frontend-regressie', () => {
       'Kandidaten',
       'Product',
     ], 'Externe databases kernlabels');
+
+    await page.getByRole('button', { name: 'Test kandidaat' }).click();
+
+    await expect(page.getByTestId('external-database-preview-meta')).toBeVisible();
+    await expect(page.getByText('Bron:', { exact: false })).toBeVisible();
+    await expect(page.getByText('lidl_taxonomy', { exact: false })).toBeVisible();
+    await expect(page.getByTestId('external-database-off-query-terms')).toBeVisible();
+    await expect(page.getByTestId('external-database-off-query-terms')).toContainText('kania taco specerijenmix');
+    await expectAnyVisible(page, [
+      'Kania Taco Specerijenmix',
+      'Kania Burrito Specerijenmix',
+      'Kania Fajita Specerijenmix',
+    ], 'Lidl kandidaatpreview');
 
     await expect(page.getByText(/Application error|Uncaught|TypeError|ReferenceError/i)).toHaveCount(0);
     await expectNoConsoleErrors(consoleErrors);


### PR DESCRIPTION
## Samenvatting

M2C2i-4 maakt de bestaande Lidl-kandidaatpreview zichtbaar in het scherm Externe databases.

## Wijziging

- Toont een zichtbare sectie **Lidl-kandidaatpreview** in Externe databases.
- Toont `candidate_source`, waaronder `lidl_taxonomy` bij taxonomie-fallback.
- Toont `off_query_terms` uit de retailer-taxonomieservice.
- Toont de bestaande kandidaten, waaronder Kania-kruidenmixkandidaten.
- Breidt de frontend-regressietest uit met controle op Lidl-preview, bron en OFF-zoektermen.

## Niet gewijzigd

- Geen live Open Food Facts lookup.
- Geen automatische aanmaak van `global_products`.
- Geen automatische aanmaak van `household_articles` / Mijn artikel.
- Geen voorraadmutatie.
- Geen wijziging aan Kassa-verwerking.
- Geen wijziging aan Uitpakken-verwerking.
- Geen backend-schemawijziging.

## Lokale validatie

```text
Backend health: ok
Frontend regressie: 7/7 groen
```

Uitgevoerde regressie:

```powershell
.\scripts\run-frontend-regression-report.ps1 -SkipDockerBuild
```

Resultaat:

```text
7 passed
=== Frontend regressie groen ===
```