### PR TITLE
feat(external-db): separate fallback candidates from linkable matches

### DIFF
--- a/docs/architecture/M2C2i-10b-b-fallback-status-contract.md
+++ b/docs/architecture/M2C2i-10b-b-fallback-status-contract.md
@@ -1,0 +1,80 @@
+# M2C2i-10b-b — Fallbackstatus en kandidaatpresentatie
+
+## Doel
+
+Fallback- en unresolved-regels mogen niet meer aanvoelen als gewone externe kandidaten.
+
+Een externe kandidaat is beslisondersteuning. Een fallback is alleen een informatieve regel waarmee Rezzerv uitlegt dat er geen echte externe match is gevonden. Een fallback mag daarom niet rechtstreeks koppelbaar zijn aan de artikelcatalogus.
+
+## Scope
+
+Deze stap borgt het contract tussen backend en frontend voor kandidaatstatussen in Externe databases.
+
+### Statusgroepen
+
+| Technische status | Gebruikerslabel | Koppelbaar | Telt als externe kandidaat |
+|---|---|---:|---:|
+| `linked_to_catalog` | Gekoppeld | nee | ja |
+| `user_confirmed` | Kandidaat | ja, als backend dit toestaat | ja |
+| `probable_candidate` | Waarschijnlijke kandidaat | ja, als backend dit toestaat | ja |
+| `weak_candidate` | Lage zekerheid | ja, als backend dit toestaat | ja |
+| `candidate` | Kandidaat | ja, als backend dit toestaat | ja |
+| `fallback_candidate` | Geen externe match | nee | nee |
+| `receipt_fallback_candidate` | Geen externe match | nee | nee |
+| `receipt_unresolved_fallback` | Geen externe match | nee | nee |
+| `unresolved_fallback` | Geen externe match | nee | nee |
+| `unresolved` | Geen externe match | nee | nee |
+| `no_external_match` | Geen externe match | nee | nee |
+
+## Functionele regels
+
+1. Fallbackregels blijven zichtbaar als uitleg, maar niet als normale externe match.
+2. Fallbackregels mogen niet geselecteerd of gekoppeld worden.
+3. Een bonartikel met alleen fallbackregels toont bovenin geen beste kandidaat en score.
+4. De kolom `Externe kandidaten` telt alleen echte externe matches.
+5. De detailtabel mag fallbackregels tonen met label `Geen externe match`.
+6. De backend blijft leidend voor `is_linked_to_catalog` en `is_linkable_to_catalog`.
+7. Geen enkele statuswijziging mag automatisch `global_products`, `product_enrichments`, `household_articles` of `inventory_events` aanmaken.
+
+## Acceptatiecriteria
+
+- Een echte kandidaat blijft zichtbaar en koppelbaar wanneer `is_linkable_to_catalog=true`.
+- Een gekoppelde kandidaat blijft zichtbaar als `Gekoppeld`.
+- Een fallbackstatus zoals `receipt_unresolved_fallback` toont `Geen externe match`.
+- Een fallbackstatus is niet koppelbaar.
+- Een fallbackstatus telt niet mee als externe kandidaat.
+- De bestaande Externe-databases-regressies blijven groen.
+
+## Voorgestelde technische wijziging
+
+De kleinste veilige wijziging zit in `frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx`:
+
+- fallbackstatussen centraal normaliseren;
+- `candidateStatusLabel()` uitbreiden;
+- fallbackregels markeren als `isFallbackCandidate`;
+- fallbackregels niet meetellen in `candidateCount`;
+- `bestCandidateForItem()` alleen echte externe matches laten kiezen;
+- radioselectie uitschakelen voor niet-koppelbare fallbackregels;
+- Playwright-regressie toevoegen met een `receipt_unresolved_fallback` fixture.
+
+## Validatie na implementatie
+
+```powershell
+cd C:\Users\Gebruiker\Rezzerv_Github
+
+git fetch origin
+git switch feature/m2c2i10b-fallback-status-contract
+
+git branch --show-current
+git status --short
+git rev-parse --short HEAD
+
+docker compose down
+docker compose up -d --build
+
+Start-Sleep -Seconds 90
+
+Invoke-RestMethod http://localhost:8011/api/health
+
+.\scripts\run-frontend-regression-report.ps1 -SkipDockerBuild
+```

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -5,6 +5,15 @@ import { fetchJsonWithAuth } from '../../lib/authSession'
 
 const PAGE_SIZE = 10
 
