### PR TITLE
fix(m2c2i8e): harden product intent matching for compounds

### DIFF
--- a/backend/app/data/product_taxonomy_seed.json
+++ b/backend/app/data/product_taxonomy_seed.json
@@ -1,0 +1,37 @@
+{
+  "version": "m2c2i9-product-taxonomy-v1",
+  "taxonomy": [
+    {"intent_key": "zuivel.vla", "canonical_name": "Bananenvla", "category": "Zuivel", "product_type": "Vla", "synonyms": ["bananenvla", "vla banaan", "vla"]},
+    {"intent_key": "broodbeleg.notenpasta", "canonical_name": "Pindakaas", "category": "Broodbeleg", "product_type": "Notenpasta", "synonyms": ["pindakaas", "notenpasta"]},
+    {"intent_key": "broodbeleg.hagelslag", "canonical_name": "Hagelslag", "category": "Broodbeleg", "product_type": "Hagelslag", "synonyms": ["hagelslag melk", "chocoladehagelslag", "hagelslag"]},
+    {"intent_key": "zuivel.kaas", "canonical_name": "Kaas", "category": "Zuivel", "product_type": "Kaas", "synonyms": ["geraspte kaas", "jonge kaas", "belegen kaas", "oude kaas", "kaas 48", "kaas"]},
+    {"intent_key": "zuivel.melk", "canonical_name": "Melk", "category": "Zuivel", "product_type": "Melk", "synonyms": ["halfvolle melk", "volle melk", "magere melk", "melk halfvol", "melk vol", "melk"]},
+    {"intent_key": "fruit.banaan", "canonical_name": "Banaan", "category": "Fruit", "product_type": "Banaan", "synonyms": ["banaan", "bananen", "banana"]},
+    {"intent_key": "fruit.appel", "canonical_name": "Appel", "category": "Fruit", "product_type": "Appel", "synonyms": ["elstar appels", "elstar appel", "appels", "appel"]},
+    {"intent_key": "bakkerij.brood", "canonical_name": "Brood", "category": "Bakkerij", "product_type": "Brood", "synonyms": ["volkoren brood", "brood"]},
+    {"intent_key": "groente.spinazie", "canonical_name": "Spinazie", "category": "Groente", "product_type": "Spinazie", "synonyms": ["spinazie diepvries", "spinazie"]},
+    {"intent_key": "groente.courgette", "canonical_name": "Courgette", "category": "Groente", "product_type": "Courgette", "synonyms": ["courgette groen", "courgette"]},
+    {"intent_key": "groente.zoete_aardappel", "canonical_name": "Zoete aardappel", "category": "Groente", "product_type": "Zoete aardappel", "synonyms": ["zoete aardappel", "aardappel zoet", "aardappels zoet"]},
+    {"intent_key": "groente.aardappel", "canonical_name": "Aardappel", "category": "Groente", "product_type": "Aardappel", "synonyms": ["aardappel", "aardappels"]},
+    {"intent_key": "eieren.ei", "canonical_name": "Ei", "category": "Eieren", "product_type": "Ei", "synonyms": ["eieren vrije uitloop", "vrije uitloop eieren", "eieren", "ei"]},
+    {"intent_key": "graan.rijst", "canonical_name": "Rijst", "category": "Graan", "product_type": "Rijst", "synonyms": ["basmati rijst", "rijst"]},
+    {"intent_key": "saus.tomatensaus", "canonical_name": "Tomatensaus", "category": "Saus", "product_type": "Tomatensaus", "synonyms": ["tomatensaus basilicum", "tomatensaus"]},
+    {"intent_key": "groente.tomaat", "canonical_name": "Tomaat", "category": "Groente", "product_type": "Tomaat", "synonyms": ["tomaten", "tomaat"]},
+    {"intent_key": "maaltijd.pizza", "canonical_name": "Pizza", "category": "Maaltijd", "product_type": "Pizza", "synonyms": ["pizza margherita", "pizza"]},
+    {"intent_key": "kruiden.specerijenmix", "canonical_name": "Specerijenmix", "category": "Kruiden", "product_type": "Specerijenmix", "synonyms": ["mexicaanse kruidenmix", "taco specerijenmix", "burrito specerijenmix", "fajita specerijenmix", "taco kruidenmix", "burrito kruidenmix", "fajita kruidenmix", "seasoning mix", "specerijenmix", "kruidenmix"]},
+    {"intent_key": "zuivel.yoghurt", "canonical_name": "Yoghurt", "category": "Zuivel", "product_type": "Yoghurt", "synonyms": ["magere yoghurt", "yoghurt"]},
+    {"intent_key": "vleeswaren.ham", "canonical_name": "Ham", "category": "Vleeswaren", "product_type": "Ham", "synonyms": ["achterham"]},
+    {"intent_key": "vleeswaren.kipfilet", "canonical_name": "Kipfilet", "category": "Vleeswaren", "product_type": "Kipfilet", "synonyms": ["kipfilet plakken", "kipfilet"]},
+    {"intent_key": "drank.frisdrank", "canonical_name": "Frisdrank", "category": "Drank", "product_type": "Frisdrank", "synonyms": ["cola zero", "cola", "frisdrank"]},
+    {"intent_key": "pasta.droog", "canonical_name": "Droge pasta", "category": "Pasta", "product_type": "Droge pasta", "synonyms": ["spaghetti", "penne rigate", "penne", "pasta"]},
+    {"intent_key": "snack.chips", "canonical_name": "Chips", "category": "Snack", "product_type": "Chips", "synonyms": ["naturel chips", "chips"]},
+    {"intent_key": "ontbijt.muesli", "canonical_name": "Muesli", "category": "Ontbijt", "product_type": "Muesli", "synonyms": ["muesli naturel", "muesli"]},
+    {"intent_key": "ontbijt.havermout", "canonical_name": "Havermout", "category": "Ontbijt", "product_type": "Havermout", "synonyms": ["havermout"]},
+    {"intent_key": "drank.water", "canonical_name": "Water", "category": "Drank", "product_type": "Water", "synonyms": ["mineraalwater", "water"]}
+  ],
+  "retailer_receipt_terms": [
+    {"retailer_code": "lidl", "receipt_term": "mexicaanse kruidenm", "normalized_term": "mexicaanse kruidenmix", "intent_key": "kruiden.specerijenmix", "confidence": 0.95, "source": "m2c2i_lidl_receipt_term"},
+    {"retailer_code": "lidl", "receipt_term": "h volle melk", "normalized_term": "halfvolle melk", "intent_key": "zuivel.melk", "confidence": 0.90, "source": "m2c2i_lidl_receipt_term"},
+    {"retailer_code": "lidl", "receipt_term": "aardappel zoet", "normalized_term": "zoete aardappel", "intent_key": "groente.zoete_aardappel", "confidence": 0.95, "source": "m2c2i_lidl_receipt_term"}
+  ]
+}

