### PR TITLE
fix(m2c2i): integrate Lidl preview in existing candidate table

### DIFF
--- a/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
+++ b/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
@@ -246,7 +246,6 @@ export default function ExternalDatabasesPage() {
               <Button variant="primary" type="button" onClick={() => navigate('/home')}>Terug</Button>
             </div>
             {renderTabContent(TAB_LABELS.overzicht)}
-            {renderTabContent(TAB_LABELS.test)}
           </div>
         </ScreenCard>
       </div>

--- a/frontend/tests/e2e/external-databases.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases.frontend-regression.spec.js
@@ -26,18 +26,17 @@ test.describe('Externe databases frontend-regressie', () => {
       'Product',
     ], 'Externe databases kernlabels');
 
-    await page.getByRole('button', { name: 'Test kandidaat' }).click();
+    await expect(page.getByText('Lidl-kandidaatpreview')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Test kandidaat' })).toHaveCount(0);
 
-    await expect(page.getByTestId('external-database-preview-meta')).toBeVisible();
-    await expect(page.getByText('Bron:', { exact: false })).toBeVisible();
-    await expect(page.getByText('lidl_taxonomy', { exact: false })).toBeVisible();
-    await expect(page.getByTestId('external-database-off-query-terms')).toBeVisible();
-    await expect(page.getByTestId('external-database-off-query-terms')).toContainText('kania taco specerijenmix');
-    await expectAnyVisible(page, [
-      'Kania Taco Specerijenmix',
-      'Kania Burrito Specerijenmix',
-      'Kania Fajita Specerijenmix',
-    ], 'Lidl kandidaatpreview');
+    const receiptTable = page.getByTestId('external-receipt-items-table');
+    await expect(receiptTable).toBeVisible();
+
+    const firstDataRow = receiptTable.locator('tbody tr').filter({ hasText: /[A-Za-z0-9]/ }).first();
+    await firstDataRow.dblclick();
+
+    await expect(page.getByText('Koppelen kandidaten in artikel-catalogus')).toBeVisible();
+    await expect(page.getByTestId('external-receipt-item-candidates-table')).toBeVisible();
 
     await expect(page.getByText(/Application error|Uncaught|TypeError|ReferenceError/i)).toHaveCount(0);
     await expectNoConsoleErrors(consoleErrors);


### PR DESCRIPTION
## Samenvatting

Correctie op M2C2i-4 op basis van PO-feedback.

De extra zichtbare Lidl-kandidaatpreview was functioneel verwarrend, omdat de bestaande flow leidend moet blijven: bonartikel selecteren en kandidaten tonen in de bestaande kandidaatentabel.

## Wijziging

- Extra blok Lidl-kandidaatpreview wordt niet meer gerenderd.
- Extra knop Test kandidaat wordt niet meer zichtbaar in de normale flow.
- Bestaande bonartikelentabel en kandidaatentabel blijven leidend.
- Frontend-regressietest controleert dat het extra previewblok weg is en de bestaande tabel-flow beschikbaar blijft.

## Niet gewijzigd

- Geen backendwijziging.
- Geen schemawijziging.
- Geen wijziging aan de Lidl-taxonomieservice.
- Geen automatische product-, artikel- of voorraadmutatie.

## Lokale validatie

Backend health: ok
Frontend regressie: 7/7 groen

Uitgevoerd:
.\scripts\run-frontend-regression-report.ps1 -SkipDockerBuild

Resultaat:
7 passed
=== Frontend regressie groen ===

## PO-testfocus

1. Open Externe databases.
2. Controleer dat Lidl-kandidaatpreview niet meer als apart blok zichtbaar is.
3. Dubbelklik op een bonartikel.
4. Controleer dat kandidaten in de bestaande kandidaatentabel worden getoond.