### PR TITLE
fix(m2c2i): remove Lidl taxonomy fallback from matcher

### DIFF
--- a/backend/app/services/external_database_matchers.py
+++ b/backend/app/services/external_database_matchers.py
@@ -825,13 +825,6 @@ def match_retailer_receipt_line(retailer_code: str, receipt_line_text: str, incl
             "creates_inventory_event": False,
         }
 
-    if article_code_analysis.get("retailer_article_codes"):
-        return _m2c2i2_build_lidl_taxonomy_preview(
-            retailer_code=retailer_code,
-            receipt_line_text=receipt_line_text,
-            include_below_threshold=include_below_threshold,
-        )
-
     return {
         "retailer_code": normalized_retailer,
         "receipt_line_text": receipt_line_text,


### PR DESCRIPTION
## Samenvatting

Verwijdert de resterende directe Lidl-taxonomy fallback-call uit de matcher.

## Probleem

Ook na de eerdere hotfix konden Lidl-taxonomy kandidaten nog in de UI terugkomen. De directe fallback-call naar `_m2c2i2_build_lidl_taxonomy_preview(...)` moest volledig uit het matcherpad worden gehaald.

## Wijziging

- Verwijdert de resterende aanroep naar `_m2c2i2_build_lidl_taxonomy_preview(...)` uit `match_retailer_receipt_line`.
- De functie-definitie blijft staan, maar wordt niet meer als fallback aangeroepen.
- Runtime-database is lokaal opgeschoond: 57 oude `lidl_taxonomy` / `lidl_product_group` kandidaten verwijderd uit `external_product_candidates`.

## Validatie

- Banaan geeft geen taxonomy-kandidaten meer terug.
- `candidate_source = external_product_index_no_match`.
- `uses_retailer_taxonomy_preview = false`.
- Frontend regressie: 7/7 groen.

## Niet gewijzigd

- Geen automatische productaanmaak.
- Geen Mijn-artikel-aanmaak.
- Geen voorraadmutatie.