### PR TITLE
fix(external-db): finalize fallback handling and catalog filter reset

### DIFF
--- a/docs/technical/Rezzerv-known-development-problems.md
+++ b/docs/technical/Rezzerv-known-development-problems.md
@@ -1,0 +1,455 @@
+# Rezzerv Known Development Problems & Fixes
+
+## Doel
+
+Dit document is het operationele playbook voor bekende ontwikkelproblemen in Rezzerv.
+
+Het vult de opstartroutine, development stack, release gate en QA/QC-afspraken aan. Die documenten beschrijven de normale werkwijze en releasevoorwaarden. Dit document beschrijft wat te doen wanneer het misgaat.
+
+Gebruik dit document bij elke fout die lijkt op een eerder bekende categorie, voordat er nieuwe code of testlogica wordt aangepast.
+
+## Basisregels
+
+1. Geen theoretische analyse zonder inspectie van de actuele code, branch, diff of testoutput.
+2. Geen merge naar `main` zolang regressie rood is.
+3. Geen grote componentvervanging als een kleine gerichte patch voldoende is.
+4. Geen PowerShell-instructies die een `>>` prompt, interactieve pager of `:` prompt kunnen veroorzaken.
+5. Bij frontendcode altijd opnieuw Docker builden voordat `-SkipDockerBuild` wordt gebruikt.
+6. Testartefacten horen niet in commits.
+7. Bij falende tests eerst bepalen of het probleem in applicatielogica, testdata, testselector of testomgeving zit.
+
+## 1. PowerShell multiline prompt `>>`
+
+### Symptoom
+
+PowerShell toont een vervolgprompt zoals:
+
+```text
+>>
+```
+
+Of de gebruiker komt vast te zitten in een invoerstatus die niet eindigt met:
+
+```text
+PS C:\Users\Gebruiker\Rezzerv_Github>
+```
+
+### Oorzaak
+
+Multiline PowerShell, here-strings of onvolledig afgesloten quotes/haakjes, bijvoorbeeld:
+
+```powershell
+@'
+...
+'@ | python -
+```
+
+### Niet doen
+
+- Geen here-strings.
+- Geen multiline scripts in de terminal.
+- Geen commando's waarbij de gebruiker zelf nog afsluitregels moet typen.
+- Geen interactieve editors of pagers.
+
+### Wel doen
+
+Gebruik alleen losse, direct uitvoerbare commando's die terugkeren naar de PowerShell prompt.
+
+Voor Git diffs altijd:
+
+```powershell
+git --no-pager diff --check
+```
+
+Niet:
+
+```powershell
+git diff
+```
+
+## 2. Oude frontendbundle door `-SkipDockerBuild`
+
+### Symptoom
+
+Een wijziging staat zichtbaar in het lokale bestand, maar Playwright lijkt nog de oude UI te testen.
+
+Voorbeeld: een fix in `ReceiptItemsOverview.jsx` staat in de broncode, maar de browser toont nog oude waarden zoals `0,000`.
+
+### Oorzaak
+
+De regressierunner wordt uitgevoerd met:
+
+```powershell
+.\scripts\run-frontend-regression-report.ps1 -SkipDockerBuild
+```
+
+terwijl de Docker-container nog een oudere frontendbuild bevat.
+
+### Fix
+
+Bij frontendwijzigingen eerst altijd:
+
+```powershell
+docker compose down
+```
+
+```powershell
+docker compose up -d --build
+```
+
+```powershell
+Start-Sleep -Seconds 90
+```
+
+```powershell
+Invoke-RestMethod http://localhost:8011/api/health
+```
+
+Daarna pas:
+
+```powershell
+.\scripts\run-frontend-regression-report.ps1 -SkipDockerBuild
+```
+
+### Preventie
+
+Gebruik `-SkipDockerBuild` alleen als zeker is dat de container al opnieuw gebouwd is na de laatste frontendwijziging.
+
+## 3. Playwright strict-mode door gedeeltelijke knopnaam
+
+### Symptoom
+
+Playwright faalt met strict-mode, bijvoorbeeld:
+
+```text
+strict mode violation: getByRole('button', { name: 'Koppel artikel' }) resolved to 2 elements
+```
+
+### Oorzaak
+
+Een knopnaam komt ook voor als onderdeel van een andere knopnaam.
+
+Voorbeeld:
+
+- `Koppel artikel`
+- `Ontkoppel artikel`
+
+Zonder exacte match kan Playwright beide vinden.
+
+### Fix
+
+Gebruik bij knoppen met overlappende namen altijd `exact: true`:
+
+```javascript
+page.getByRole('button', { name: 'Koppel artikel', exact: true })
+```
+
+### Preventie
+
+Bij Playwright selectors voor knoppen geldt:
+
+- gebruik `getByRole`;
+- gebruik `exact: true` bij overlappende namen;
+- voorkom selectors op losse substring wanneer er verwante knoppen bestaan.
+
+## 4. JavaScript `Number(null)` toont `0`
+
+### Symptoom
+
+Een lege score of ontbrekende numerieke waarde verschijnt als:
+
+```text
+0,000
+```
+
+terwijl de UI eigenlijk moet tonen:
+
+```text
+-
+```
+
+### Oorzaak
+
+JavaScript zet `null` om naar `0`:
+
+```javascript
+Number(null) // 0
+```
+
+### Fix
+
+Controleer lege waarden voordat numerieke conversie plaatsvindt:
+
+```javascript
+function scoreText(value) {
+  if (value === null || value === undefined || value === '') return '-'
+  const number = Number(value)
+  return Number.isFinite(number) ? number.toFixed(3).replace('.', ',') : '-'
+}
+```
+
+### Preventie
+
+Alle formatterfuncties moeten eerst expliciet testen op:
+
+- `null`
+- `undefined`
+- lege string
+
+Pas daarna mag `Number(...)` worden gebruikt.
+
+## 5. Afgeleide UI-telling wordt later overschreven
+
+### Symptoom
+
+Een telling lijkt correct opgebouwd, maar de UI toont alsnog een verkeerde waarde.
+
+Voorbeeld: fallbackkandidaten worden niet meegeteld tijdens opbouw, maar bovenin toont de UI toch `1` externe kandidaat.
+
+### Oorzaak
+
+De correcte telling wordt later overschreven door een algemene lengteberekening:
+
+```javascript
+candidateCount: sortedCandidates.length
+```
+
+Daarmee tellen ook informatieve/fallbackregels mee.
+
+### Fix
+
+Gebruik de eerder berekende contractuele telling:
+
+```javascript
+candidateCount: item.candidateCount
+```
+
+### Preventie
+
+Afgeleide UI-waarden mogen maar op een centrale plek worden bepaald.
+
+Voor Externe databases geldt:
+
+- echte externe match telt mee;
+- gekoppelde kandidaat telt mee;
+- fallback/uitlegregel telt niet mee;
+- eindmapping mag dit niet opnieuw herberekenen met arraylengte.
+
+## 6. Fallbackregels voelen als echte kandidaten
+
+### Symptoom
+
+Een fallback of unresolved regel verschijnt als normale externe kandidaat.
+
+Mogelijke gevolgen:
+
+- fallback is selecteerbaar;
+- fallback is koppelbaar;
+- fallback telt mee als externe kandidaat;
+- fallback wordt beste kandidaat;
+- fallback toont score.
+
+### Oorzaak
+
+Fallbackstatussen worden niet centraal onderscheiden van echte externe matches.
+
+Bekende fallbackstatussen:
+
+```text
+fallback_candidate
+receipt_fallback_candidate
+receipt_unresolved_fallback
+unresolved_fallback
+unresolved
+no_external_match
+```
+
+### Fix
+
+Gebruik een centrale statusset en markeer kandidaten expliciet:
+
+```javascript
+const FALLBACK_CANDIDATE_STATUSES = new Set([
+  'fallback_candidate',
+  'receipt_fallback_candidate',
+  'receipt_unresolved_fallback',
+  'unresolved_fallback',
+  'unresolved',
+  'no_external_match',
+])
+```
+
+Contract:
+
+- label: `Geen externe match`;
+- niet selecteerbaar;
+- niet koppelbaar;
+- telt niet mee;
+- wordt geen beste kandidaat;
+- toont geen score.
+
+### Preventie
+
+Elke nieuwe kandidaatstatus moet worden ingedeeld in precies een van deze groepen:
+
+1. gekoppelde kandidaat;
+2. echte externe kandidaat;
+3. fallback/uitlegregel.
+
+## 7. Testartefacten vervuilen `git status`
+
+### Symptoom
+
+Na Playwright-tests toont Git:
+
+```text
+?? frontend/playwright-report/
+?? frontend/playwright/
+?? frontend/test-results/
+```
+
+### Oorzaak
+
+Playwright schrijft rapporten, screenshots, video's en testresultaten naar lokale mappen.
+
+### Fix
+
+Ruim testartefacten op:
+
+```powershell
+Remove-Item -Recurse -Force frontend\playwright-report, frontend\playwright, frontend\test-results -ErrorAction SilentlyContinue
+```
+
+Daarna:
+
+```powershell
+git status --short
+```
+
+### Preventie
+
+Voor elke commit of mergecontrole moet `git status --short` leeg zijn, behalve bewust gewijzigde bronbestanden.
+
+## 8. LF/CRLF-waarschuwingen en lege regel aan EOF
+
+### Symptoom
+
+`git --no-pager diff --check` toont bijvoorbeeld:
+
+```text
+new blank line at EOF
+```
+
+of:
+
+```text
+LF will be replaced by CRLF the next time Git touches it
+```
+
+### Oorzaak
+
+Snelle tekstpatches via PowerShell kunnen line endings of eindnewlines wijzigen.
+
+### Fix
+
+Een `new blank line at EOF` moet worden opgelost voordat er wordt gecommit.
+
+Een LF/CRLF-waarschuwing is meestal niet blokkerend, zolang `diff --check` geen echte fout meldt.
+
+### Preventie
+
+- Gebruik geen grote tekstpatches via PowerShell.
+- Beperk patchcommando's tot een enkele gerichte vervanging.
+- Controleer altijd met:
+
+```powershell
+git --no-pager diff --check
+```
+
+## 9. Applicatiebug versus testbug
+
+### Symptoom
+
+Een test faalt, maar de UI lijkt inhoudelijk correct.
+
+### Oorzaak
+
+De test kan zelf te breed, te smal of ambigu zijn.
+
+Voorbeelden:
+
+- selector matcht meerdere knoppen;
+- kolomindex klopt niet;
+- test verwacht technische waarde in plaats van gebruikerslabel;
+- test draait tegen oude build.
+
+### Diagnosevolgorde
+
+1. Lees de exacte foutmelding.
+2. Bepaal of het om UI-output, selector, datafixture of buildversie gaat.
+3. Pas niet direct applicatiecode aan als de fout in de testselector zit.
+4. Voeg alleen een testfix toe als de applicatielogica aantoonbaar correct is.
+
+## 10. Minimale validatie vóór push
+
+Voor elke lokale codewijziging:
+
+```powershell
+git --no-pager diff --check
+```
+
+```powershell
+git status --short
+```
+
+Voor frontendwijzigingen:
+
+```powershell
+docker compose down
+```
+
+```powershell
+docker compose up -d --build
+```
+
+```powershell
+Start-Sleep -Seconds 90
+```
+
+```powershell
+Invoke-RestMethod http://localhost:8011/api/health
+```
+
+```powershell
+.\scripts\run-frontend-regression-report.ps1 -SkipDockerBuild
+```
+
+Voor afronding:
+
+```powershell
+Remove-Item -Recurse -Force frontend\playwright-report, frontend\playwright, frontend\test-results -ErrorAction SilentlyContinue
+```
+
+```powershell
+git status --short
+```
+
+## 11. Wanneer dit document bijwerken
+
+Werk dit document bij wanneer:
+
+- een fout meer dan een keer voorkomt;
+- een regressie fout bleek door testinrichting, niet applicatiecode;
+- een workaround structureel blijkt;
+- een ontwikkelregel expliciet moet worden aangescherpt;
+- een nieuwe foutcategorie impact heeft op releasekwaliteit.
+
+## 12. Kwaliteitsregel
+
+Een fout is pas opgelost wanneer:
+
+1. de oorzaak is begrepen;
+2. de fix minimaal en uitlegbaar is;
+3. de regressie groen is;
+4. `git status --short` schoon is;
+5. de oplossing waar nodig in dit document staat.

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -66,6 +66,30 @@ function isFallbackCandidateStatus(value) {
   return FALLBACK_CANDIDATE_STATUSES.has(normalizeCandidateStatus(value))
 }
 