+const FALLBACK_CANDIDATE_STATUSES = new Set([
+  'fallback_candidate',
+  'receipt_fallback_candidate',
+  'receipt_unresolved_fallback',
+  'unresolved_fallback',
+  'unresolved',
+  'no_external_match',
+])
+
 function text(value, fallback = '-') {
   const normalized = String(value || '').trim()
   return normalized || fallback
@@ -48,16 +57,34 @@ function retailerLabel(value) {
   return labels[key] || normalized
 }
 
+function normalizeCandidateStatus(value) {
+  return String(value || '').trim().toLowerCase()
+}
+
+function isFallbackCandidateStatus(value) {
+  return FALLBACK_CANDIDATE_STATUSES.has(normalizeCandidateStatus(value))
+}
+
 function candidateStatusLabel(value) {
-  const normalized = String(value || '').trim().toLowerCase()
+  const normalized = normalizeCandidateStatus(value)
   const labels = {
     linked_to_catalog: 'Gekoppeld',
     user_confirmed: 'Bevestigd',
     probable_candidate: 'Waarschijnlijke kandidaat',
     weak_candidate: 'Lage zekerheid',
     candidate: 'Kandidaat',
+    fallback_candidate: 'Geen externe match',
+    receipt_fallback_candidate: 'Geen externe match',
+    receipt_unresolved_fallback: 'Geen externe match',
+    unresolved_fallback: 'Geen externe match',
+    unresolved: 'Geen externe match',
+    no_external_match: 'Geen externe match',
   }
   return labels[normalized] || text(value)
+}
+
+function candidateRawStatus(candidate) {
+  return normalizeCandidateStatus(candidate?.candidate_status || candidate?.status)
 }
 
 function rowKey(item) {
@@ -121,7 +148,7 @@ function dedupeCandidates(candidates) {
 function bestCandidateForItem(candidates) {
   const linkedCandidate = candidates.find((candidate) => candidate.isLinkedToCatalog)
   if (linkedCandidate) return linkedCandidate
-  return candidates[0] || null
+  return candidates.find((candidate) => !candidate.isFallbackCandidate) || null
 }
 
 function candidateExternalCode(candidate) {
@@ -160,7 +187,8 @@ function candidateStatusFromBackend(candidate, linked) {
   const rawLabel = text(candidate.status_label, '')
   if (rawLabel && rawLabel.toLowerCase() !== 'gekoppeld') return rawLabel
 
-  const rawStatus = String(candidate.candidate_status || candidate.status || '').trim().toLowerCase()
+  const rawStatus = candidateRawStatus(candidate)
+  if (isFallbackCandidateStatus(rawStatus)) return candidateStatusLabel(rawStatus)
   if (rawStatus === 'linked_to_catalog' || rawStatus === 'user_confirmed') return 'Kandidaat'
 
   return candidateStatusLabel(candidate.candidate_status || candidate.status)
@@ -174,6 +202,9 @@ function buildReceiptItems(candidates) {
     const isPlaceholder = Boolean(candidate.is_receipt_item_placeholder)
     const linked = isBackendLinkedCandidate(candidate)
 
+    const rawStatus = candidateRawStatus(candidate)
+    const isFallbackCandidate = isFallbackCandidateStatus(rawStatus)
+
     const candidateItem = {
       id: candidateKey(candidate),
       candidateName: text(candidate.candidate_name),
@@ -183,9 +214,11 @@ function buildReceiptItems(candidates) {
       variant: text(candidate.variant),
       score: candidate.score,
       status: candidateStatusFromBackend(candidate, linked),
+      rawStatus,
       catalogLinked: linked,
       isLinkedToCatalog: linked,
-      isLinkableToCatalog: Boolean(candidate.is_linkable_to_catalog) && !linked,
+      isFallbackCandidate,
+      isLinkableToCatalog: Boolean(candidate.is_linkable_to_catalog) && !linked && !isFallbackCandidate,
       isExistingLinkForReceiptItem: linked,
       canonicalCatalogProductId: text(candidate.canonical_catalog_product_id, ''),
       raw: candidate,
@@ -205,6 +238,7 @@ function buildReceiptItems(candidates) {
       price: candidate.price ?? '-',
       amount: '-',
       candidateCount: 0,
+      hasFallbackCandidate: false,
       catalogLinked: false,
       linkedGlobalProductId: '',
       linkedProductIdentityId: '',
@@ -215,13 +249,17 @@ function buildReceiptItems(candidates) {
     }
 
     if (!isPlaceholder) {
-      current.candidateCount += 1
+      if (!candidateItem.isFallbackCandidate) current.candidateCount += 1
+      if (candidateItem.isFallbackCandidate) current.hasFallbackCandidate = true
       current.candidates.push(candidateItem)
     }
 
     if (isPlaceholder && Array.isArray(candidate.candidates)) {
       candidate.candidates.forEach((nestedCandidate) => {
         const nestedLinked = isBackendLinkedCandidate(nestedCandidate)
+        const nestedRawStatus = candidateRawStatus(nestedCandidate)
+        const nestedIsFallbackCandidate = isFallbackCandidateStatus(nestedRawStatus)
+
         const nestedItem = {
           id: candidateKey(nestedCandidate),
           candidateName: text(nestedCandidate.candidate_name),
@@ -231,15 +269,18 @@ function buildReceiptItems(candidates) {
           variant: text(nestedCandidate.variant),
           score: nestedCandidate.score,
           status: candidateStatusFromBackend(nestedCandidate, nestedLinked),
+          rawStatus: nestedRawStatus,
           catalogLinked: nestedLinked,
           isLinkedToCatalog: nestedLinked,
-          isLinkableToCatalog: Boolean(nestedCandidate.is_linkable_to_catalog) && !nestedLinked,
+          isFallbackCandidate: nestedIsFallbackCandidate,
+          isLinkableToCatalog: Boolean(nestedCandidate.is_linkable_to_catalog) && !nestedLinked && !nestedIsFallbackCandidate,
           isExistingLinkForReceiptItem: nestedLinked,
           canonicalCatalogProductId: text(nestedCandidate.canonical_catalog_product_id, ''),
           raw: nestedCandidate,
         }
 
-        current.candidateCount += 1
+        if (!nestedItem.isFallbackCandidate) current.candidateCount += 1
+        if (nestedItem.isFallbackCandidate) current.hasFallbackCandidate = true
         current.candidates.push(nestedItem)
 
         if (nestedLinked) {
@@ -262,6 +303,8 @@ function buildReceiptItems(candidates) {
       current.linkedMatchedGlobalArticleId = text(candidate.matched_global_article_id, current.linkedMatchedGlobalArticleId || '')
     } else if (current.candidateCount > 0) {
       current.status = 'Kandidaten gevonden'
+    } else if (current.hasFallbackCandidate) {
+      current.status = 'Geen externe match'
     }
 
     if (!current.contextKey && candidate.context_key) current.contextKey = String(candidate.context_key)
@@ -885,14 +928,18 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
                 <tbody>
                   {selectedItemCandidatesAreLoading ? (
                     <tr><td colSpan="8">Kandidaten worden bijgewerkt voor dit bonartikel...</td></tr>
-                  ) : selectedCandidates.length ? selectedCandidates.map((candidate) => (
+                  ) : selectedCandidates.length ? selectedCandidates.map((candidate) => {
+                    const candidateSelectable = candidate.isLinkedToCatalog || candidate.isLinkableToCatalog
+                    return (
                     <tr key={candidate.id}>
                       <td className="rz-check">
                         <input
                           type="radio"
                           name="external-candidate-choice"
                           checked={selectedCandidateId === candidate.id}
-                          onChange={() => setSelectedCandidateId(candidate.id)}
+                          disabled={!candidateSelectable}
+                          aria-label={candidateSelectable ? 'Kandidaat selecteren' : 'Informatieve fallback, niet koppelbaar'}
+                          onChange={() => candidateSelectable && setSelectedCandidateId(candidate.id)}
                         />
                       </td>
                       <td>{candidate.candidateName}</td>
@@ -903,7 +950,8 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
                       <td>{candidate.variant}</td>
                       <td>{candidate.status}</td>
                     </tr>
-                  )) : <tr><td colSpan="8">Geen externe kandidaten gevonden voor dit bonartikel.</td></tr>}
+                    )
+                  }) : <tr><td colSpan="8">Geen externe kandidaten gevonden voor dit bonartikel.</td></tr>}
                 </tbody>
               </Table>
             </div>

--- a/frontend/tests/e2e/external-databases.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases.frontend-regression.spec.js
@@ -291,4 +291,75 @@ test.describe('Externe databases frontend-regressie', () => {
     await expectNoConsoleErrors(consoleErrors);
   });
 
+  test('Fallbackkandidaat is zichtbaar maar niet koppelbaar', async ({ page }) => {
+    const consoleErrors = attachConsoleErrorCollector(page);
+
+    await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [
+            {
+              context_key: 'ctx-fallback-regression',
+              receipt_line_id: 'receipt-line-fallback-regression',
+              purchase_import_line_id: 'purchase-line-fallback-regression',
+              receipt_line_text: 'Fallback kandidaat regressietest',
+              retailer_code: 'lidl',
+              retailer_article_number: '12345',
+              gtin: '',
+              quantity_label: '1 stuk',
+              price: 1.23,
+              candidate_id: 'candidate-fallback-regression',
+              candidate_name: 'Fallback kandidaat',
+              candidate_brand: '-',
+              external_source_name: 'Rezzerv fallback',
+              external_source_product_code: '',
+              variant: 'Geen externe match',
+              score: 0.1,
+              candidate_status: 'receipt_unresolved_fallback',
+              is_linked_to_catalog: false,
+              is_linkable_to_catalog: true,
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.route('**/api/external-databases/receipt-items/ensure-candidates', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok' }),
+      });
+    });
+
+    await expectRouteLoads(page, '/externe-databases', [
+      'Externe databases',
+      'Bonartikelen',
+      'Kandidaten',
+      'Product',
+    ]);
+
+    const receiptTable = page.getByTestId('external-receipt-items-table');
+    const receiptRow = receiptTable.locator('tbody tr', { hasText: 'Fallback kandidaat regressietest' });
+    await expect(receiptRow).toBeVisible();
+    await expect(receiptRow.locator('td').nth(9)).toHaveText('-');
+    await expect(receiptRow.locator('td').nth(10)).toHaveText('-');
+    await expect(receiptRow.locator('td').nth(11)).toHaveText('0');
+
+    await receiptRow.dblclick();
+
+    const candidateTable = page.getByTestId('external-receipt-item-candidates-table');
+    await expect(candidateTable).toBeVisible();
+    const fallbackRow = candidateTable.locator('tbody tr', { hasText: 'Fallback kandidaat' });
+    await expect(fallbackRow).toBeVisible();
+    await expect(fallbackRow).toContainText('Geen externe match');
+    await expect(fallbackRow.locator('input[type="radio"]')).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Koppel artikel' })).toBeDisabled();
+
+    await expectNoConsoleErrors(consoleErrors);
+  });
+
+
 });


### PR DESCRIPTION
## Samenvatting

M2C2i-10b-b scheidt fallback/unresolved-regels van echte externe kandidaten in Externe databases.

Wijzigingen:
- documenteert het fallbackstatus-contract;
- toont fallbackstatussen als `Geen externe match`;
- voorkomt dat fallbackregels koppelbaar zijn;
- voorkomt dat fallbackregels als beste kandidaat of externe kandidaat meetellen;
- voegt frontend-regressie toe voor `receipt_unresolved_fallback`.

## Architectuurregel

Fallback/unresolved is beslisuitleg, geen externe productmatch. Deze wijziging mag geen automatische mutaties maken in `global_products`, `product_enrichments`, `household_articles` of `inventory_events`.

## PO-test

Controleer in Externe databases:
1. Een gewone kandidaat blijft zichtbaar en koppelbaar.
2. Een gekoppelde kandidaat blijft zichtbaar als `Gekoppeld`.
3. Een fallbackregel toont `Geen externe match`.
4. Een fallbackregel kan niet geselecteerd of gekoppeld worden.
5. Een bonartikel met alleen fallback toont geen beste kandidaat en score in de bovenste tabel.
6. De teller `Externe kandidaten` telt fallback niet mee.

## Validatie

Voer lokaal uit:

```powershell
cd C:\Users\Gebruiker\Rezzerv_Github

git fetch origin
git switch feature/m2c2i10b-fallback-status-contract
git pull --ff-only

git branch --show-current
git status --short
git rev-parse --short HEAD

docker compose down
docker compose up -d --build

Start-Sleep -Seconds 90

Invoke-RestMethod http://localhost:8011/api/health

.\scripts\run-frontend-regression-report.ps1 -SkipDockerBuild
```

Verwacht: backend health `ok` en Playwright frontend-regressie groen.