### PR TITLE
feat(taxonomy): make receipt product analyzer data-driven

### DIFF
--- a/backend/app/data/product_taxonomy_seed.json
+++ b/backend/app/data/product_taxonomy_seed.json
@@ -1,5 +1,5 @@
 {
-  "version": "m2c2i10a-product-taxonomy-v3",
+  "version": "m2c2i10b-product-taxonomy-v1",
   "taxonomy": [
     {"intent_key": "zuivel.vla", "canonical_name": "Bananenvla", "category": "Zuivel", "product_type": "Vla", "synonyms": ["bananenvla", "vla banaan", "vla"]},
     {"intent_key": "broodbeleg.notenpasta", "canonical_name": "Pindakaas", "category": "Broodbeleg", "product_type": "Notenpasta", "synonyms": ["pindakaas", "notenpasta"]},
@@ -46,5 +46,30 @@
     {"retailer_code": "lidl", "receipt_term": "mexicaanse kruidenm", "normalized_term": "mexicaanse kruidenmix", "intent_key": "kruiden.specerijenmix", "confidence": 0.95, "source": "m2c2i_lidl_receipt_term"},
     {"retailer_code": "lidl", "receipt_term": "h volle melk", "normalized_term": "halfvolle melk", "intent_key": "zuivel.melk", "confidence": 0.90, "source": "m2c2i_lidl_receipt_term"},
     {"retailer_code": "lidl", "receipt_term": "aardappel zoet", "normalized_term": "zoete aardappel", "intent_key": "groente.zoete_aardappel", "confidence": 0.95, "source": "m2c2i_lidl_receipt_term"}
+  ],
+  "product_variant_terms": [
+    {"intent_key": "zuivel.kaas", "variant_term": "gouda", "variant_type": "kaassoort", "search_terms": ["gouda kaas"], "confidence": 0.95},
+    {"intent_key": "zuivel.kaas", "variant_term": "gerasp", "variant_type": "vorm", "search_terms": ["geraspte kaas", "gerasp kaas"], "confidence": 0.95},
+    {"intent_key": "zuivel.kaas", "variant_term": "geraspt", "variant_type": "vorm", "search_terms": ["geraspte kaas", "gerasp kaas"], "confidence": 0.95},
+    {"intent_key": "zuivel.kaas", "variant_term": "rasp", "variant_type": "vorm", "search_terms": ["rasp kaas", "geraspte kaas"], "confidence": 0.90},
+    {"intent_key": "zuivel.kaas", "variant_term": "jong belegen", "variant_type": "rijping", "search_terms": ["jong belegen kaas"], "confidence": 0.95},
+    {"intent_key": "zuivel.kaas", "variant_term": "belegen", "variant_type": "rijping", "search_terms": ["belegen kaas"], "confidence": 0.95},
+    {"intent_key": "zuivel.kaas", "variant_term": "oude", "variant_type": "rijping", "search_terms": ["oude kaas"], "confidence": 0.90},
+    {"intent_key": "zuivel.kaas", "variant_term": "jong", "variant_type": "rijping", "search_terms": ["jonge kaas", "jong kaas"], "confidence": 0.85},
+    {"intent_key": "zuivel.kaas", "variant_term": "jonge", "variant_type": "rijping", "search_terms": ["jonge kaas"], "confidence": 0.85},
+    {"intent_key": "zuivel.melk", "variant_term": "halfvol", "variant_type": "vetgehalte", "search_terms": ["halfvolle melk"], "confidence": 0.90},
+    {"intent_key": "zuivel.melk", "variant_term": "halfvolle", "variant_type": "vetgehalte", "search_terms": ["halfvolle melk"], "confidence": 0.90},
+    {"intent_key": "zuivel.melk", "variant_term": "vol", "variant_type": "vetgehalte", "search_terms": ["volle melk"], "confidence": 0.90},
+    {"intent_key": "zuivel.melk", "variant_term": "volle", "variant_type": "vetgehalte", "search_terms": ["volle melk"], "confidence": 0.90},
+    {"intent_key": "zuivel.yoghurt", "variant_term": "mager", "variant_type": "vetgehalte", "search_terms": ["magere yoghurt"], "confidence": 0.90},
+    {"intent_key": "zuivel.yoghurt", "variant_term": "magere", "variant_type": "vetgehalte", "search_terms": ["magere yoghurt"], "confidence": 0.90},
+    {"intent_key": "zuivel.creme_fraiche", "variant_term": "30", "variant_type": "vetgehalte", "search_terms": ["creme fraiche 30", "crème fraîche 30"], "confidence": 0.85},
+    {"intent_key": "pasta.droog", "variant_term": "linguine", "variant_type": "pastasoort", "search_terms": ["pasta linguine"], "confidence": 0.95},
+    {"intent_key": "bakkerij.brood", "variant_term": "volkoren", "variant_type": "graansoort", "search_terms": ["volkoren brood"], "confidence": 0.95},
+    {"intent_key": "eieren.ei", "variant_term": "vrije uitloop", "variant_type": "houderij", "search_terms": ["vrije uitloop eieren"], "confidence": 0.95},
+    {"intent_key": "saus.tomatensaus", "variant_term": "basilicum", "variant_type": "smaak", "search_terms": ["tomatensaus basilicum"], "confidence": 0.95},
+    {"intent_key": "snack.chips", "variant_term": "naturel", "variant_type": "smaak", "search_terms": ["naturel chips"], "confidence": 0.90},
+    {"intent_key": "drank.frisdrank", "variant_term": "zero", "variant_type": "suiker", "search_terms": ["cola zero", "frisdrank zero"], "confidence": 0.90},
+    {"intent_key": "drank.water", "variant_term": "bruisend", "variant_type": "koolzuur", "search_terms": ["bruisend water"], "confidence": 0.90}
   ]
 }

