### PR TITLE
test(kassa): isolate regression seed cleanup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17897,6 +17897,8 @@ def clear_regression_receipt_state(household_id: str):
                     WHERE household_id = :household_id
                       AND (
                         source_reference = 'mock:export-regression-fixture'
+                        OR source_reference LIKE 'mock:seed-%'
+                        OR source_reference LIKE '%regression-seed%'
                         OR (source_type = 'receipt' AND source_reference IN :references)
                       )
                     """
@@ -18266,9 +18268,17 @@ def ensure_regression_inventory_fixture_endpoint():
     }
 
 
-def cleanup_regression_fixture_state_endpoint():
+@app.post("/api/testing/fixtures/cleanup")
+def cleanup_regression_fixture_state_endpoint(authorization: Optional[str] = Header(None)):
+    require_platform_admin_user(authorization)
     household_id = str(ensure_household("admin@rezzerv.local").get("id") or "1")
-    return cleanup_regression_fixture_state(household_id)
+    cleanup = cleanup_regression_fixture_state(household_id)
+    log_regression_action('fixture.cleanup_endpoint', cleanup=cleanup)
+    return {
+        "status": "ok",
+        "household_id": household_id,
+        **cleanup,
+    }
 
 @app.get("/api/testing/fixtures/receipt/file")
 def get_regression_receipt_fixture_file(kind: str = Query('manual')):

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -4,6 +4,7 @@ const baseURL = process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:5174';
 
 export default defineConfig({
   testDir: './tests/e2e',
+  globalTeardown: './tests/e2e/global.teardown.js',
   timeout: 30_000,
   expect: {
     timeout: 10_000,

--- a/frontend/tests/e2e/global.teardown.js
+++ b/frontend/tests/e2e/global.teardown.js
@@ -1,0 +1,18 @@
+const API_URL = process.env.PLAYWRIGHT_API_URL || 'http://127.0.0.1:8001';
+const DEV_ADMIN_TOKEN = process.env.PLAYWRIGHT_ADMIN_TOKEN || 'rezzerv-dev-token::admin@rezzerv.local';
+
+async function globalTeardown() {
+  const response = await fetch(`${API_URL}/api/testing/fixtures/cleanup`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${DEV_ADMIN_TOKEN}`,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Regression fixture cleanup failed with ${response.status}: ${body}`);
+  }
+}
+
+export default globalTeardown;

--- a/frontend/tests/e2e/helpers/devApi.js
+++ b/frontend/tests/e2e/helpers/devApi.js
@@ -12,7 +12,7 @@ async function parseJson(response) {
   }
 }
 
-async function apiFetch(request, path, options = {}) {
+export async function apiFetch(request, path, options = {}) {
   const headers = {
     ...(options.headers || {}),
     Authorization: `Bearer ${DEV_ADMIN_TOKEN}`,
@@ -28,9 +28,13 @@ async function apiFetch(request, path, options = {}) {
   return payload;
 }
 
-async function resolveAuthorizedHouseholdId(request) {
+export async function resolveAuthorizedHouseholdId(request) {
   const household = await apiFetch(request, '/api/household');
   return String(household?.id || household?.household_id || DEMO_HOUSEHOLD_ID);
+}
+
+export async function cleanupRegressionFixtures(request) {
+  return apiFetch(request, '/api/testing/fixtures/cleanup', { method: 'POST' });
 }
 
 export async function resetAndSeedStoreImportFixture(request) {
@@ -79,4 +83,4 @@ export async function loginThroughUi(page) {
   await page.waitForURL('**/home');
 }
 
-export { API_URL, DEMO_HOUSEHOLD_ID, apiFetch, resolveAuthorizedHouseholdId };
+export { API_URL, DEMO_HOUSEHOLD_ID };

--- a/scripts/run-frontend-regression-report.ps1
+++ b/scripts/run-frontend-regression-report.ps1
@@ -6,6 +6,12 @@ $ErrorActionPreference = "Stop"
 
 Write-Host "=== Rezzerv frontend regressie: Kassa + Uitpakken ===" -ForegroundColor Cyan
 
+function Invoke-RegressionFixtureCleanup {
+  Write-Host "`n=== Regression fixture cleanup ===" -ForegroundColor Cyan
+  $headers = @{ Authorization = "Bearer rezzerv-dev-token::admin@rezzerv.local" }
+  Invoke-RestMethod -Method Post -Uri "http://localhost:8011/api/testing/fixtures/cleanup" -Headers $headers | Out-Host
+}
+
 $repoRoot = Split-Path -Parent $PSScriptRoot
 Push-Location $repoRoot
 
@@ -33,6 +39,8 @@ try {
     throw "Backend healthcheck niet groen na 12 pogingen."
   }
 
+  Invoke-RegressionFixtureCleanup
+
   Write-Host "`n=== Playwright frontend regressie via Docker ===" -ForegroundColor Cyan
 
   $frontendPath = Join-Path $repoRoot "frontend"
@@ -55,5 +63,13 @@ try {
   Write-Host "`n=== Frontend regressie groen ===" -ForegroundColor Green
 }
 finally {
+  try {
+    Invoke-RegressionFixtureCleanup
+  } catch {
+    Write-Host "Regression fixture cleanup na test faalde: $($_.Exception.Message)" -ForegroundColor Red
+    if ($LASTEXITCODE -eq 0) {
+      $global:LASTEXITCODE = 1
+    }
+  }
   Pop-Location
 }


### PR DESCRIPTION
## Doel

Voorkomen dat Kassa-regressietests testbonnen achterlaten in de normale PO-runtime database.

## Scope

M2C2i-8g — Kassa regression seedbonnen isoleren en opruimen.

Deze PR bevat alleen testfixture-governance en cleanup. De eerder besproken M2C2i-8f UI-fix voor kandidaat-reset bij bonartikelselectie zit niet in deze commit.

## Wijzigingen

- Backend cleanup-route toegevoegd: `POST /api/testing/fixtures/cleanup`.
- Cleanup van Kassa-regressiedata uitgebreid met `mock:seed-*` en `regression-seed` purchase import batches.
- Playwright `globalTeardown` toegevoegd voor cleanup na regressierun.
- Frontend testhelper uitgebreid met `cleanupRegressionFixtures`.
- Frontend regressierunner voert fixture-cleanup uit vóór én na Playwright.

## Testbewijs

- Gerichte seed-cleanup-validatie: geslaagd.
- `seed-kassa` maakt seeddata aan; cleanup verwijdert deze weer.
- Eindcontrole: geen `regression-seed::%` raw receipts en geen `mock:seed-*` purchase import batches achtergebleven.
- Frontend-regressie: `7 passed`.
- Cleanup vóór en na Playwright: `status: ok`.
- Lokale werkmap na commit/push: schoon.

## Risico

Laag tot middelmatig. De wijziging raakt testfixture-routes en regressierunner, niet de gewone PO-flow. Door de extra cleanup wordt testdata juist minder persistent in de runtime database.

## Niet gewijzigd

- Geen UI-gedragswijziging in Kassa, Uitpakken of Externe databases.
- Geen wijziging aan parserlogica.
- Geen wijziging aan productmatching of M2C2i-8f kandidaatselectie.
- Geen database-schemawijziging.