### PR TITLE
fix(external-databases): dedupe receipt item candidates

### DIFF
--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -67,6 +67,51 @@ function candidateKey(candidate) {
   )
 }
 
+function candidateDedupValue(value) {
+  return String(value || '').trim().toLowerCase()
+}
+
+function candidateDedupKey(candidate) {
+  const raw = candidate?.raw || {}
+  const source = candidateDedupValue(candidate.source || raw.external_source_name || raw.candidate_source_name || raw.source_name)
+  const externalCode = candidateDedupValue(candidate.externalCode || raw.external_source_product_code || raw.candidate_source_product_code || raw.source_product_code || raw.retailer_article_number)
+  const gtin = candidateDedupValue(raw.gtin || raw.ean)
+
+  if (source && externalCode) return `source:${source}|code:${externalCode}`
+  if (gtin) return `gtin:${gtin}`
+
+  const name = candidateDedupValue(candidate.candidateName || raw.candidate_name)
+  const brand = candidateDedupValue(candidate.brand || raw.candidate_brand)
+  const variant = candidateDedupValue(candidate.variant || raw.variant)
+
+  return `fallback:${name}|brand:${brand}|variant:${variant}`
+}
+
+function preferCandidate(current, next) {
+  if (!current) return next
+
+  if (next.isLinkedToCatalog && !current.isLinkedToCatalog) return next
+  if (current.isLinkedToCatalog && !next.isLinkedToCatalog) return current
+
+  const currentScore = Number(current.score || 0)
+  const nextScore = Number(next.score || 0)
+
+  if (nextScore > currentScore) return next
+
+  return current
+}
+
+function dedupeCandidates(candidates) {
+  const deduped = new Map()
+
+  candidates.forEach((candidate) => {
+    const key = candidateDedupKey(candidate)
+    deduped.set(key, preferCandidate(deduped.get(key), candidate))
+  })
+
+  return Array.from(deduped.values())
+}
+
 function isBackendLinkedCandidate(candidate) {
   // Single source of truth: de backend bepaalt of deze kandidaat de actieve koppeling is.
   return candidate?.is_linked_to_catalog === true
@@ -187,7 +232,8 @@ function buildReceiptItems(candidates) {
   })
 
   return Array.from(grouped.values()).map((item) => {
-    const sortedCandidates = [...item.candidates].sort((left, right) => Number(right.score || 0) - Number(left.score || 0))
+    const uniqueCandidates = dedupeCandidates(item.candidates)
+    const sortedCandidates = [...uniqueCandidates].sort((left, right) => Number(right.score || 0) - Number(left.score || 0))
     if (item.catalogLinked && sortedCandidates.length === 0) {
       sortedCandidates.push({
         id: `${item.id}-catalog-link`,

--- a/frontend/tests/e2e/external-databases.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases.frontend-regression.spec.js
@@ -42,4 +42,93 @@ test.describe('Externe databases frontend-regressie', () => {
     await expect(page.getByText(/Application error|Uncaught|TypeError|ReferenceError/i)).toHaveCount(0);
     await expectNoConsoleErrors(consoleErrors);
   });
+  test('Kandidatenlijst ondertabel ontdubbelt dubbele externe kandidaten', async ({ page }) => {
+    const consoleErrors = attachConsoleErrorCollector(page);
+
+    await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [
+            {
+              context_key: 'ctx-dedupe-regression',
+              receipt_line_id: 'receipt-line-dedupe-regression',
+              purchase_import_line_id: 'purchase-line-dedupe-regression',
+              receipt_line_text: 'Dubbele kandidaat regressietest',
+              retailer_code: 'lidl',
+              retailer_article_number: '12345',
+              gtin: '8710000000001',
+              quantity_label: '1 stuk',
+              price: 1.23,
+              candidate_id: 'candidate-low-score',
+              candidate_name: 'Rezzerv Test Mosterd',
+              candidate_brand: 'Testmerk',
+              external_source_name: 'Open Food Facts',
+              external_source_product_code: '8710000000001',
+              variant: 'Standaard',
+              score: 0.4,
+              candidate_status: 'candidate',
+              is_linked_to_catalog: false,
+              is_linkable_to_catalog: true,
+            },
+            {
+              context_key: 'ctx-dedupe-regression',
+              receipt_line_id: 'receipt-line-dedupe-regression',
+              purchase_import_line_id: 'purchase-line-dedupe-regression',
+              receipt_line_text: 'Dubbele kandidaat regressietest',
+              retailer_code: 'lidl',
+              retailer_article_number: '12345',
+              gtin: '8710000000001',
+              quantity_label: '1 stuk',
+              price: 1.23,
+              candidate_id: 'candidate-high-score',
+              candidate_name: 'Rezzerv Test Mosterd',
+              candidate_brand: 'Testmerk',
+              external_source_name: 'Open Food Facts',
+              external_source_product_code: '8710000000001',
+              variant: 'Standaard',
+              score: 0.8,
+              candidate_status: 'candidate',
+              is_linked_to_catalog: false,
+              is_linkable_to_catalog: true,
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.route('**/api/external-databases/receipt-items/ensure-candidates', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok' }),
+      });
+    });
+
+    await expectRouteLoads(page, '/externe-databases', [
+      'Externe databases',
+      'Bonartikelen',
+      'Kandidaten',
+      'Product',
+    ]);
+
+    const receiptTable = page.getByTestId('external-receipt-items-table');
+    await expect(receiptTable).toBeVisible();
+
+    await receiptTable.locator('tbody tr', { hasText: 'Dubbele kandidaat regressietest' }).dblclick();
+
+    const candidateTable = page.getByTestId('external-receipt-item-candidates-table');
+    await expect(candidateTable).toBeVisible();
+
+    const candidateRows = candidateTable.locator('tbody tr').filter({
+      has: page.locator('input[type="radio"]'),
+    });
+
+    await expect(candidateRows).toHaveCount(1);
+    await expect(candidateTable.getByText('0,800')).toBeVisible();
+    await expect(candidateTable.getByText('0,400')).toHaveCount(0);
+
+    await expectNoConsoleErrors(consoleErrors);
+  });
 });


### PR DESCRIPTION
## Samenvatting
- Ontdubbelt de onderste kandidatentabel per geselecteerd bonartikel.
- Voorkomt dat inhoudelijk dezelfde externe kandidaat meerdere keren zichtbaar is wanneer technische candidate-id's verschillen.
- Behoudt de gekoppelde kandidaat; als er geen gekoppelde kandidaat is, blijft de kandidaat met de hoogste score over.

## Scope
- Frontend-code: `frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx`.
- Regressietest: `frontend/tests/e2e/external-databases.frontend-regression.spec.js`.
- Geen backend-, schema-, parser- of fixturewijzigingen.
- Geen los nieuw document aangemaakt; documentatie hoort in de bestaande canonieke Rezzerv-documentenset te worden verwerkt.

## Validatie
- PO-test visueel uitgevoerd: geen doublures meer in de onderste kandidatentabel.
- Gerichte Externe databases-regressie: `3 passed`.
- Volledige frontend-regressie via `scripts/run-frontend-regression-report.ps1 -SkipDockerBuild`: groen, `8 passed`.

## PO-testinstructie
1. Open Externe databases / bonartikelenoverzicht.
2. Selecteer een bonartikel met meerdere externe kandidaten.
3. Controleer de onderste kandidatentabel.
4. Bevestig dat kandidaten met dezelfde bron + externe code niet dubbel zichtbaar zijn.
5. Controleer dat bij dubbele kandidaten de gekoppelde kandidaat of hoogste score zichtbaar blijft.