--- a/backend/app/services/product_taxonomy_store.py
+++ b/backend/app/services/product_taxonomy_store.py
@@ -58,7 +58,7 @@ def normalize_taxonomy_text(value: str | None) -> str:
     normalized = str(value or "").strip().lower()
     normalized = normalized.replace(".", " ")
     normalized = normalized.replace("-", " ")
-    normalized = re.sub(r"[^a-z0-9áéíóúàèìòùäëïöüçñ\s]+", " ", normalized, flags=re.IGNORECASE)
+    normalized = re.sub(r"[^a-z0-9áéíóúàèìòùäëïöüâêîôûçñ\s]+", " ", normalized, flags=re.IGNORECASE)
     return " ".join(normalized.split())
 
 

--- a/backend/app/services/product_taxonomy_store.py
+++ b/backend/app/services/product_taxonomy_store.py
@@ -82,7 +82,7 @@ def contains_taxonomy_term(normalized_text: str, normalized_term: str) -> bool:
 
 def _seed_payload() -> dict[str, Any]:
     if not TAXONOMY_SEED_PATH.exists():
-        return {"taxonomy": [], "retailer_receipt_terms": []}
+        return {"taxonomy": [], "retailer_receipt_terms": [], "product_variant_terms": []}
     return json.loads(TAXONOMY_SEED_PATH.read_text(encoding="utf-8"))
 
 
@@ -234,6 +234,8 @@ def ensure_product_taxonomy_seeded() -> dict[str, Any]:
             inserted_retailer_terms += 1
 
     load_taxonomy_rules.cache_clear()
