### PR TITLE
fix(external-databases): derive receipt identifiers from preferred candidate

### DIFF
--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -124,6 +124,31 @@ function bestCandidateForItem(candidates) {
   return candidates[0] || null
 }
 
+function candidateExternalCode(candidate) {
+  if (!candidate) return ''
+  const raw = candidate.raw || {}
+  return text(
+    candidate.externalCode ||
+    raw.external_source_product_code ||
+    raw.candidate_source_product_code ||
+    raw.source_product_code,
+    ''
+  )
+}
+
+function candidateExternalGtin(candidate) {
+  if (!candidate) return '-'
+  const raw = candidate.raw || {}
+  return gtinText(
+    raw.gtin ||
+    raw.ean ||
+    candidate.externalCode ||
+    raw.external_source_product_code ||
+    raw.candidate_source_product_code ||
+    raw.source_product_code
+  )
+}
+
 function isBackendLinkedCandidate(candidate) {
   // Single source of truth: de backend bepaalt of deze kandidaat de actieve koppeling is.
   return candidate?.is_linked_to_catalog === true
@@ -273,9 +298,13 @@ function buildReceiptItems(candidates) {
       })
     }
     const bestCandidate = bestCandidateForItem(sortedCandidates)
+    const externalArticleNumber = candidateExternalCode(bestCandidate)
+    const externalGtin = candidateExternalGtin(bestCandidate)
 
     return {
       ...item,
+      articleNumber: externalArticleNumber || '-',
+      gtin: externalGtin,
       candidateCount: sortedCandidates.length,
       candidates: sortedCandidates,
       bestCandidateName: text(bestCandidate?.candidateName, ''),

--- a/frontend/tests/e2e/external-databases.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases.frontend-regression.spec.js
@@ -118,6 +118,7 @@ test.describe('Externe databases frontend-regressie', () => {
 
     const receiptRow = receiptTable.locator('tbody tr', { hasText: 'Dubbele kandidaat regressietest' });
     await expect(receiptRow).toBeVisible();
+    await expect(receiptRow.locator('td').nth(4)).toHaveText('8710000000001');
     await expect(receiptRow.locator('td').nth(5)).toHaveText('8710000000001');
     await expect(receiptRow.locator('td').nth(9)).toContainText('Rezzerv Test Mosterd');
     await expect(receiptRow.locator('td').nth(10)).toContainText('0,800');
@@ -160,7 +161,7 @@ test.describe('Externe databases frontend-regressie', () => {
               candidate_name: 'Rezzerv Test Product',
               candidate_brand: 'Testmerk',
               external_source_name: 'Open Food Facts',
-              external_source_product_code: '8710000000001',
+              external_source_product_code: 'LIDL-00999',
               variant: 'Standaard',
               score: 0.9,
               candidate_status: 'candidate',
@@ -192,10 +193,100 @@ test.describe('Externe databases frontend-regressie', () => {
 
     const receiptRow = receiptTable.locator('tbody tr', { hasText: 'Winkelspecifieke code regressietest' });
     await expect(receiptRow).toBeVisible();
-    await expect(receiptRow.locator('td').nth(4)).toHaveText('12345');
+    await expect(receiptRow.locator('td').nth(4)).toHaveText('LIDL-00999');
     await expect(receiptRow.locator('td').nth(5)).toHaveText('-');
     await expect(receiptRow.locator('td').nth(9)).toContainText('Rezzerv Test Product');
     await expect(receiptRow.locator('td').nth(10)).toContainText('0,900');
+
+    await expectNoConsoleErrors(consoleErrors);
+  });
+
+  test('Bovenste tabel gebruikt gekoppelde kandidaat boven hoogste score', async ({ page }) => {
+    const consoleErrors = attachConsoleErrorCollector(page);
+
+    await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [
+            {
+              context_key: 'ctx-linked-wins-regression',
+              receipt_line_id: 'receipt-line-linked-wins-regression',
+              purchase_import_line_id: 'purchase-line-linked-wins-regression',
+              receipt_line_text: 'Gekoppelde kandidaat regressietest',
+              retailer_code: 'lidl',
+              retailer_article_number: '12345',
+              gtin: '',
+              quantity_label: '1 stuk',
+              price: 1.23,
+              candidate_id: 'candidate-highest-score-not-linked',
+              candidate_name: 'Niet gekoppelde hoogste score',
+              candidate_brand: 'Testmerk',
+              external_source_name: 'Open Food Facts',
+              external_source_product_code: 'LIDL-HIGH',
+              variant: 'Standaard',
+              score: 0.99,
+              candidate_status: 'candidate',
+              is_linked_to_catalog: false,
+              is_linkable_to_catalog: true,
+            },
+            {
+              context_key: 'ctx-linked-wins-regression',
+              receipt_line_id: 'receipt-line-linked-wins-regression',
+              purchase_import_line_id: 'purchase-line-linked-wins-regression',
+              receipt_line_text: 'Gekoppelde kandidaat regressietest',
+              retailer_code: 'lidl',
+              retailer_article_number: '12345',
+              gtin: '',
+              quantity_label: '1 stuk',
+              price: 1.23,
+              candidate_id: 'candidate-linked-lower-score',
+              candidate_name: 'Gekoppelde lagere score',
+              candidate_brand: 'Testmerk',
+              external_source_name: 'Open Food Facts',
+              external_source_product_code: 'LIDL-LINKED',
+              variant: 'Standaard',
+              score: 0.50,
+              candidate_status: 'linked_to_catalog',
+              is_linked_to_catalog: true,
+              is_linkable_to_catalog: false,
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.route('**/api/external-databases/receipt-items/ensure-candidates', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok' }),
+      });
+    });
+
+    await expectRouteLoads(page, '/externe-databases', [
+      'Externe databases',
+      'Bonartikelen',
+      'Kandidaten',
+      'Product',
+    ]);
+
+    const receiptTable = page.getByTestId('external-receipt-items-table');
+    await expect(receiptTable).toBeVisible();
+
+    const receiptRow = receiptTable.locator('tbody tr', { hasText: 'Gekoppelde kandidaat regressietest' });
+    await expect(receiptRow).toBeVisible();
+    await expect(receiptRow.locator('td').nth(4)).toHaveText('LIDL-LINKED');
+    await expect(receiptRow.locator('td').nth(5)).toHaveText('-');
+
+    await receiptRow.dblclick();
+
+    const candidateTable = page.getByTestId('external-receipt-item-candidates-table');
+    await expect(candidateTable).toBeVisible();
+    const linkedCandidateRow = candidateTable.locator('tbody tr', { hasText: 'Gekoppelde lagere score' });
+    await expect(linkedCandidateRow).toBeVisible();
+    await expect(linkedCandidateRow).toContainText('Gekoppeld');
 
     await expectNoConsoleErrors(consoleErrors);
   });


### PR DESCRIPTION
## Samenvatting
- Vult `Artikelnummer` in de bovenste bonartikelentabel vanuit de voorkeurskandidaat.
- Voorkeursregel: gekoppelde kandidaat eerst; als die ontbreekt de hoogste-score-kandidaat.
- Vult `GTIN / EAN` vanuit de externe kandidaatdata, maar alleen wanneer dit een geldige numerieke GTIN/EAN is van 8, 12, 13 of 14 cijfers.
- Voorkomt dat winkelspecifieke artikelcodes zoals `LIDL-00999` of `ART-...` in `GTIN / EAN` verschijnen.

## Scope
- Frontend-code: `frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx`.
- Regressietest: `frontend/tests/e2e/external-databases.frontend-regression.spec.js`.
- Geen backend-, schema-, parser- of fixturewijzigingen.

## Functionele regels
- `Artikelnummer` toont de externe code van de gekoppelde kandidaat.
- Als geen kandidaat gekoppeld is, toont `Artikelnummer` de externe code van de hoogste-score-kandidaat.
- `GTIN / EAN` toont alleen externe geldige EAN/GTIN-waarden.
- Winkelspecifieke artikelcodes blijven buiten `GTIN / EAN`.

## Validatie
- Gerichte Externe databases-regressie: `5 passed`.
- Volledige frontend-regressie via `scripts/run-frontend-regression-report.ps1 -SkipDockerBuild`: groen, `10 passed`.

## PO-testinstructie
1. Open Externe databases / bonartikelenoverzicht.
2. Selecteer een bonartikel met kandidaten.
3. Controleer dat `Artikelnummer` gelijk is aan de externe code van de gekoppelde kandidaat.
4. Als er geen gekoppelde kandidaat is, controleer dat `Artikelnummer` de externe code van de kandidaat met hoogste score toont.
5. Controleer dat `GTIN / EAN` alleen een echte numerieke EAN/GTIN toont en geen winkelspecifieke artikelcode.