### PR TITLE
feat(m2c2i): load Lidl candidates from existing receipt table flow

### DIFF
--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import Table from '../../ui/Table'
 import Button from '../../ui/Button'
 import { fetchJsonWithAuth } from '../../lib/authSession'
@@ -394,10 +394,46 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
     }
   }, [items.length, dedupedItems.length, currentPage])
 
-  function selectReceiptItem(item) {
+  async function selectReceiptItem(item) {
     setSelectedItem(item)
     setSelectedCandidateId('')
     setConfirmOverwrite(false)
+
+    if (!item || item.candidates?.length) return
+
+    setCandidateProgress({
+      active: true,
+      current: 1,
+      total: 1,
+      label: `Bijlezen en wegen: ${item.receiptLineText}`,
+    })
+
+    try {
+      const response = await fetchJsonWithAuth('/api/external-databases/receipt-items/ensure-candidates', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          include_below_threshold: true,
+          items: [{
+            receipt_line_text: item.receiptLineText,
+            retailer_code: item.retailerCodeRaw || item.retailerCode,
+            purchase_import_line_id: item.purchaseImportLineId,
+            receipt_line_id: item.receiptLineId,
+          }],
+        }),
+      })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data?.detail || 'Kandidaten bijlezen is mislukt')
+
+      const refreshed = await fetchItems()
+      setItems(refreshed)
+      const refreshedSelection = refreshed.find((nextItem) => nextItem.id === item.id) || null
+      if (refreshedSelection) setSelectedItem(refreshedSelection)
+    } catch (err) {
+      onError?.(err?.message || 'Kandidaten bijlezen is mislukt')
+    } finally {
+      setCandidateProgress({ active: false, current: 0, total: 0, label: '' })
+    }
   }
 
   function toggleSelectedItem(itemId) {

--- a/frontend/tests/e2e/external-databases.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases.frontend-regression.spec.js
@@ -33,6 +33,7 @@ test.describe('Externe databases frontend-regressie', () => {
     await expect(receiptTable).toBeVisible();
 
     const firstDataRow = receiptTable.locator('tbody tr').filter({ hasText: /[A-Za-z0-9]/ }).first();
+    await expect(firstDataRow).toBeVisible();
     await firstDataRow.dblclick();
 
     await expect(page.getByText('Koppelen kandidaten in artikel-catalogus')).toBeVisible();


### PR DESCRIPTION
## Samenvatting

M2C2i-5 sluit de Lidl-kandidaatherkenning aan op de bestaande Externe-databases-flow.

## Wijziging

- Bij dubbelklik op een bonartikel worden kandidaten voor die rij bijgelezen.
- De geselecteerde bonregel wordt daarna ververst.
- Kandidaten verschijnen in de bestaande kandidaatentabel.
- Geen extra previewblok of aparte testflow.

## Niet gewijzigd

- Geen backendwijziging.
- Geen schemawijziging.
- Geen automatische product-, artikel- of voorraadmutatie.

## Validatie

Backend health: ok
Frontend regressie: 7/7 groen
PO-test: akkoord.