+    load_taxonomy_metadata.cache_clear()
+    load_product_variant_terms.cache_clear()
     return {
         "ok": True,
         "taxonomy_rows": inserted_taxonomy,
@@ -324,3 +326,96 @@ def classify_product_intent_from_taxonomy(text_value: str | None, retailer_code:
             return str(rule.get("intent_key") or "")
 
     return ""
+
+
+def _fallback_metadata_from_seed() -> dict[str, dict[str, str]]:
+    metadata: dict[str, dict[str, str]] = {}
+    for item in _seed_payload().get("taxonomy") or []:
+        intent_key = str(item.get("intent_key") or "").strip()
+        if not intent_key:
+            continue
+        metadata[intent_key] = {
+            "intent_key": intent_key,
+            "canonical_name": str(item.get("canonical_name") or intent_key).strip(),
+            "category": normalize_taxonomy_text(item.get("category")),
+            "product_type": normalize_taxonomy_text(item.get("product_type")),
+        }
+    return metadata
+
+
+@lru_cache(maxsize=1)
+def load_taxonomy_metadata() -> dict[str, dict[str, str]]:
+    try:
+        ensure_product_taxonomy_seeded()
+        with engine.begin() as conn:
+            rows = conn.execute(
+                text(
+                    """
+                    SELECT intent_key, canonical_name, category, product_type
+                    FROM product_taxonomy
+                    WHERE COALESCE(is_active, 1) = 1
+                    """
+                )
+            ).mappings().all()
+        return {
+            str(row["intent_key"]): {
+                "intent_key": str(row["intent_key"]),
+                "canonical_name": str(row["canonical_name"] or row["intent_key"]),
+                "category": normalize_taxonomy_text(row["category"]),
+                "product_type": normalize_taxonomy_text(row["product_type"]),
+            }
+            for row in rows
+            if row.get("intent_key")
+        }
+    except Exception:
+        return _fallback_metadata_from_seed()
+
+
+def get_taxonomy_metadata_for_intent(intent_key: str | None) -> dict[str, str]:
+    key = str(intent_key or "").strip()
+    if not key:
+        return {"intent_key": "", "canonical_name": "", "category": "", "product_type": ""}
+    return load_taxonomy_metadata().get(
+        key,
+        {"intent_key": key, "canonical_name": key, "category": "", "product_type": ""},
+    )
+
+
+def _variant_rules_from_seed(intent_key: str | None = None) -> list[dict[str, Any]]:
+    requested_intent = str(intent_key or "").strip()
+    rules: list[dict[str, Any]] = []
+    for item in _seed_payload().get("product_variant_terms") or []:
+        item_intent = str(item.get("intent_key") or "").strip()
+        if requested_intent and item_intent != requested_intent:
+            continue
+        variant_term = str(item.get("variant_term") or "").strip()
+        normalized_variant = normalize_taxonomy_text(variant_term)
+        if not item_intent or not normalized_variant:
+            continue
+        search_terms = [
+            normalize_taxonomy_text(search_term)
+            for search_term in (item.get("search_terms") or [])
+            if normalize_taxonomy_text(search_term)
+        ]
+        rules.append({
+            "intent_key": item_intent,
+            "variant_term": variant_term,
+            "normalized_variant_term": normalized_variant,
+            "variant_type": normalize_taxonomy_text(item.get("variant_type")),
+            "search_terms": search_terms,
+            "confidence": float(item.get("confidence") or 1.0),
+            "source": str(item.get("source") or "taxonomy_seed"),
+        })
+    return sorted(
+        rules,
+        key=lambda row: (
+            -len(str(row.get("normalized_variant_term") or "").split()),
+            -len(str(row.get("normalized_variant_term") or "")),
+            str(row.get("normalized_variant_term") or ""),
+        ),
+    )
+
+
+@lru_cache(maxsize=64)
+def load_product_variant_terms(intent_key: str | None = None) -> tuple[dict[str, Any], ...]:
+    return tuple(_variant_rules_from_seed(intent_key))

--- a/backend/app/services/receipt_product_intent_analyzer.py
+++ b/backend/app/services/receipt_product_intent_analyzer.py
@@ -2,9 +2,15 @@ from __future__ import annotations
 
 import re
 from dataclasses import asdict, dataclass
+from typing import Any
 
 from app.services.product_intent_classifier import classify_product_intent
-from app.services.product_taxonomy_store import contains_taxonomy_term, normalize_taxonomy_text
+from app.services.product_taxonomy_store import (
+    contains_taxonomy_term,
+    get_taxonomy_metadata_for_intent,
+    load_product_variant_terms,
+    normalize_taxonomy_text,
+)
 
 
 QUANTITY_PATTERN = re.compile(
@@ -12,106 +18,7 @@ QUANTITY_PATTERN = re.compile(
     flags=re.IGNORECASE,
 )
 
-PRODUCT_TYPE_BY_INTENT_PREFIX = {
-    "zuivel.melk": "melk",
-    "zuivel.yoghurt": "yoghurt",
-    "zuivel.vla": "vla",
-    "zuivel.kaas": "kaas",
-    "zuivel.creme_fraiche": "crème fraîche",
-    "fruit.banaan": "banaan",
-    "fruit.appel": "appel",
-    "bakkerij.brood": "brood",
-    "groente.spinazie": "spinazie",
-    "groente.courgette": "courgette",
-    "groente.zoete_aardappel": "zoete aardappel",
-    "groente.aardappel": "aardappel",
-    "eieren.ei": "ei",
-    "graan.rijst": "rijst",
-    "saus.tomatensaus": "tomatensaus",
-    "groente.tomaat": "tomaat",
-    "maaltijd.pizza": "pizza",
-    "kruiden.specerijenmix": "specerijenmix",
-    "vleeswaren.ham": "ham",
-    "vleeswaren.kipfilet": "kipfilet",
-    "drank.frisdrank": "frisdrank",
-    "pasta.droog": "pasta",
-    "snack.chips": "chips",
-    "ontbijt.muesli": "muesli",
-    "ontbijt.havermout": "havermout",
-    "drank.water": "water",
-}
-
-CATEGORY_BY_INTENT_PREFIX = {
-    "zuivel.": "zuivel",
-    "fruit.": "fruit",
-    "bakkerij.": "bakkerij",
-    "groente.": "groente",
-    "eieren.": "eieren",
-    "graan.": "graan",
-    "saus.": "saus",
-    "maaltijd.": "maaltijd",
-    "kruiden.": "kruiden",
-    "vleeswaren.": "vleeswaren",
-    "drank.": "drank",
-    "pasta.": "pasta",
-    "snack.": "snack",
-    "ontbijt.": "ontbijt",
-}
-
-VARIANT_TERMS = (
-    "gouda",
-    "gerasp",
-    "geraspt",
-    "rasp",
-    "raspkaas",
-    "italiaans",
-    "mozzarella",
-    "parmezaan",
-    "grana padano",
-    "emmentaler",
-    "jong belegen",
-    "jong",
-    "jonge",
-    "belegen",
-    "oud",
-    "48",
-    "30",
-    "halfvol",
-    "halfvolle",
-    "vol",
-    "volle",
-    "mager",
-    "magere",
-    "naturel",
-    "paprika",
-    "mild",
-    "hot",
-    "zero",
-    "bruisend",
-    "ongezouten",
-    "volkoren",
-    "vrije uitloop",
-    "diepvries",
-    "basilicum",
-    "linguine",
-)
-
-STOPWORDS = {
-    "de",
-    "het",
-    "een",
-    "en",
-    "of",
-    "met",
-    "voor",
-    "van",
-    "lidl",
-    "ah",
-    "aldi",
-    "jumbo",
-    "plus",
-    "picnic",
-}
+STOPWORDS = {"de", "het", "een", "en", "of", "met", "voor", "van"}
 
 
 @dataclass(frozen=True)
@@ -128,17 +35,6 @@ class ReceiptProductAnalysis:
     quantity_label: str
     searchable_terms: list[str]
     requires_user_confirmation: bool
-
-
-def _category_for_intent(intent_key: str) -> str:
-    for prefix, category in CATEGORY_BY_INTENT_PREFIX.items():
-        if intent_key.startswith(prefix):
-            return category
-    return ""
-
-
-def _product_type_for_intent(intent_key: str) -> str:
-    return PRODUCT_TYPE_BY_INTENT_PREFIX.get(intent_key, "")
 
 
 def _extract_quantity(normalized_text: str) -> tuple[str, str, str]:
@@ -159,13 +55,13 @@ def _extract_quantity(normalized_text: str) -> tuple[str, str, str]:
     return amount, normalized_unit, f"{amount} {normalized_unit}"
 
 
-def _extract_variant_terms(normalized_text: str) -> list[str]:
-    variants: list[str] = []
-    for term in VARIANT_TERMS:
-        normalized_term = normalize_taxonomy_text(term)
+def _extract_variant_matches(normalized_text: str, product_intent: str) -> list[dict[str, Any]]:
+    matches: list[dict[str, Any]] = []
+    for rule in load_product_variant_terms(product_intent or None):
+        normalized_term = str(rule.get("normalized_variant_term") or "")
         if normalized_term and contains_taxonomy_term(normalized_text, normalized_term):
-            variants.append(normalized_term)
-    return variants
+            matches.append(dict(rule))
+    return matches
 
 
 def _deduplicate(values: list[str]) -> list[str]:
@@ -180,26 +76,55 @@ def _deduplicate(values: list[str]) -> list[str]:
     return result
 
 
-def analyze_receipt_product_line(receipt_line_text: str | None, retailer_code: str | None = None) -> ReceiptProductAnalysis:
-    raw_text = str(receipt_line_text or "").strip()
-    normalized_text = normalize_taxonomy_text(raw_text)
-    normalized_retailer = normalize_taxonomy_text(retailer_code)
-    product_intent = classify_product_intent(normalized_text, retailer_code=normalized_retailer)
-    category = _category_for_intent(product_intent)
-    product_type = _product_type_for_intent(product_intent)
-    quantity_amount, quantity_unit, quantity_label = _extract_quantity(normalized_text)
-    variant_terms = _extract_variant_terms(normalized_text)
-
+def _build_searchable_terms(
+    normalized_text: str,
+    product_intent: str,
+    category: str,
+    product_type: str,
+    variant_matches: list[dict[str, Any]],
+    quantity_label: str,
+) -> list[str]:
     tokens = [token for token in normalized_text.split() if len(token) >= 3 and token not in STOPWORDS]
-    searchable_terms = _deduplicate([
+    variant_terms = [str(match.get("normalized_variant_term") or "") for match in variant_matches]
+    variant_search_terms: list[str] = []
+
+    for match in variant_matches:
+        variant = str(match.get("normalized_variant_term") or "")
+        variant_search_terms.extend(str(term or "") for term in (match.get("search_terms") or []))
+        if variant and product_type and not contains_taxonomy_term(variant, product_type):
+            variant_search_terms.append(f"{variant} {product_type}")
+
+    return _deduplicate([
         normalized_text,
         product_intent,
         category,
         product_type,
         *variant_terms,
+        *variant_search_terms,
         quantity_label,
         *tokens,
     ])
+
+
+def analyze_receipt_product_line(receipt_line_text: str | None, retailer_code: str | None = None) -> ReceiptProductAnalysis:
+    raw_text = str(receipt_line_text or "").strip()
+    normalized_text = normalize_taxonomy_text(raw_text)
+    normalized_retailer = normalize_taxonomy_text(retailer_code)
+    product_intent = classify_product_intent(normalized_text, retailer_code=normalized_retailer)
+    taxonomy_metadata = get_taxonomy_metadata_for_intent(product_intent)
+    category = taxonomy_metadata.get("category") or ""
+    product_type = taxonomy_metadata.get("product_type") or ""
+    quantity_amount, quantity_unit, quantity_label = _extract_quantity(normalized_text)
+    variant_matches = _extract_variant_matches(normalized_text, product_intent)
+    variant_terms = _deduplicate([str(match.get("normalized_variant_term") or "") for match in variant_matches])
+    searchable_terms = _build_searchable_terms(
+        normalized_text=normalized_text,
+        product_intent=product_intent,
+        category=category,
+        product_type=product_type,
+        variant_matches=variant_matches,
+        quantity_label=quantity_label,
+    )
 
     return ReceiptProductAnalysis(
         raw_text=raw_text,

--- a/backend/tests/test_product_taxonomy_receipt_terms_m2c2i10a.py
+++ b/backend/tests/test_product_taxonomy_receipt_terms_m2c2i10a.py
@@ -1,3 +1,6 @@
+import inspect
+
+import app.services.receipt_product_intent_analyzer as receipt_product_intent_analyzer
 from app.services.product_intent_classifier import classify_product_intent
 from app.services.receipt_product_intent_analyzer import analyze_receipt_product_line
 
@@ -14,6 +17,15 @@ def test_lidl_gouda_belegen_gerasp_is_recognized_as_cheese():
     assert "oud" not in analysis.variant_terms
 
 
+def test_lidl_gouda_belegen_gerasp_builds_enriched_searchable_terms():
+    analysis = analyze_receipt_product_line("Gouda belegen gerasp", retailer_code="lidl")
+
+    assert "kaas" in analysis.searchable_terms
+    assert "gouda kaas" in analysis.searchable_terms
+    assert "belegen kaas" in analysis.searchable_terms
+    assert "geraspte kaas" in analysis.searchable_terms
+
+
 def test_lidl_creme_fraiche_receipt_line_is_recognized():
     assert classify_product_intent("Crème fraiche 30%", retailer_code="lidl") == "zuivel.creme_fraiche"
     assert classify_product_intent("Creme fraiche 30%", retailer_code="lidl") == "zuivel.creme_fraiche"
@@ -26,6 +38,25 @@ def test_lidl_creme_frache_ocr_receipt_line_is_recognized():
     assert classify_product_intent("Cr me frache 30%", retailer_code="lidl") == "zuivel.creme_fraiche"
 
 
+def test_lidl_creme_frache_analysis_uses_taxonomy_metadata():
+    analysis = analyze_receipt_product_line("Crème frache 30%", retailer_code="lidl")
+
+    assert analysis.product_intent == "zuivel.creme_fraiche"
+    assert analysis.category == "zuivel"
+    assert analysis.product_type == "crème fraîche"
+    assert "30" in analysis.variant_terms
+    assert "creme fraiche 30" in analysis.searchable_terms
+    assert analysis.requires_user_confirmation is False
+
+
 def test_lidl_receipt_terms_for_rice_and_pasta_are_recognized():
     assert classify_product_intent("Duurzame basmati rijst", retailer_code="lidl") == "graan.rijst"
     assert classify_product_intent("Gebronsde pasta linguin", retailer_code="lidl") == "pasta.droog"
+
+
+def test_receipt_product_analyzer_has_no_hardcoded_taxonomy_maps():
+    source = inspect.getsource(receipt_product_intent_analyzer)
+
+    assert "PRODUCT_TYPE_BY_INTENT_PREFIX" not in source
+    assert "CATEGORY_BY_INTENT_PREFIX" not in source
+    assert "VARIANT_TERMS" not in source

--- a/docs/architecture/.m2c2i-10b-check-placeholder
+++ b/docs/architecture/.m2c2i-10b-check-placeholder
@@ -1,0 +1,1 @@
+placeholder

--- a/docs/architecture/.m2c2i-10b-check-placeholder
+++ b/docs/architecture/.m2c2i-10b-check-placeholder
@@ -1,1 +1,0 @@
-placeholder

--- a/docs/architecture/M2C2i-10b-data-driven-taxonomy.md
+++ b/docs/architecture/M2C2i-10b-data-driven-taxonomy.md
@@ -1,0 +1,68 @@
+# M2C2i-10b — Datagedreven taxonomie en kandidaatselectie
+
+## Doel
+
+Productkennis voor Externe databases, Uitpakken en kandidaatselectie wordt als data beheerd, niet als programmacode.
+
+Deze stap verwijdert hardcoded categorie-, producttype- en variantkennis uit de receipt product analyzer. De analyzer gebruikt voortaan de taxonomie- en variantdata uit `backend/app/data/product_taxonomy_seed.json` en de generieke taxonomystore.
+
+## Geraakt
+
+- `backend/app/data/product_taxonomy_seed.json`
+- `backend/app/services/product_taxonomy_store.py`
+- `backend/app/services/receipt_product_intent_analyzer.py`
+- `backend/tests/test_product_taxonomy_receipt_terms_m2c2i10a.py`
+
+## Niet geraakt
+
+- Geen frontendwijziging
+- Geen UI-layoutwijziging
+- Geen Open Food Facts live lookup
+- Geen automatische global_product-aanmaak
+- Geen household_article-mutatie
+- Geen inventory_event-mutatie
+- Geen release-zip
+
+## Functionele regels
+
+- Categorie komt uit `product_taxonomy.category` / seeddata.
+- Producttype komt uit `product_taxonomy.product_type` / seeddata.
+- Varianttermen komen uit `product_variant_terms` in seeddata.
+- Searchable terms worden generiek opgebouwd uit ruwe bontekst, intent, categorie, producttype, varianttermen, variantzoektermen, hoeveelheid en tokens.
+- Fallback- en unresolved-kandidaten blijven beslisondersteuning en mogen geen definitieve product- of voorraadmutatie veroorzaken.
+
+## Acceptatiecriteria
+
+- `Gouda belegen gerasp` wordt herkend als `zuivel.kaas`.
+- `Crème frache 30%` wordt herkend als `zuivel.creme_fraiche`.
+- `Gouda belegen gerasp` levert verrijkte zoektermen op zoals `gouda kaas`, `belegen kaas`, `geraspte kaas` en `kaas`.
+- De receipt product analyzer bevat geen `PRODUCT_TYPE_BY_INTENT_PREFIX`, `CATEGORY_BY_INTENT_PREFIX` of `VARIANT_TERMS` meer.
+- De frontend-regressie voor Kassa, Uitpakken en Externe databases blijft groen.
+
+## Validatie
+
+```powershell
+cd C:\Users\Gebruiker\Rezzerv_Github
+
+git switch feature/m2c2i10b-data-driven-taxonomy
+
+docker compose up -d --build
+Invoke-RestMethod http://localhost:8011/api/health
+
+@'
+from app.services.receipt_product_intent_analyzer import analyze_receipt_product_line
+
+cases = [
+    "Gouda belegen gerasp",
+    "Crème frache 30%",
+]
+for text in cases:
+    analysis = analyze_receipt_product_line(text, retailer_code="lidl")
+    print(text, "->", analysis)
+'@ | docker compose exec -T backend python -
+
+# indien pytest beschikbaar is:
+docker compose exec -T backend pytest backend/tests/test_product_taxonomy_receipt_terms_m2c2i10a.py
+
+.\scripts\run-frontend-regression-report.ps1 -SkipDockerBuild
+```


### PR DESCRIPTION
## Samenvatting
- Verplaatst productvariantkennis uit `receipt_product_intent_analyzer.py` naar `product_taxonomy_seed.json` onder `product_variant_terms`.
- Laat de analyzer categorie en producttype ophalen via de taxonomystore in plaats van via hardcoded Python-maps.
- Bouwt `searchable_terms` generiek op uit product-intent, taxonomie, varianttermen, variantzoektermen, hoeveelheid en teksttokens.
- Breidt backendtests uit voor `Gouda belegen gerasp`, `Crème frache 30%` en verrijkte zoektermen zoals `gouda kaas`, `belegen kaas`, `geraspte kaas` en `kaas`.
- Voegt documentatie toe voor de M2C2i-10b-a scope.

## Niet gewijzigd
- Geen frontendwijziging.
- Geen UI-layoutwijziging.
- Geen Open Food Facts live lookup.
- Geen automatische `global_product`-, `household_article`-, `product_enrichment`- of `inventory_event`-mutatie.
- Geen release-zip.

## Architectuurregel
Deze PR ondersteunt het principe: **Productkennis is data, geen code**. Programmacode voert alleen generieke normalisatie, lookup, matching en searchable-term-opbouw uit.

## Validatieadvies lokaal
```powershell
cd C:\Users\Gebruiker\Rezzerv_Github

git fetch origin
git switch feature/m2c2i10b-data-driven-taxonomy

docker compose up -d --build
Invoke-RestMethod http://localhost:8011/api/health

@'
from app.services.receipt_product_intent_analyzer import analyze_receipt_product_line

cases = [
    "Gouda belegen gerasp",
    "Crème frache 30%",
]
for text in cases:
    analysis = analyze_receipt_product_line(text, retailer_code="lidl")
    print(text)
    print("  intent:", analysis.product_intent)
    print("  category:", analysis.category)
    print("  product_type:", analysis.product_type)
    print("  variants:", analysis.variant_terms)
    print("  searchable_terms:", analysis.searchable_terms)
'@ | docker compose exec -T backend python -

# indien pytest beschikbaar is:
docker compose exec -T backend pytest backend/tests/test_product_taxonomy_receipt_terms_m2c2i10a.py

.\scripts\run-frontend-regression-report.ps1 -SkipDockerBuild
```

## Verwacht resultaat
- `Gouda belegen gerasp -> zuivel.kaas`.
- `Crème frache 30% -> zuivel.creme_fraiche`.
- Searchable terms bevatten o.a. `gouda kaas`, `belegen kaas`, `geraspte kaas` en `kaas`.
- Frontend-regressie blijft groen; huidige main-baseline was lokaal 10/10 passed vóór deze PR.