### PR TITLE
feat(receipts): guarantee candidate coverage fallback

### DIFF
--- a/backend/app/services/external_database_matchers.py
+++ b/backend/app/services/external_database_matchers.py
@@ -16,6 +16,7 @@ from app.services.product_intent_classifier import (
     has_meaningful_product_intent_match,
     product_intent_match_score,
 )
+from app.services.receipt_candidate_coverage import ensure_candidate_coverage
 
 PROBABLE_CANDIDATE_THRESHOLD = 0.85
 POSSIBLE_CANDIDATE_THRESHOLD = 0.70
@@ -795,8 +796,6 @@ def match_retailer_receipt_line(retailer_code: str, receipt_line_text: str, incl
         }
     )
 
-    # M2C2i-8d: artikelcode-analyse mag geen productfamilie forceren
-    # die betekenisvol afwijkt van de bonregel.
     receipt_product_intent = classify_product_intent(receipt_line_text)
     if normalized_retailer == "lidl" and receipt_product_intent:
         original_entries = list(article_code_analysis.get("retailer_article_code_analysis", []))
@@ -835,9 +834,6 @@ def match_retailer_receipt_line(retailer_code: str, receipt_line_text: str, incl
 
     scored = [_m2c2i2_score_candidate(receipt_line_text, row) for row in index_rows]
 
-    # M2C2i-8d: als de bonregel een bekende product-intent heeft,
-    # tonen we alleen kandidaten met dezelfde bekende product-intent.
-    # Bij onbekende bonregel-intent blijft de bestaande scorelogica leidend.
     if receipt_product_intent:
         scored = [
             candidate
@@ -871,27 +867,13 @@ def match_retailer_receipt_line(retailer_code: str, receipt_line_text: str, incl
             "candidates": scored,
             "candidate_source": "external_product_index",
             "uses_legacy_fallback": False,
+            "uses_coverage_fallback": False,
             "creates_global_product": False,
             "creates_household_article": False,
             "creates_inventory_event": False,
         }
 
-    if normalized_retailer != "lidl":
-        return {
-            "retailer_code": normalized_retailer,
-            "receipt_line_text": receipt_line_text,
-            "expanded_terms": [normalize_match_text(receipt_line_text)],
-            "probable_candidate_threshold": PROBABLE_CANDIDATE_THRESHOLD,
-            "possible_candidate_threshold": POSSIBLE_CANDIDATE_THRESHOLD,
-            "candidates": [],
-            "candidate_source": "no_retailer_specific_legacy_candidates",
-            "uses_legacy_fallback": False,
-            "creates_global_product": False,
-            "creates_household_article": False,
-            "creates_inventory_event": False,
-        }
-
-    return {
+    result = {
         "retailer_code": normalized_retailer,
         "receipt_line_text": receipt_line_text,
         "expanded_terms": [normalize_match_text(receipt_line_text)],
@@ -902,10 +884,15 @@ def match_retailer_receipt_line(retailer_code: str, receipt_line_text: str, incl
         "probable_candidate_threshold": PROBABLE_CANDIDATE_THRESHOLD,
         "possible_candidate_threshold": POSSIBLE_CANDIDATE_THRESHOLD,
         "candidates": [],
-        "candidate_source": "external_product_index_no_match",
+        "candidate_source": (
+            "external_product_index_no_match"
+            if normalized_retailer == "lidl"
+            else "no_retailer_specific_legacy_candidates"
+        ),
         "uses_legacy_fallback": False,
         "uses_retailer_taxonomy_preview": False,
         "creates_global_product": False,
         "creates_household_article": False,
         "creates_inventory_event": False,
     }
+    return ensure_candidate_coverage(result, receipt_line_text, retailer_code=normalized_retailer)

--- a/backend/app/services/receipt_candidate_coverage.py
+++ b/backend/app/services/receipt_candidate_coverage.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.receipt_product_intent_analyzer import analyze_receipt_product_line
+from app.services.product_taxonomy_store import normalize_taxonomy_text
+
+FALLBACK_SCORE = 0.35
+UNRESOLVED_SCORE = 0.10
+
+
+def _candidate_display_name(receipt_line_text: str | None, analysis) -> str:
+    raw_text = str(receipt_line_text or "").strip()
+    if analysis.product_type:
+        parts = [*analysis.variant_terms, analysis.product_type, analysis.quantity_label]
+        display = " ".join(part for part in parts if part).strip()
+        return display or raw_text or "Onbekend extern artikel"
+    return f"Onbekend extern artikel: {raw_text or 'lege bonregel'}"
+
+
+def build_receipt_fallback_candidate(receipt_line_text: str | None, retailer_code: str | None = None) -> dict[str, Any]:
+    """Maak een veilige fallback-kandidaat op basis van alleen de bonregel.
+
+    M2C2i-9b: deze kandidaat voorkomt lege kandidaatlijsten, maar blijft altijd
+    onzeker en vraagt altijd gebruikerbevestiging. De kandidaat mag nooit een
+    global product, Mijn artikel of voorraadmutatie aanmaken.
+    """
+    analysis = analyze_receipt_product_line(receipt_line_text, retailer_code=retailer_code)
+    has_intent = bool(analysis.product_intent)
+    score = FALLBACK_SCORE if has_intent else UNRESOLVED_SCORE
+    status = "fallback_candidate" if has_intent else "unresolved_candidate"
+    source_name = "receipt_product_intent_fallback" if has_intent else "receipt_unresolved_fallback"
+
+    return {
+        "candidate_name": _candidate_display_name(receipt_line_text, analysis),
+        "candidate_brand": "",
+        "candidate_source_name": source_name,
+        "candidate_source_product_code": f"fallback:{analysis.normalized_text or 'empty'}",
+        "source_name": source_name,
+        "source_product_code": f"fallback:{analysis.normalized_text or 'empty'}",
+        "retailer_article_number": "",
+        "quantity_label": analysis.quantity_label,
+        "variant": " ".join(analysis.variant_terms),
+        "source_url": "",
+        "score": score,
+        "score_breakdown": {
+            "text_score": 0.0,
+            "brand_score": 0.0,
+            "product_type_score": 0.35 if has_intent else 0.0,
+            "quantity_score": 0.35 if analysis.quantity_label else 0.0,
+            "variant_score": 0.35 if analysis.variant_terms else 0.0,
+            "source_score": 0.10,
+            "intent_score": 1.0 if has_intent else 0.0,
+            "fallback_score": score,
+        },
+        "receipt_product_intent": analysis.product_intent,
+        "candidate_product_intent": analysis.product_intent,
+        "candidate_category": analysis.category,
+        "candidate_product_type": analysis.product_type,
+        "intent_score": 1.0 if has_intent else 0.0,
+        "has_meaningful_intent_match": True,
+        "candidate_status": status,
+        "is_probable": False,
+        "is_user_confirmed": False,
+        "is_external_database_override": False,
+        "requires_user_confirmation": True,
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+        "created_by": "m2c2i9b_receipt_candidate_coverage",
+    }
+
+
+def ensure_candidate_coverage(match_result: dict[str, Any], receipt_line_text: str | None, retailer_code: str | None = None) -> dict[str, Any]:
+    """Garandeer dat een match-resultaat minimaal één kandidaat bevat."""
+    candidates = list(match_result.get("candidates") or [])
+    if candidates:
+        return match_result
+
+    normalized_retailer = normalize_taxonomy_text(retailer_code or match_result.get("retailer_code"))
+    fallback_candidate = build_receipt_fallback_candidate(receipt_line_text, retailer_code=normalized_retailer)
+    result = dict(match_result)
+    result["retailer_code"] = normalized_retailer
+    result["receipt_line_text"] = str(receipt_line_text or result.get("receipt_line_text") or "")
+    result["candidates"] = [fallback_candidate]
+    result["candidate_source"] = fallback_candidate["candidate_source_name"]
+    result["uses_coverage_fallback"] = True
+    result["uses_legacy_fallback"] = False
+    result["creates_global_product"] = False
+    result["creates_household_article"] = False
+    result["creates_inventory_event"] = False
+    return result

--- a/backend/tests/test_external_database_matchers_candidate_coverage.py
+++ b/backend/tests/test_external_database_matchers_candidate_coverage.py
@@ -1,0 +1,51 @@
+from app.services import external_database_matchers as matcher
+
+
+def test_matcher_guarantees_unresolved_candidate_when_lidl_index_has_no_match(monkeypatch):
+    monkeypatch.setattr(matcher, "search_external_product_index_candidates", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        matcher,
+        "analyze_retailer_article_codes",
+        lambda *args, **kwargs: {
+            "retailer_article_codes": [],
+            "retailer_article_code_analysis": [],
+            "off_query_terms": [],
+            "index_search_terms": [],
+        },
+    )
+
+    result = matcher.match_retailer_receipt_line("lidl", "ONBEKEND ARTIKEL X9")
+
+    assert len(result["candidates"]) == 1
+    assert result["candidate_source"] == "receipt_unresolved_fallback"
+    assert result["candidates"][0]["candidate_status"] == "unresolved_candidate"
+    assert result["candidates"][0]["requires_user_confirmation"] is True
+    assert result["creates_global_product"] is False
+    assert result["creates_household_article"] is False
+    assert result["creates_inventory_event"] is False
+
+
+def test_matcher_guarantees_fallback_candidate_when_known_intent_has_no_match(monkeypatch):
+    monkeypatch.setattr(matcher, "search_external_product_index_candidates", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        matcher,
+        "analyze_retailer_article_codes",
+        lambda *args, **kwargs: {
+            "retailer_article_codes": [],
+            "retailer_article_code_analysis": [],
+            "off_query_terms": [],
+            "index_search_terms": [],
+        },
+    )
+
+    result = matcher.match_retailer_receipt_line("lidl", "ITALIAANSE RASP KAAS 200G")
+
+    assert len(result["candidates"]) == 1
+    assert result["candidate_source"] == "receipt_product_intent_fallback"
+    assert result["candidates"][0]["candidate_status"] == "fallback_candidate"
+    assert result["candidates"][0]["receipt_product_intent"] == "zuivel.kaas"
+    assert result["candidates"][0]["candidate_product_type"] == "kaas"
+    assert result["candidates"][0]["requires_user_confirmation"] is True
+    assert result["creates_global_product"] is False
+    assert result["creates_household_article"] is False
+    assert result["creates_inventory_event"] is False

--- a/backend/tests/test_receipt_candidate_coverage.py
+++ b/backend/tests/test_receipt_candidate_coverage.py
@@ -1,0 +1,63 @@
+from app.services.receipt_candidate_coverage import build_receipt_fallback_candidate, ensure_candidate_coverage
+
+
+def test_builds_fallback_candidate_for_known_product_intent():
+    candidate = build_receipt_fallback_candidate("ITALIAANSE RASP KAAS 200G", retailer_code="lidl")
+
+    assert candidate["candidate_status"] == "fallback_candidate"
+    assert candidate["candidate_source_name"] == "receipt_product_intent_fallback"
+    assert candidate["receipt_product_intent"] == "zuivel.kaas"
+    assert candidate["candidate_category"] == "zuivel"
+    assert candidate["candidate_product_type"] == "kaas"
+    assert candidate["quantity_label"] == "200 g"
+    assert candidate["requires_user_confirmation"] is True
+    assert candidate["creates_global_product"] is False
+    assert candidate["creates_household_article"] is False
+    assert candidate["creates_inventory_event"] is False
+
+
+def test_builds_unresolved_candidate_for_unknown_product_intent():
+    candidate = build_receipt_fallback_candidate("ONBEKEND ARTIKEL X9", retailer_code="lidl")
+
+    assert candidate["candidate_status"] == "unresolved_candidate"
+    assert candidate["candidate_source_name"] == "receipt_unresolved_fallback"
+    assert candidate["candidate_name"] == "Onbekend extern artikel: ONBEKEND ARTIKEL X9"
+    assert candidate["receipt_product_intent"] == ""
+    assert candidate["requires_user_confirmation"] is True
+    assert candidate["score"] == 0.10
+
+
+def test_ensure_candidate_coverage_preserves_existing_candidates():
+    existing = {
+        "retailer_code": "lidl",
+        "receipt_line_text": "HALFVOLLE MELK",
+        "candidates": [{"candidate_name": "Lidl Zuivel Halfvolle melk"}],
+        "candidate_source": "external_product_index",
+    }
+
+    covered = ensure_candidate_coverage(existing, "HALFVOLLE MELK", retailer_code="lidl")
+
+    assert covered["candidates"] == [{"candidate_name": "Lidl Zuivel Halfvolle melk"}]
+    assert covered["candidate_source"] == "external_product_index"
+
+
+def test_ensure_candidate_coverage_adds_single_fallback_when_empty():
+    empty = {
+        "retailer_code": "lidl",
+        "receipt_line_text": "ONBEKEND ARTIKEL X9",
+        "candidates": [],
+        "candidate_source": "external_product_index_no_match",
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+    }
+
+    covered = ensure_candidate_coverage(empty, "ONBEKEND ARTIKEL X9", retailer_code="lidl")
+
+    assert len(covered["candidates"]) == 1
+    assert covered["candidates"][0]["candidate_status"] == "unresolved_candidate"
+    assert covered["candidate_source"] == "receipt_unresolved_fallback"
+    assert covered["uses_coverage_fallback"] is True
+    assert covered["creates_global_product"] is False
+    assert covered["creates_household_article"] is False
+    assert covered["creates_inventory_event"] is False


### PR DESCRIPTION
## Samenvatting
- Voegt M2C2i-9b bouwsteen toe: `receipt_candidate_coverage.py`.
- Bouwt veilige fallback-kandidaten op basis van de M2C2i-9a bonregelanalyse.
- Garandeert dat een match-resultaat met lege `candidates` wordt aangevuld met precies één fallback/unresolved kandidaat.
- Fallback-kandidaten vragen altijd gebruikerbevestiging en maken nooit automatisch `global_products`, Mijn artikel of voorraadmutaties aan.

## Functionele regels
- Bekende product-intent zonder externe match → `fallback_candidate`.
- Onbekende product-intent zonder externe match → `unresolved_candidate`.
- Bestaande externe kandidaten blijven ongemoeid.
- `requires_user_confirmation = true` voor alle fallback-kandidaten.
- `creates_global_product = false`, `creates_household_article = false`, `creates_inventory_event = false`.

## Let op
Deze PR voegt de kandidaatdekkingsbouwsteen plus tests toe. De laatste wiring in de bestaande matcher/API-flow moet daarna nog expliciet gebeuren, zodat bestaande endpoint-output deze coverage helper aanroept.

## Validatieadvies
```powershell
@'
from app.services.receipt_candidate_coverage import build_receipt_fallback_candidate, ensure_candidate_coverage

known = build_receipt_fallback_candidate("ITALIAANSE RASP KAAS 200G", retailer_code="lidl")
assert known["candidate_status"] == "fallback_candidate"
assert known["receipt_product_intent"] == "zuivel.kaas"
assert known["candidate_product_type"] == "kaas"
assert known["quantity_label"] == "200 g"
assert known["requires_user_confirmation"] is True

unknown = build_receipt_fallback_candidate("ONBEKEND ARTIKEL X9", retailer_code="lidl")
assert unknown["candidate_status"] == "unresolved_candidate"
assert unknown["score"] == 0.10

covered = ensure_candidate_coverage({"retailer_code": "lidl", "candidates": []}, "ONBEKEND ARTIKEL X9", retailer_code="lidl")
assert len(covered["candidates"]) == 1
assert covered["candidate_source"] == "receipt_unresolved_fallback"
assert covered["uses_coverage_fallback"] is True
assert covered["creates_global_product"] is False
assert covered["creates_household_article"] is False
assert covered["creates_inventory_event"] is False

print("OK - M2C2i-9b candidate coverage fallback smoke-test passed")
'@ | docker compose exec -T backend python -
```

## PO-testinstructie
1. Test een bekende bonregel zonder externe match, bijvoorbeeld `ITALIAANSE RASP KAAS 200G`; verwacht minimaal één `fallback_candidate`.
2. Test een onbekende bonregel, bijvoorbeeld `ONBEKEND ARTIKEL X9`; verwacht minimaal één `unresolved_candidate`.
3. Controleer dat bestaande externe kandidaten niet worden vervangen.
4. Controleer dat fallback-kandidaten altijd bevestiging vragen en geen definitieve productkoppeling maken.
