### PR TITLE
fix(m2c2i): prevent Lidl taxonomy fallback without article code match

### DIFF
--- a/backend/app/services/external_database_matchers.py
+++ b/backend/app/services/external_database_matchers.py
@@ -825,8 +825,28 @@ def match_retailer_receipt_line(retailer_code: str, receipt_line_text: str, incl
             "creates_inventory_event": False,
         }
 
-    return _m2c2i2_build_lidl_taxonomy_preview(
-        retailer_code=retailer_code,
-        receipt_line_text=receipt_line_text,
-        include_below_threshold=include_below_threshold,
-    )
+    if article_code_analysis.get("retailer_article_codes"):
+        return _m2c2i2_build_lidl_taxonomy_preview(
+            retailer_code=retailer_code,
+            receipt_line_text=receipt_line_text,
+            include_below_threshold=include_below_threshold,
+        )
+
+    return {
+        "retailer_code": normalized_retailer,
+        "receipt_line_text": receipt_line_text,
+        "expanded_terms": [normalize_match_text(receipt_line_text)],
+        "off_query_terms": article_code_analysis.get("off_query_terms", []),
+        "retailer_article_codes": article_code_analysis.get("retailer_article_codes", []),
+        "retailer_article_code_analysis": article_code_analysis.get("retailer_article_code_analysis", []),
+        "index_search_terms": article_code_analysis.get("index_search_terms", []),
+        "probable_candidate_threshold": PROBABLE_CANDIDATE_THRESHOLD,
+        "possible_candidate_threshold": POSSIBLE_CANDIDATE_THRESHOLD,
+        "candidates": [],
+        "candidate_source": "external_product_index_no_match",
+        "uses_legacy_fallback": False,
+        "uses_retailer_taxonomy_preview": False,
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+    }


### PR DESCRIPTION
## Samenvatting

Hotfix op M2C2i-6: voorkom dat de Lidl-taxonomie als fallback kandidaten toont wanneer er geen echte artikelcodematch is.

## Probleem

Bij een Lidl-bonartikel zoals Banaan werden toch kruidenmix- en taco-sauskandidaten getoond uit de beperkte Lidl-taxonomie. Dat kwam doordat de taxonomiepreview werd gebruikt zonder dat `retailer_article_codes` gevuld was.

## Wijziging

- Lidl-taxonomiepreview wordt alleen nog gebruikt als de artikelcodeanalyse daadwerkelijk codes oplevert.
- Zonder artikelcodematch wordt een lege kandidaatset teruggegeven met `candidate_source = external_product_index_no_match`.
- Mutatievlaggen blijven false.

## Validatie

- Banaan toont geen kruidenmix/taco-saus taxonomy-kandidaten meer.
- Mexicaanse kruidenm. blijft artikelcode 21175 vinden.
- Backend health: ok.
- Frontend regressie: 7/7 groen.