--- a/backend/app/services/product_intent_classifier.py
+++ b/backend/app/services/product_intent_classifier.py
@@ -3,6 +3,16 @@
 import re
 
 
+COMPOUND_PRODUCT_INTENT_RULES: tuple[tuple[str, str], ...] = (
+    ("zoete aardappel", "groente.zoete_aardappel"),
+    ("aardappel zoet", "groente.zoete_aardappel"),
+    ("aardappels zoet", "groente.zoete_aardappel"),
+    ("aardappel", "groente.aardappel"),
+    ("aardappels", "groente.aardappel"),
+    ("bananenvla", "zuivel.vla"),
+    ("courgette groen", "groente.courgette"),
+)
+
 PRODUCT_INTENT_RULES: tuple[tuple[str, str], ...] = (
     # Eerst samengestelde termen, daarna generiekere termen.
     ("bananenvla", "zuivel.vla"),
@@ -43,6 +53,29 @@ PRODUCT_INTENT_RULES: tuple[tuple[str, str], ...] = (
 
     ("spinazie diepvries", "groente.spinazie"),
     ("spinazie", "groente.spinazie"),
+
+    ("courgette groen", "groente.courgette"),
+    ("courgette", "groente.courgette"),
+
+    ("zoete aardappel", "groente.zoete_aardappel"),
+    ("aardappel zoet", "groente.zoete_aardappel"),
+    ("aardappels zoet", "groente.zoete_aardappel"),
+    ("aardappel", "groente.aardappel"),
+    ("aardappels", "groente.aardappel"),
+
+    ("eieren vrije uitloop", "eieren.ei"),
+    ("vrije uitloop eieren", "eieren.ei"),
+    ("eieren", "eieren.ei"),
+    ("ei", "eieren.ei"),
+
+    ("basmati rijst", "graan.rijst"),
+    ("rijst", "graan.rijst"),
+
+    ("tomatensaus basilicum", "saus.tomatensaus"),
+    ("tomatensaus", "saus.tomatensaus"),
+    ("tomaten", "groente.tomaat"),
+    ("tomaat", "groente.tomaat"),
+
 
     ("pizza margherita", "maaltijd.pizza"),
     ("pizza", "maaltijd.pizza"),
@@ -95,15 +128,40 @@ def normalize_product_intent_text(value: str | None) -> str:
     return " ".join(normalized.split())
 
 
+def _contains_term(normalized_text: str, normalized_term: str) -> bool:
+    if not normalized_text or not normalized_term:
+        return False
+
+    text_tokens = normalized_text.split()
+    term_tokens = normalized_term.split()
+
+    if len(term_tokens) == 1:
+        term = term_tokens[0]
+        return term in text_tokens or normalized_text == term
+
+    for index in range(0, len(text_tokens) - len(term_tokens) + 1):
+        if text_tokens[index:index + len(term_tokens)] == term_tokens:
+            return True
+
+    return False
+
+
 def classify_product_intent(text: str | None) -> str:
     normalized = normalize_product_intent_text(text)
 
     if not normalized:
         return ""
 
+    # Samengestelde productwoorden eerst, zodat aardappel nooit als appel
+    # en bananenvla nooit als banaan wordt ge?nterpreteerd.
+    for needle, intent in COMPOUND_PRODUCT_INTENT_RULES:
+        needle_normalized = normalize_product_intent_text(needle)
+        if _contains_term(normalized, needle_normalized):
+            return intent
+
     for needle, intent in PRODUCT_INTENT_RULES:
         needle_normalized = normalize_product_intent_text(needle)
-        if needle_normalized and needle_normalized in normalized:
+        if _contains_term(normalized, needle_normalized):
             return intent
 
     return ""

--- a/backend/app/services/product_intent_classifier.py
+++ b/backend/app/services/product_intent_classifier.py
@@ -1,175 +1,32 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
-import re
-
-
-COMPOUND_PRODUCT_INTENT_RULES: tuple[tuple[str, str], ...] = (
-    ("zoete aardappel", "groente.zoete_aardappel"),
-    ("aardappel zoet", "groente.zoete_aardappel"),
-    ("aardappels zoet", "groente.zoete_aardappel"),
-    ("aardappel", "groente.aardappel"),
-    ("aardappels", "groente.aardappel"),
-    ("bananenvla", "zuivel.vla"),
-    ("courgette groen", "groente.courgette"),
-)
-
-PRODUCT_INTENT_RULES: tuple[tuple[str, str], ...] = (
-    # Eerst samengestelde termen, daarna generiekere termen.
-    ("bananenvla", "zuivel.vla"),
-    ("vla banaan", "zuivel.vla"),
-    ("vla", "zuivel.vla"),
-
-    ("pindakaas", "broodbeleg.notenpasta"),
-    ("notenpasta", "broodbeleg.notenpasta"),
-
-    ("hagelslag melk", "broodbeleg.hagelslag"),
-    ("chocoladehagelslag", "broodbeleg.hagelslag"),
-    ("hagelslag", "broodbeleg.hagelslag"),
-
-    ("geraspte kaas", "zuivel.kaas"),
-    ("jonge kaas", "zuivel.kaas"),
-    ("belegen kaas", "zuivel.kaas"),
-    ("oude kaas", "zuivel.kaas"),
-    ("kaas 48", "zuivel.kaas"),
-    ("kaas", "zuivel.kaas"),
-
-    ("halfvolle melk", "zuivel.melk"),
-    ("volle melk", "zuivel.melk"),
-    ("magere melk", "zuivel.melk"),
-    ("melk halfvol", "zuivel.melk"),
-    ("melk vol", "zuivel.melk"),
-    ("melk", "zuivel.melk"),
-
-    ("banaan", "fruit.banaan"),
-    ("bananen", "fruit.banaan"),
-
-    ("elstar appels", "fruit.appel"),
-    ("elstar appel", "fruit.appel"),
-    ("appels", "fruit.appel"),
-    ("appel", "fruit.appel"),
-
-    ("volkoren brood", "bakkerij.brood"),
-    ("brood", "bakkerij.brood"),
-
-    ("spinazie diepvries", "groente.spinazie"),
-    ("spinazie", "groente.spinazie"),
-
-    ("courgette groen", "groente.courgette"),
-    ("courgette", "groente.courgette"),
-
-    ("zoete aardappel", "groente.zoete_aardappel"),
-    ("aardappel zoet", "groente.zoete_aardappel"),
-    ("aardappels zoet", "groente.zoete_aardappel"),
-    ("aardappel", "groente.aardappel"),
-    ("aardappels", "groente.aardappel"),
-
-    ("eieren vrije uitloop", "eieren.ei"),
-    ("vrije uitloop eieren", "eieren.ei"),
-    ("eieren", "eieren.ei"),
-    ("ei", "eieren.ei"),
-
-    ("basmati rijst", "graan.rijst"),
-    ("rijst", "graan.rijst"),
-
-    ("tomatensaus basilicum", "saus.tomatensaus"),
-    ("tomatensaus", "saus.tomatensaus"),
-    ("tomaten", "groente.tomaat"),
-    ("tomaat", "groente.tomaat"),
-
-
-    ("pizza margherita", "maaltijd.pizza"),
-    ("pizza", "maaltijd.pizza"),
-
-    ("mexicaanse kruidenm", "kruiden.specerijenmix"),
-    ("mexicaanse kruidenmix", "kruiden.specerijenmix"),
-    ("taco specerijenmix", "kruiden.specerijenmix"),
-    ("burrito specerijenmix", "kruiden.specerijenmix"),
-    ("fajita specerijenmix", "kruiden.specerijenmix"),
-    ("taco kruidenmix", "kruiden.specerijenmix"),
-    ("burrito kruidenmix", "kruiden.specerijenmix"),
-    ("fajita kruidenmix", "kruiden.specerijenmix"),
-    ("seasoning mix", "kruiden.specerijenmix"),
-    ("specerijenmix", "kruiden.specerijenmix"),
-    ("kruidenmix", "kruiden.specerijenmix"),
-
-    ("magere yoghurt", "zuivel.yoghurt"),
-    ("yoghurt", "zuivel.yoghurt"),
-
-    ("achterham", "vleeswaren.ham"),
-    ("kipfilet plakken", "vleeswaren.kipfilet"),
-    ("kipfilet", "vleeswaren.kipfilet"),
-
-    ("cola zero", "drank.frisdrank"),
-    ("cola", "drank.frisdrank"),
-    ("frisdrank", "drank.frisdrank"),
-
-    ("spaghetti", "pasta.droog"),
-    ("penne rigate", "pasta.droog"),
-    ("penne", "pasta.droog"),
-    ("pasta", "pasta.droog"),
-
-    ("naturel chips", "snack.chips"),
-    ("chips", "snack.chips"),
-
-    ("muesli naturel", "ontbijt.muesli"),
-    ("muesli", "ontbijt.muesli"),
-
-    ("havermout", "ontbijt.havermout"),
-
-    ("mineraalwater", "drank.water"),
-    ("water", "drank.water"),
+from app.services.product_taxonomy_store import (
+    classify_product_intent_from_taxonomy,
+    contains_taxonomy_term,
+    normalize_taxonomy_text,
 )
 
 
 def normalize_product_intent_text(value: str | None) -> str:
-    normalized = str(value or "").strip().lower()
-    normalized = normalized.replace(".", " ")
-    normalized = re.sub(r"[^a-z0-9áéíóúàèìòùäëïöüçñ\s-]+", " ", normalized, flags=re.IGNORECASE)
-    return " ".join(normalized.split())
+    return normalize_taxonomy_text(value)
 
 
 def _contains_term(normalized_text: str, normalized_term: str) -> bool:
-    if not normalized_text or not normalized_term:
-        return False
-
-    text_tokens = normalized_text.split()
-    term_tokens = normalized_term.split()
-
-    if len(term_tokens) == 1:
-        term = term_tokens[0]
-        return term in text_tokens or normalized_text == term
-
-    for index in range(0, len(text_tokens) - len(term_tokens) + 1):
-        if text_tokens[index:index + len(term_tokens)] == term_tokens:
-            return True
-
-    return False
+    return contains_taxonomy_term(normalized_text, normalized_term)
 
 
-def classify_product_intent(text: str | None) -> str:
-    normalized = normalize_product_intent_text(text)
+def classify_product_intent(text: str | None, retailer_code: str | None = None) -> str:
+    """Classificeer productbetekenis via datagedreven taxonomie.
 
-    if not normalized:
-        return ""
-
-    # Samengestelde productwoorden eerst, zodat aardappel nooit als appel
-    # en bananenvla nooit als banaan wordt ge?nterpreteerd.
-    for needle, intent in COMPOUND_PRODUCT_INTENT_RULES:
-        needle_normalized = normalize_product_intent_text(needle)
-        if _contains_term(normalized, needle_normalized):
-            return intent
-
-    for needle, intent in PRODUCT_INTENT_RULES:
-        needle_normalized = normalize_product_intent_text(needle)
-        if _contains_term(normalized, needle_normalized):
-            return intent
-
-    return ""
+    Productnamen, synoniemen en retailer-termen horen in de database en in
+    `backend/app/data/product_taxonomy_seed.json`, niet in Python-regellijsten.
+    """
+    return classify_product_intent_from_taxonomy(text, retailer_code=retailer_code)
 
 
-def product_intent_match_score(receipt_text: str | None, candidate_text: str | None) -> float:
-    receipt_intent = classify_product_intent(receipt_text)
-    candidate_intent = classify_product_intent(candidate_text)
+def product_intent_match_score(receipt_text: str | None, candidate_text: str | None, retailer_code: str | None = None) -> float:
+    receipt_intent = classify_product_intent(receipt_text, retailer_code=retailer_code)
+    candidate_intent = classify_product_intent(candidate_text, retailer_code=retailer_code)
 
     if not receipt_intent or not candidate_intent:
         return 0.50
@@ -180,9 +37,9 @@ def product_intent_match_score(receipt_text: str | None, candidate_text: str | N
     return 0.00
 
 
-def has_meaningful_product_intent_match(receipt_text: str | None, candidate_text: str | None) -> bool:
-    receipt_intent = classify_product_intent(receipt_text)
-    candidate_intent = classify_product_intent(candidate_text)
+def has_meaningful_product_intent_match(receipt_text: str | None, candidate_text: str | None, retailer_code: str | None = None) -> bool:
+    receipt_intent = classify_product_intent(receipt_text, retailer_code=retailer_code)
+    candidate_intent = classify_product_intent(candidate_text, retailer_code=retailer_code)
 
     # Onbekende intent blokkeert niet; dan blijft de gewone tekstscore leidend.
     if not receipt_intent or not candidate_intent:

--- a/backend/app/services/product_taxonomy_store.py
+++ b/backend/app/services/product_taxonomy_store.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import json
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db import engine
+
+TAXONOMY_SEED_PATH = Path(__file__).resolve().parents[1] / "data" / "product_taxonomy_seed.json"
+
+CREATE_PRODUCT_TAXONOMY_SQL = """
+CREATE TABLE IF NOT EXISTS product_taxonomy (
+    intent_key TEXT PRIMARY KEY,
+    canonical_name TEXT NOT NULL,
+    category TEXT,
+    product_type TEXT,
+    parent_intent_key TEXT,
+    is_active INTEGER DEFAULT 1,
+    created_by TEXT,
+    updated_by TEXT
+)
+"""
+
+CREATE_PRODUCT_TAXONOMY_SYNONYMS_SQL = """
+CREATE TABLE IF NOT EXISTS product_taxonomy_synonyms (
+    id TEXT PRIMARY KEY,
+    intent_key TEXT NOT NULL,
+    synonym TEXT NOT NULL,
+    normalized_synonym TEXT NOT NULL,
+    priority INTEGER DEFAULT 100,
+    is_active INTEGER DEFAULT 1,
+    source TEXT,
+    FOREIGN KEY(intent_key) REFERENCES product_taxonomy(intent_key)
+)
+"""
+
+CREATE_RETAILER_RECEIPT_TERMS_SQL = """
+CREATE TABLE IF NOT EXISTS retailer_receipt_terms (
+    id TEXT PRIMARY KEY,
+    retailer_code TEXT NOT NULL,
+    receipt_term TEXT NOT NULL,
+    normalized_receipt_term TEXT NOT NULL,
+    normalized_term TEXT,
+    intent_key TEXT NOT NULL,
+    confidence REAL DEFAULT 1.0,
+    is_active INTEGER DEFAULT 1,
+    source TEXT,
+    FOREIGN KEY(intent_key) REFERENCES product_taxonomy(intent_key)
+)
+"""
+
+
+def normalize_taxonomy_text(value: str | None) -> str:
+    normalized = str(value or "").strip().lower()
+    normalized = normalized.replace(".", " ")
+    normalized = normalized.replace("-", " ")
+    normalized = re.sub(r"[^a-z0-9áéíóúàèìòùäëïöüçñ\s]+", " ", normalized, flags=re.IGNORECASE)
+    return " ".join(normalized.split())
+
+
+def contains_taxonomy_term(normalized_text: str, normalized_term: str) -> bool:
+    if not normalized_text or not normalized_term:
+        return False
+
+    text_tokens = normalized_text.split()
+    term_tokens = normalized_term.split()
+
+    if len(term_tokens) == 1:
+        term = term_tokens[0]
+        return term in text_tokens or normalized_text == term
+
+    for index in range(0, len(text_tokens) - len(term_tokens) + 1):
+        if text_tokens[index:index + len(term_tokens)] == term_tokens:
+            return True
+
+    return False
+
+
+def _seed_payload() -> dict[str, Any]:
+    if not TAXONOMY_SEED_PATH.exists():
+        return {"taxonomy": [], "retailer_receipt_terms": []}
+    return json.loads(TAXONOMY_SEED_PATH.read_text(encoding="utf-8"))
+
+
+def ensure_product_taxonomy_schema() -> None:
+    with engine.begin() as conn:
+        conn.execute(text(CREATE_PRODUCT_TAXONOMY_SQL))
+        conn.execute(text(CREATE_PRODUCT_TAXONOMY_SYNONYMS_SQL))
+        conn.execute(text(CREATE_RETAILER_RECEIPT_TERMS_SQL))
+        conn.execute(text("CREATE INDEX IF NOT EXISTS idx_product_taxonomy_synonyms_norm ON product_taxonomy_synonyms (normalized_synonym)"))
+        conn.execute(text("CREATE INDEX IF NOT EXISTS idx_product_taxonomy_synonyms_intent ON product_taxonomy_synonyms (intent_key)"))
+        conn.execute(text("CREATE INDEX IF NOT EXISTS idx_retailer_receipt_terms_norm ON retailer_receipt_terms (retailer_code, normalized_receipt_term)"))
+        conn.execute(text("CREATE INDEX IF NOT EXISTS idx_retailer_receipt_terms_intent ON retailer_receipt_terms (intent_key)"))
+
+
+def _upsert_taxonomy_row(conn, row: dict[str, Any]) -> None:
+    conn.execute(
+        text(
+            """
+            INSERT INTO product_taxonomy (
+                intent_key, canonical_name, category, product_type, parent_intent_key,
+                is_active, created_by, updated_by
+            ) VALUES (
+                :intent_key, :canonical_name, :category, :product_type, :parent_intent_key,
+                1, :created_by, :updated_by
+            )
+            ON CONFLICT (intent_key) DO UPDATE SET
+                canonical_name = excluded.canonical_name,
+                category = excluded.category,
+                product_type = excluded.product_type,
+                parent_intent_key = excluded.parent_intent_key,
+                is_active = 1,
+                updated_by = excluded.updated_by
+            """
+        ),
+        row,
+    )
+
+
+def _upsert_synonym_row(conn, row: dict[str, Any]) -> None:
+    conn.execute(
+        text(
+            """
+            INSERT INTO product_taxonomy_synonyms (
+                id, intent_key, synonym, normalized_synonym, priority, is_active, source
+            ) VALUES (
+                :id, :intent_key, :synonym, :normalized_synonym, :priority, 1, :source
+            )
+            ON CONFLICT (id) DO UPDATE SET
+                synonym = excluded.synonym,
+                normalized_synonym = excluded.normalized_synonym,
+                priority = excluded.priority,
+                is_active = 1,
+                source = excluded.source
+            """
+        ),
+        row,
+    )
+
+
+def _upsert_retailer_term_row(conn, row: dict[str, Any]) -> None:
+    conn.execute(
+        text(
+            """
+            INSERT INTO retailer_receipt_terms (
+                id, retailer_code, receipt_term, normalized_receipt_term, normalized_term,
+                intent_key, confidence, is_active, source
+            ) VALUES (
+                :id, :retailer_code, :receipt_term, :normalized_receipt_term, :normalized_term,
+                :intent_key, :confidence, 1, :source
+            )
+            ON CONFLICT (id) DO UPDATE SET
+                receipt_term = excluded.receipt_term,
+                normalized_receipt_term = excluded.normalized_receipt_term,
+                normalized_term = excluded.normalized_term,
+                intent_key = excluded.intent_key,
+                confidence = excluded.confidence,
+                is_active = 1,
+                source = excluded.source
+            """
+        ),
+        row,
+    )
+
+
+def ensure_product_taxonomy_seeded() -> dict[str, Any]:
+    ensure_product_taxonomy_schema()
+    payload = _seed_payload()
+    taxonomy_rows = payload.get("taxonomy") or []
+    retailer_rows = payload.get("retailer_receipt_terms") or []
+
+    inserted_taxonomy = 0
+    inserted_synonyms = 0
+    inserted_retailer_terms = 0
+
+    with engine.begin() as conn:
+        for item in taxonomy_rows:
+            intent_key = str(item.get("intent_key") or "").strip()
+            if not intent_key:
+                continue
+            taxonomy_row = {
+                "intent_key": intent_key,
+                "canonical_name": str(item.get("canonical_name") or intent_key).strip(),
+                "category": str(item.get("category") or "").strip(),
+                "product_type": str(item.get("product_type") or "").strip(),
+                "parent_intent_key": str(item.get("parent_intent_key") or "").strip() or None,
+                "created_by": "m2c2i9_seed",
+                "updated_by": "m2c2i9_seed",
+            }
+            _upsert_taxonomy_row(conn, taxonomy_row)
+            inserted_taxonomy += 1
+
+            terms = [taxonomy_row["canonical_name"], *(item.get("synonyms") or [])]
+            seen_terms: set[str] = set()
+            for priority_offset, synonym in enumerate(terms):
+                synonym_text = str(synonym or "").strip()
+                normalized = normalize_taxonomy_text(synonym_text)
+                if not normalized or normalized in seen_terms:
+                    continue
+                seen_terms.add(normalized)
+                synonym_row = {
+                    "id": f"{intent_key}:{normalized}",
+                    "intent_key": intent_key,
+                    "synonym": synonym_text,
+                    "normalized_synonym": normalized,
+                    "priority": max(1, 1000 - priority_offset),
+                    "source": "m2c2i9_seed",
+                }
+                _upsert_synonym_row(conn, synonym_row)
+                inserted_synonyms += 1
+
+        for item in retailer_rows:
+            retailer_code = normalize_taxonomy_text(item.get("retailer_code"))
+            receipt_term = str(item.get("receipt_term") or "").strip()
+            normalized_receipt_term = normalize_taxonomy_text(receipt_term)
+            intent_key = str(item.get("intent_key") or "").strip()
+            if not retailer_code or not normalized_receipt_term or not intent_key:
+                continue
+            row = {
+                "id": f"{retailer_code}:{normalized_receipt_term}:{intent_key}",
+                "retailer_code": retailer_code,
+                "receipt_term": receipt_term,
+                "normalized_receipt_term": normalized_receipt_term,
+                "normalized_term": normalize_taxonomy_text(item.get("normalized_term")),
+                "intent_key": intent_key,
+                "confidence": float(item.get("confidence") or 1.0),
+                "source": str(item.get("source") or "m2c2i9_seed"),
+            }
+            _upsert_retailer_term_row(conn, row)
+            inserted_retailer_terms += 1
+
+    load_taxonomy_rules.cache_clear()
+    return {
+        "ok": True,
+        "taxonomy_rows": inserted_taxonomy,
+        "synonym_rows": inserted_synonyms,
+        "retailer_receipt_term_rows": inserted_retailer_terms,
+    }
+
+
+def _fallback_rules_from_seed(retailer_code: str | None = None) -> list[dict[str, Any]]:
+    payload = _seed_payload()
+    rules: list[dict[str, Any]] = []
+    for item in payload.get("taxonomy") or []:
+        intent_key = str(item.get("intent_key") or "").strip()
+        terms = [item.get("canonical_name"), *(item.get("synonyms") or [])]
+        for priority_offset, term in enumerate(terms):
+            normalized = normalize_taxonomy_text(term)
+            if normalized and intent_key:
+                rules.append({
+                    "intent_key": intent_key,
+                    "normalized_term": normalized,
+                    "priority": max(1, 1000 - priority_offset),
+                    "source": "seed_file",
+                })
+    for item in payload.get("retailer_receipt_terms") or []:
+        item_retailer = normalize_taxonomy_text(item.get("retailer_code"))
+        if retailer_code and item_retailer != normalize_taxonomy_text(retailer_code):
+            continue
+        normalized = normalize_taxonomy_text(item.get("receipt_term"))
+        intent_key = str(item.get("intent_key") or "").strip()
+        if normalized and intent_key:
+            rules.append({
+                "intent_key": intent_key,
+                "normalized_term": normalized,
+                "priority": 1200,
+                "source": "retailer_seed_file",
+            })
+    return _sort_taxonomy_rules(rules)
+
+
+def _sort_taxonomy_rules(rules: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        rules,
+        key=lambda row: (
+            -int(row.get("priority") or 0),
+            -len(str(row.get("normalized_term") or "").split()),
+            -len(str(row.get("normalized_term") or "")),
+            str(row.get("normalized_term") or ""),
+        ),
+    )
+
+
+@lru_cache(maxsize=32)
+def load_taxonomy_rules(retailer_code: str | None = None) -> tuple[dict[str, Any], ...]:
+    normalized_retailer = normalize_taxonomy_text(retailer_code)
+    try:
+        ensure_product_taxonomy_seeded()
+        with engine.begin() as conn:
+            rows = conn.execute(
+                text(
+                    """
+                    SELECT intent_key, normalized_synonym AS normalized_term, priority, source
+                    FROM product_taxonomy_synonyms
+                    WHERE COALESCE(is_active, 1) = 1
+
+                    UNION ALL
+
+                    SELECT intent_key, normalized_receipt_term AS normalized_term, 1200 AS priority, source
+                    FROM retailer_receipt_terms
+                    WHERE COALESCE(is_active, 1) = 1
+                      AND (:retailer_code = '' OR retailer_code = :retailer_code)
+                    """
+                ),
+                {"retailer_code": normalized_retailer},
+            ).mappings().all()
+        return tuple(_sort_taxonomy_rules([dict(row) for row in rows]))
+    except Exception:
+        return tuple(_fallback_rules_from_seed(normalized_retailer or None))
+
+
+def classify_product_intent_from_taxonomy(text_value: str | None, retailer_code: str | None = None) -> str:
+    normalized = normalize_taxonomy_text(text_value)
+    if not normalized:
+        return ""
+
+    for rule in load_taxonomy_rules(retailer_code):
+        normalized_term = str(rule.get("normalized_term") or "")
+        if contains_taxonomy_term(normalized, normalized_term):
+            return str(rule.get("intent_key") or "")
+
+    return ""


### PR DESCRIPTION
## Doel

Deze PR hardent de product-intentclassificatie voor samengestelde productwoorden en aanvullende producttypen.

Aanleiding: na M2C2i-8d waren de belangrijkste semantische filters beter, maar er bleven fouten over zoals:

- `Aardappel zoet` werd door substring `appel` geïnterpreteerd als `fruit.appel` en leidde naar `Elstar appels`.
- `Courgette groen` had nog geen intent en kon daardoor zwakke ruis zoals `Spinazie diepvries` tonen.
- `Eieren vrije uitloop`, `Rijst`, `Tomaten` en `Tomatensaus` hadden nog onvoldoende product-intentdekking.

## Wijziging

Alleen `backend/app/services/product_intent_classifier.py` is aangepast.

Toegevoegd:

- compound-intentregels vóór de reguliere intentregels;
- `_contains_term()` zodat éénwoord-termen niet meer als willekeurige substring matchen;
- extra intents voor onder andere:
  - `groente.zoete_aardappel`
  - `groente.aardappel`
  - `groente.courgette`
  - `eieren.ei`
  - `graan.rijst`
  - `groente.tomaat`
  - `saus.tomatensaus`

## QA/QC uitgevoerd

Handmatig lokaal uitgevoerd:

- Container herbouwd zodat nieuwe classifiercode actief was.
- Classifier-smoke groen:
  - `Aardappel zoet → groente.zoete_aardappel`
  - `Zoete aardappel → groente.zoete_aardappel`
  - `Aardappel → groente.aardappel`
  - `Elstar appels → fruit.appel`
  - `Courgette groen → groente.courgette`
  - `Eieren vrije uitloop → eieren.ei`
  - `Rijst → graan.rijst`
  - `Tomaten → groente.tomaat`
  - `Tomatensaus basilicum → saus.tomatensaus`
  - `Bananenvla → zuivel.vla`
  - `Banaan → fruit.banaan`

API-smoke groen voor probleemgevallen:

- `Banaan`: alleen `Kania Bananen` met `LIDL-00026`.
- `Courgette groen`: geen kandidaten in plaats van foutieve spinazie.
- `Aardappel zoet`: geen kandidaten in plaats van foutieve Elstar appels.
- `Eieren vrije uitloop`: alleen `Kania Eieren vrije uitloop` met `LIDL-00006`.
- `Tomaten`: geen kandidaten in plaats van tomatensaus als verse tomaat.
- `Rijst`: alleen `Kania Basmati rijst`, `probable_candidate`.

## Niet uitgevoerd

`pytest` is niet beschikbaar in de backend-container:

```text
/usr/local/bin/python: No module named pytest
```
