### PR TITLE
feat(m2c2i): enrich Lidl OFF search with article code analysis

### DIFF
--- a/backend/app/services/external_database_matchers.py
+++ b/backend/app/services/external_database_matchers.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from app.services.external_retailer_taxonomy import (
+    analyze_retailer_article_codes,
     build_off_query_terms,
     expand_receipt_terms as expand_taxonomy_receipt_terms,
     list_taxonomy_entries,
@@ -587,6 +588,10 @@ def match_retailer_receipt_line(retailer_code: str, receipt_line_text: str, incl
             "retailer_code": normalized_retailer,
             "receipt_line_text": receipt_line_text,
             "expanded_terms": [normalize_match_text(receipt_line_text)],
+            "off_query_terms": article_code_analysis.get("off_query_terms", []),
+            "retailer_article_codes": article_code_analysis.get("retailer_article_codes", []),
+            "retailer_article_code_analysis": article_code_analysis.get("retailer_article_code_analysis", []),
+            "index_search_terms": article_code_analysis.get("index_search_terms", []),
             "probable_candidate_threshold": PROBABLE_CANDIDATE_THRESHOLD,
             "possible_candidate_threshold": POSSIBLE_CANDIDATE_THRESHOLD,
             "candidates": [],
@@ -630,9 +635,10 @@ def _m2c2i2_build_lidl_taxonomy_preview(
     include_below_threshold: bool = True,
 ) -> dict[str, Any]:
     normalized_retailer = normalize_match_text(retailer_code)
+    article_code_analysis = analyze_retailer_article_codes(receipt_line_text, normalized_retailer)
     taxonomy_entries = list_taxonomy_entries(normalized_retailer)
     expanded_terms = expand_taxonomy_receipt_terms(receipt_line_text, normalized_retailer)
-    off_query_terms = build_off_query_terms(receipt_line_text, normalized_retailer)
+    off_query_terms = article_code_analysis.get("off_query_terms") or build_off_query_terms(receipt_line_text, normalized_retailer)
 
     scored = [
         score_candidate(
@@ -657,6 +663,9 @@ def _m2c2i2_build_lidl_taxonomy_preview(
         "receipt_line_text": receipt_line_text,
         "expanded_terms": expanded_terms,
         "off_query_terms": off_query_terms,
+        "retailer_article_codes": article_code_analysis.get("retailer_article_codes", []),
+        "retailer_article_code_analysis": article_code_analysis.get("retailer_article_code_analysis", []),
+        "index_search_terms": article_code_analysis.get("index_search_terms", []),
         "probable_candidate_threshold": PROBABLE_CANDIDATE_THRESHOLD,
         "possible_candidate_threshold": POSSIBLE_CANDIDATE_THRESHOLD,
         "candidates": scored,
@@ -758,7 +767,22 @@ def _m2c2i2_score_candidate(receipt_line_text: str, row: dict[str, Any]) -> dict
 
 def match_retailer_receipt_line(retailer_code: str, receipt_line_text: str, include_below_threshold: bool = True) -> dict[str, Any]:
     normalized_retailer = normalize_match_text(retailer_code)
-    index_rows = search_external_product_index_candidates(receipt_line_text, limit=120, retailer_code=normalized_retailer)
+    article_code_analysis = (
+        analyze_retailer_article_codes(receipt_line_text, normalized_retailer)
+        if normalized_retailer == "lidl"
+        else {
+            "retailer_article_codes": [],
+            "retailer_article_code_analysis": [],
+            "off_query_terms": [],
+            "index_search_terms": [normalize_match_text(receipt_line_text)],
+        }
+    )
+    index_rows = search_external_product_index_candidates(
+        receipt_line_text,
+        limit=120,
+        retailer_code=normalized_retailer,
+        additional_search_terms=article_code_analysis.get("index_search_terms", []),
+    )
 
     scored = [_m2c2i2_score_candidate(receipt_line_text, row) for row in index_rows]
     if not include_below_threshold:
@@ -772,6 +796,10 @@ def match_retailer_receipt_line(retailer_code: str, receipt_line_text: str, incl
             "retailer_code": normalized_retailer,
             "receipt_line_text": receipt_line_text,
             "expanded_terms": [normalize_match_text(receipt_line_text)],
+            "off_query_terms": article_code_analysis.get("off_query_terms", []),
+            "retailer_article_codes": article_code_analysis.get("retailer_article_codes", []),
+            "retailer_article_code_analysis": article_code_analysis.get("retailer_article_code_analysis", []),
+            "index_search_terms": article_code_analysis.get("index_search_terms", []),
             "probable_candidate_threshold": PROBABLE_CANDIDATE_THRESHOLD,
             "possible_candidate_threshold": POSSIBLE_CANDIDATE_THRESHOLD,
             "candidates": scored,

--- a/backend/app/services/external_product_index_store.py
+++ b/backend/app/services/external_product_index_store.py
@@ -331,18 +331,33 @@ def ensure_external_product_index_seeded(minimum_rows: int = 100) -> dict[str, A
     return {"ok": True, "seeded": True, "inserted": inserted}
 
 
-def search_external_product_index_candidates(receipt_line_text: str, limit: int = 120, retailer_code: str | None = None) -> list[dict[str, Any]]:
+def search_external_product_index_candidates(
+    receipt_line_text: str,
+    limit: int = 120,
+    retailer_code: str | None = None,
+    additional_search_terms: list[str] | tuple[str, ...] | None = None,
+) -> list[dict[str, Any]]:
     ensure_external_product_index_seeded()
 
     normalized = normalize_index_text(receipt_line_text)
-    tokens = [token for token in normalized.split() if len(token) >= 3]
+    search_text = " ".join([
+        normalized,
+        *[normalize_index_text(term) for term in (additional_search_terms or [])],
+    ])
+    tokens: list[str] = []
+    seen_tokens: set[str] = set()
+    for token in search_text.split():
+        if len(token) < 3 or token in seen_tokens:
+            continue
+        tokens.append(token)
+        seen_tokens.add(token)
     if not tokens:
         return []
 
     params: dict[str, Any] = {"limit": max(10, min(int(limit or 120), 200))}
     where_parts: list[str] = []
 
-    for index, token in enumerate(tokens[:10]):
+    for index, token in enumerate(tokens[:16]):
         key = f"token_{index}"
         where_parts.append(f"normalized_search_text LIKE :{key}")
         params[key] = f"%{token}%"

--- a/backend/app/services/external_retailer_taxonomy.py
+++ b/backend/app/services/external_retailer_taxonomy.py
@@ -159,6 +159,92 @@ def expand_receipt_terms(receipt_line_text: str, retailer_code: str) -> list[str
     return [item for item in sorted(expanded) if item]
 
 
+def analyze_retailer_article_codes(receipt_line_text: str, retailer_code: str) -> dict[str, Any]:
+    """Analyseer mogelijke retailer-artikelcodes voor een bonregel.
+
+    Deze functie is alleen metadata/zoekverrijking:
+    - geen productmutatie
+    - geen household_article-mutatie
+    - geen voorraadmutatie
+    - geen beperking van kandidaatresultaten tot deze codes
+    """
+    normalized_retailer = normalize_taxonomy_text(retailer_code)
+    expanded_terms = set(expand_receipt_terms(receipt_line_text, normalized_retailer))
+    matches: list[RetailerTaxonomyEntry] = []
+
+    for entry in list_taxonomy_entries(normalized_retailer):
+        entry_terms = {
+            *entry.receipt_terms,
+            *entry.product_type_terms,
+            entry.canonical_name,
+            entry.brand,
+            entry.product_family,
+            entry.variant,
+            entry.retailer_article_number,
+        }
+        normalized_entry_terms = {
+            normalize_taxonomy_text(term)
+            for term in entry_terms
+            if normalize_taxonomy_text(term)
+        }
+        if normalized_entry_terms & expanded_terms:
+            matches.append(entry)
+
+    article_codes = sorted({
+        entry.retailer_article_number
+        for entry in matches
+        if normalize_taxonomy_text(entry.retailer_article_number)
+    })
+
+    off_query_terms = sorted({
+        normalize_taxonomy_text(term)
+        for entry in matches
+        for term in entry.off_query_terms
+        if normalize_taxonomy_text(term)
+    })
+
+    enriched_search_terms = {
+        normalize_taxonomy_text(receipt_line_text),
+        *expanded_terms,
+        *off_query_terms,
+    }
+
+    # Artikelcodes zijn extra signalen, maar mogen de zoekresultaten niet beperken.
+    for entry in matches:
+        enriched_search_terms.update({
+            normalize_taxonomy_text(entry.retailer_article_number),
+            normalize_taxonomy_text(entry.canonical_name),
+            normalize_taxonomy_text(entry.brand),
+            normalize_taxonomy_text(entry.product_family),
+            normalize_taxonomy_text(entry.variant),
+            *[normalize_taxonomy_text(term) for term in entry.product_type_terms],
+        })
+
+    return {
+        "retailer_code": normalized_retailer,
+        "receipt_line_text": receipt_line_text,
+        "retailer_article_codes": article_codes,
+        "retailer_article_code_analysis": [
+            {
+                "retailer_article_number": entry.retailer_article_number,
+                "canonical_name": entry.canonical_name,
+                "brand": entry.brand,
+                "variant": entry.variant,
+                "product_family": entry.product_family,
+                "quantity_label": entry.quantity_label,
+                "source_name": entry.source_name,
+                "source_url": entry.source_url,
+            }
+            for entry in matches
+        ],
+        "off_query_terms": off_query_terms,
+        "index_search_terms": sorted(term for term in enriched_search_terms if term),
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+    }
+
+
 def build_off_query_terms(receipt_line_text: str, retailer_code: str) -> list[str]:
     """Return reviewable OFF search terms derived from retailer taxonomy.
 

--- a/frontend/tests/e2e/external-databases.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases.frontend-regression.spec.js
@@ -32,9 +32,9 @@ test.describe('Externe databases frontend-regressie', () => {
     const receiptTable = page.getByTestId('external-receipt-items-table');
     await expect(receiptTable).toBeVisible();
 
-    const firstDataRow = receiptTable.locator('tbody tr').filter({ hasText: /[A-Za-z0-9]/ }).first();
-    await expect(firstDataRow).toBeVisible();
-    await firstDataRow.dblclick();
+    const rowWithCandidates = receiptTable.locator('tbody tr').filter({ hasText: /\b[1-9]\d*$/ }).first();
+    await expect(rowWithCandidates).toBeVisible();
+    await rowWithCandidates.dblclick();
 
     await expect(page.getByText('Koppelen kandidaten in artikel-catalogus')).toBeVisible();
     await expect(page.getByTestId('external-receipt-item-candidates-table')).toBeVisible();


### PR DESCRIPTION
## Samenvatting

M2C2i-6 voegt veilige Lidl-artikelcodeanalyse toe als zoekverrijking voor OFF/external_product_index.

## Wijziging

- Analyseert Lidl-bonregels op mogelijke retailer-artikelcodes.
- Geeft artikelcodes terug als metadata in de matchresponse.
- Verrijkt OFF/index-zoektermen met artikelcodes, canonical names, merken en varianten.
- Behoudt brede kandidaatzoekactie: artikelcodes werken niet als hard filter.
- Maakt de Externe-databases regressietest robuuster door een rij met kandidaten te kiezen.

## Niet gewijzigd

- Geen automatische productaanmaak.
- Geen Mijn-artikel-aanmaak.
- Geen voorraadmutatie.
- Geen extra frontendflow.

## Validatie

- Backend health: ok.
- Backend smoke: groen.
- Frontend regressie: 7/7 groen.

Smokecases:
- Mexicaanse kruidenm. -> 21175.
- Taco saus -> 20122386, 20122393.
- Halfvolle melk -> geen taxonomiecode, maar brede kandidaatzoekactie blijft werken.