+function isFallbackSignal(value) {
+  const normalized = normalizeCandidateStatus(value)
+  return normalized.includes('fallback') || normalized.includes('unresolved') || normalized.includes('no_external_match')
+}
+
+function isFallbackCandidate(candidate) {
+  if (!candidate) return false
+  return [
+    candidate.candidate_status,
+    candidate.status,
+    candidate.status_label,
+    candidate.external_source_name,
+    candidate.external_source_product_code,
+    candidate.candidate_source_name,
+    candidate.candidate_source_product_code,
+    candidate.source_name,
+    candidate.source_product_code,
+    candidate.candidate_source,
+    candidate.variant,
+    candidate.candidate_id,
+    candidate.id,
+  ].some((value) => isFallbackCandidateStatus(value) || isFallbackSignal(value))
+}
+
 function candidateStatusLabel(value) {
   const normalized = normalizeCandidateStatus(value)
   const labels = {
@@ -185,6 +209,8 @@ function isBackendLinkedCandidate(candidate) {
 function candidateStatusFromBackend(candidate, linked) {
   if (linked) return 'Gekoppeld'
 
+  if (isFallbackCandidate(candidate)) return 'Geen externe match'
+
   const rawLabel = text(candidate.status_label, '')
   if (rawLabel && rawLabel.toLowerCase() !== 'gekoppeld') return rawLabel
 
@@ -204,7 +230,7 @@ function buildReceiptItems(candidates) {
     const linked = isBackendLinkedCandidate(candidate)
 
     const rawStatus = candidateRawStatus(candidate)
-    const isFallbackCandidate = isFallbackCandidateStatus(rawStatus)
+    const isFallbackCandidate = isFallbackCandidate(candidate)
 
     const candidateItem = {
       id: candidateKey(candidate),
@@ -259,7 +285,7 @@ function buildReceiptItems(candidates) {
       candidate.candidates.forEach((nestedCandidate) => {
         const nestedLinked = isBackendLinkedCandidate(nestedCandidate)
         const nestedRawStatus = candidateRawStatus(nestedCandidate)
-        const nestedIsFallbackCandidate = isFallbackCandidateStatus(nestedRawStatus)
+        const nestedIsFallbackCandidate = isFallbackCandidate(nestedCandidate)
 
         const nestedItem = {
           id: candidateKey(nestedCandidate),
@@ -478,6 +504,7 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   const selectedCandidateCanBeLinked = Boolean(
     selectedCandidate &&
     selectedCandidate.isLinkableToCatalog === true &&
+    selectedCandidate.isFallbackCandidate !== true &&
     selectedCandidateIsLinked === false
   )
 

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -202,8 +202,19 @@ function candidateExternalGtin(candidate) {
 }
 
 function isBackendLinkedCandidate(candidate) {
-  // Single source of truth: de backend bepaalt of deze kandidaat de actieve koppeling is.
+  // Single source of truth: expliciete backendkoppeling blijft leidend.
   return candidate?.is_linked_to_catalog === true
+}
+
+function hasCatalogLink(candidate) {
+  if (!candidate) return false
+  return (
+    candidate.is_linked_to_catalog === true ||
+    Boolean(text(candidate.global_product_id, '')) ||
+    Boolean(text(candidate.product_identity_id, '')) ||
+    Boolean(text(candidate.matched_global_product_id, '')) ||
+    Boolean(text(candidate.matched_global_article_id, ''))
+  )
 }
 
 function candidateStatusFromBackend(candidate, linked) {
@@ -228,6 +239,7 @@ function buildReceiptItems(candidates) {
     const key = rowKey(candidate)
     const isPlaceholder = Boolean(candidate.is_receipt_item_placeholder)
     const linked = isBackendLinkedCandidate(candidate)
+    const catalogLinked = hasCatalogLink(candidate)
 
     const rawStatus = candidateRawStatus(candidate)
     const isFallbackCandidate = detectFallbackCandidate(candidate)
@@ -242,7 +254,7 @@ function buildReceiptItems(candidates) {
       score: candidate.score,
       status: candidateStatusFromBackend(candidate, linked),
       rawStatus,
-      catalogLinked: linked,
+      catalogLinked,
       isLinkedToCatalog: linked,
       isFallbackCandidate,
       isLinkableToCatalog: Boolean(candidate.is_linkable_to_catalog) && !linked && !isFallbackCandidate,
@@ -284,6 +296,7 @@ function buildReceiptItems(candidates) {
     if (isPlaceholder && Array.isArray(candidate.candidates)) {
       candidate.candidates.forEach((nestedCandidate) => {
         const nestedLinked = isBackendLinkedCandidate(nestedCandidate)
+        const nestedCatalogLinked = hasCatalogLink(nestedCandidate)
         const nestedRawStatus = candidateRawStatus(nestedCandidate)
         const nestedIsFallbackCandidate = detectFallbackCandidate(nestedCandidate)
 
@@ -297,7 +310,7 @@ function buildReceiptItems(candidates) {
           score: nestedCandidate.score,
           status: candidateStatusFromBackend(nestedCandidate, nestedLinked),
           rawStatus: nestedRawStatus,
-          catalogLinked: nestedLinked,
+          catalogLinked: nestedCatalogLinked,
           isLinkedToCatalog: nestedLinked,
           isFallbackCandidate: nestedIsFallbackCandidate,
           isLinkableToCatalog: Boolean(nestedCandidate.is_linkable_to_catalog) && !nestedLinked && !nestedIsFallbackCandidate,
@@ -310,7 +323,7 @@ function buildReceiptItems(candidates) {
         if (nestedItem.isFallbackCandidate) current.hasFallbackCandidate = true
         current.candidates.push(nestedItem)
 
-        if (nestedLinked) {
+        if (nestedCatalogLinked) {
           current.catalogLinked = true
           current.status = 'Gekoppeld'
           current.linkedGlobalProductId = text(nestedCandidate.global_product_id, current.linkedGlobalProductId || '')
@@ -321,7 +334,7 @@ function buildReceiptItems(candidates) {
       })
     }
 
-    if (linked) {
+    if (catalogLinked) {
       current.catalogLinked = true
       current.status = 'Gekoppeld'
       current.linkedGlobalProductId = text(candidate.global_product_id, current.linkedGlobalProductId || '')
@@ -500,6 +513,14 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   const selectedItemCandidatesAreLoading = Boolean(selectedItem && selectedItemCandidateLoadingId === selectedItem.id)
   const selectedCandidates = selectedItemCandidatesAreLoading ? [] : (selectedItem?.candidates || [])
   const selectedCandidate = selectedCandidates.find((candidate) => candidate.id === selectedCandidateId) || null
+  useEffect(() => {
+    if (!selectedItem) return
+    if (filteredItems.some((item) => item.id === selectedItem.id)) return
+    setSelectedItem(null)
+    setSelectedCandidateId('')
+    setConfirmOverwrite(false)
+  }, [filteredItems, selectedItem])
+
   const selectedCandidateIsLinked = selectedCandidate?.isLinkedToCatalog === true
   const selectedCandidateCanBeLinked = Boolean(
     selectedCandidate &&

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+﻿import { useEffect, useMemo, useRef, useState } from 'react'
 import Table from '../../ui/Table'
 import Button from '../../ui/Button'
 import { fetchJsonWithAuth } from '../../lib/authSession'
@@ -32,6 +32,7 @@ function gtinText(value) {
 }
 
 function scoreText(value) {
+  if (value === null || value === undefined || value === '') return '-'
   const number = Number(value)
   if (!Number.isFinite(number)) return '-'
   return number.toLocaleString('nl-NL', { minimumFractionDigits: 3, maximumFractionDigits: 3 })
@@ -459,7 +460,7 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
     return rows
   }, [items, filters, sortKey, sortDesc])
 
-  // De backend levert Ã©Ã©n rij per bonartikelcontext.
+  // De backend levert ÃƒÂ©ÃƒÂ©n rij per bonartikelcontext.
   // Niet extra ontdubbelen op artikeltekst: gelijke omschrijvingen met andere artikelcode zijn aparte bonartikelen.
   const dedupedItems = filteredItems
 
@@ -618,7 +619,7 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   function exportSelectedItems() {
     const selectedRows = items.filter((item) => selectedItemIds.includes(item.id))
     if (!selectedRows.length) {
-      onMessage?.('Selecteer eerst Ã©Ã©n of meer bonartikelen om te exporteren.')
+      onMessage?.('Selecteer eerst ÃƒÂ©ÃƒÂ©n of meer bonartikelen om te exporteren.')
       return
     }
 

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -349,7 +349,7 @@ function buildReceiptItems(candidates) {
       ...item,
       articleNumber: externalArticleNumber || '-',
       gtin: externalGtin,
-      candidateCount: sortedCandidates.length,
+      candidateCount: item.candidateCount,
       candidates: sortedCandidates,
       bestCandidateName: text(bestCandidate?.candidateName, ''),
       bestCandidateScore: bestCandidate?.score ?? null,

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -71,7 +71,7 @@ function isFallbackSignal(value) {
   return normalized.includes('fallback') || normalized.includes('unresolved') || normalized.includes('no_external_match')
 }
 
-function isFallbackCandidate(candidate) {
+function detectFallbackCandidate(candidate) {
   if (!candidate) return false
   return [
     candidate.candidate_status,
@@ -209,7 +209,7 @@ function isBackendLinkedCandidate(candidate) {
 function candidateStatusFromBackend(candidate, linked) {
   if (linked) return 'Gekoppeld'
 
-  if (isFallbackCandidate(candidate)) return 'Geen externe match'
+  if (detectFallbackCandidate(candidate)) return 'Geen externe match'
 
   const rawLabel = text(candidate.status_label, '')
   if (rawLabel && rawLabel.toLowerCase() !== 'gekoppeld') return rawLabel
@@ -230,7 +230,7 @@ function buildReceiptItems(candidates) {
     const linked = isBackendLinkedCandidate(candidate)
 
     const rawStatus = candidateRawStatus(candidate)
-    const isFallbackCandidate = isFallbackCandidate(candidate)
+    const isFallbackCandidate = detectFallbackCandidate(candidate)
 
     const candidateItem = {
       id: candidateKey(candidate),
@@ -285,7 +285,7 @@ function buildReceiptItems(candidates) {
       candidate.candidates.forEach((nestedCandidate) => {
         const nestedLinked = isBackendLinkedCandidate(nestedCandidate)
         const nestedRawStatus = candidateRawStatus(nestedCandidate)
-        const nestedIsFallbackCandidate = isFallbackCandidate(nestedCandidate)
+        const nestedIsFallbackCandidate = detectFallbackCandidate(nestedCandidate)
 
         const nestedItem = {
           id: candidateKey(nestedCandidate),

--- a/frontend/src/features/externalDatabases/externalDatabases.css
+++ b/frontend/src/features/externalDatabases/externalDatabases.css
@@ -1,4 +1,4 @@
-.rz-external-databases {
+﻿.rz-external-databases {
   display: grid;
   gap: var(--space-md);
 }
@@ -283,7 +283,14 @@
 }
 
 .rz-external-databases .rz-table th {
-  overflow: visible;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rz-external-databases .rz-table th button {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .rz-external-receipt-col-receipt { width: 360px; }
@@ -487,3 +494,4 @@
   color: var(--color-text-primary);
   line-height: 1.5;
 }
+

--- a/frontend/tests/e2e/external-databases.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases.frontend-regression.spec.js
@@ -356,7 +356,7 @@ test.describe('Externe databases frontend-regressie', () => {
     await expect(fallbackRow).toBeVisible();
     await expect(fallbackRow).toContainText('Geen externe match');
     await expect(fallbackRow.locator('input[type="radio"]')).toBeDisabled();
-    await expect(page.getByRole('button', { name: 'Koppel artikel' })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Koppel artikel', exact: true })).toBeDisabled();
 
     await expectNoConsoleErrors(consoleErrors);
   });

--- a/frontend/tests/e2e/external-databases.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases.frontend-regression.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+﻿import { test, expect } from '@playwright/test';
 import {
   attachConsoleErrorCollector,
   expectAnyVisible,
@@ -313,11 +313,11 @@ test.describe('Externe databases frontend-regressie', () => {
               candidate_id: 'candidate-fallback-regression',
               candidate_name: 'Fallback kandidaat',
               candidate_brand: '-',
-              external_source_name: 'Rezzerv fallback',
-              external_source_product_code: '',
+              external_source_name: 'receipt_product_intent_fallback',
+              external_source_product_code: 'fallback:creme-frache',
               variant: 'Geen externe match',
               score: 0.1,
-              candidate_status: 'receipt_unresolved_fallback',
+              candidate_status: 'candidate',
               is_linked_to_catalog: false,
               is_linkable_to_catalog: true,
             },
@@ -363,3 +363,4 @@ test.describe('Externe databases frontend-regressie', () => {
 
 
 });
+

--- a/frontend/tests/e2e/external-databases.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases.frontend-regression.spec.js
@@ -361,6 +361,41 @@ test.describe('Externe databases frontend-regressie', () => {
     await expectNoConsoleErrors(consoleErrors);
   });
 
+  test('Catalogusfilter reset detailselectie als geselecteerde rij verdwijnt', async ({ page }) => {
+    const consoleErrors = attachConsoleErrorCollector(page);
+
+    await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [
+            { context_key: 'ctx-filter-linked', receipt_line_id: 'line-filter-linked', purchase_import_line_id: 'purchase-filter-linked', receipt_line_text: 'Gekoppeld filter product', retailer_code: 'lidl', retailer_article_number: 'LIDL-LINKED', gtin: '', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-filter-linked', candidate_name: 'Gekoppeld filter kandidaat', candidate_brand: '-', external_source_name: 'Open Food Facts', external_source_product_code: '8710000000001', variant: 'Standaard', score: 0.9, candidate_status: 'linked_to_catalog', is_linked_to_catalog: true, is_linkable_to_catalog: false, global_product_id: 'gp-filter-linked' },
+            { context_key: 'ctx-filter-unlinked', receipt_line_id: 'line-filter-unlinked', purchase_import_line_id: 'purchase-filter-unlinked', receipt_line_text: 'Niet gekoppeld filter product', retailer_code: 'lidl', retailer_article_number: 'LIDL-UNLINKED', gtin: '', quantity_label: '1 stuk', price: 1.45, candidate_id: 'candidate-filter-unlinked', candidate_name: 'Niet gekoppeld filter kandidaat', candidate_brand: '-', external_source_name: 'Open Food Facts', external_source_product_code: '8710000000002', variant: 'Standaard', score: 0.8, candidate_status: 'candidate', is_linked_to_catalog: false, is_linkable_to_catalog: true },
+          ],
+        }),
+      });
+    });
+
+    await page.route('**/api/external-databases/receipt-items/ensure-candidates', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'ok' }) });
+    });
+
+    await expectRouteLoads(page, '/externe-databases', ['Externe databases', 'Bonartikelen', 'Kandidaten', 'Product']);
+
+    const receiptTable = page.getByTestId('external-receipt-items-table');
+    const unlinkedRow = receiptTable.locator('tbody tr', { hasText: 'Niet gekoppeld filter product' });
+    await expect(unlinkedRow).toBeVisible();
+    await unlinkedRow.dblclick();
+    await expect(page.getByTestId('external-receipt-item-candidates-table')).toContainText('Niet gekoppeld filter kandidaat');
+
+    await receiptTable.locator('select').first().selectOption('linked');
+    await expect(receiptTable.locator('tbody tr', { hasText: 'Gekoppeld filter product' })).toBeVisible();
+    await expect(receiptTable.locator('tbody tr', { hasText: 'Niet gekoppeld filter product' })).toHaveCount(0);
+    await expect(page.getByTestId('external-receipt-item-candidates-table')).not.toContainText('Niet gekoppeld filter kandidaat');
+
+    await expectNoConsoleErrors(consoleErrors);
+  });
 
 });
 

--- a/frontend/tests/e2e/external-databases.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases.frontend-regression.spec.js
@@ -392,7 +392,7 @@ test.describe('Externe databases frontend-regressie', () => {
     await receiptTable.locator('select').first().selectOption('linked');
     await expect(receiptTable.locator('tbody tr', { hasText: 'Gekoppeld filter product' })).toBeVisible();
     await expect(receiptTable.locator('tbody tr', { hasText: 'Niet gekoppeld filter product' })).toHaveCount(0);
-    await expect(page.getByTestId('external-receipt-item-candidates-table')).not.toContainText('Niet gekoppeld filter kandidaat');
+    await expect(page.getByText('Niet gekoppeld filter kandidaat')).toHaveCount(0);
 
     await expectNoConsoleErrors(consoleErrors);
   });


### PR DESCRIPTION
## Samenvatting

Vervolg op PR #87. PR #87 was al gemerged voordat de latere PO-herstelpatches waren verwerkt. Deze PR brengt de resterende wijzigingen naar `main`.

Wijzigingen:
- fallbackdetectie uitgebreid naar fallback-signalen in source/code/id/variant/statuslabel;
- fallbackregels blijven niet-selecteerbaar en niet-koppelbaar;
- catalogusfilter gebruikt robuustere cataloguskoppeling;
- detailselectie wordt gereset als filteren de geselecteerde hoofdrij verbergt;
- hoofdtabelheader opgeschoond tegen overlappende kolomteksten;
- known-development-problems playbook toegevoegd;
- regressie uitgebreid naar 12 tests.

## Validatie

Lokaal gevalideerd door PO:

```text
Backend health ok
Frontend regressie groen
12 passed
Fixture cleanup ok
```

## PO-check

PO heeft bevestigd:
- fallback met `fallback:` is niet selecteerbaar/koppelbaar;
- catalogusfilter werkt;
- detailtabel reset als hoofdrij door filter verdwijnt;
- headervervuiling is opgelost.