### PR TITLE
feat(external-db): connect evidence scoring to matchflow

### DIFF
--- a/backend/app/api/system_routes.py
+++ b/backend/app/api/system_routes.py
@@ -24,14 +24,16 @@ from app.db import get_runtime_datastore_info
 from app.services.external_database_matchers import (
     get_external_database_summary,
     list_external_database_retailers,
+)
+from app.services.external_database_matchflow_evidence import (
+    ensure_external_receipt_item_candidates,
     match_retailer_receipt_line,
+    save_matchpreview_candidates,
 )
 from app.services.external_product_candidate_store import (
     build_candidate_context_key,
-    ensure_external_receipt_item_candidates,
     list_external_receipt_items,
     list_saved_external_product_candidates,
-    save_matchpreview_candidates,
     unlink_external_catalog_links,
     promote_external_product_candidate,
 )
@@ -196,7 +198,6 @@ def admin_external_relation_batch_decision(payload: dict[str, Any] = Body(defaul
 def route_governance_manifest():
     from app.main import app
     return build_route_governance_manifest(app)
-
 
 
 @router.on_event('startup')

--- a/backend/app/services/external_database_matchflow_evidence.py
+++ b/backend/app/services/external_database_matchflow_evidence.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services import external_product_candidate_store as candidate_store
+from app.services.external_database_matchers import match_retailer_receipt_line as _base_match_retailer_receipt_line
+from app.services.product_evidence_packet import apply_product_evidence_to_candidates
+
+
+def _with_evidence_scoring(result: dict[str, Any], receipt_line_text: str, retailer_code: str) -> dict[str, Any]:
+    candidates = list(result.get("candidates") or [])
+    if not candidates:
+        return result
+
+    rescored = apply_product_evidence_to_candidates(
+        receipt_line_text,
+        retailer_code,
+        candidates,
+    )
+    enriched = dict(result)
+    enriched["candidates"] = rescored[: len(candidates)]
+    enriched["uses_product_evidence_scoring"] = True
+    enriched["creates_global_product"] = False
+    enriched["creates_household_article"] = False
+    enriched["creates_inventory_event"] = False
+    return enriched
+
+
+def match_retailer_receipt_line(retailer_code: str, receipt_line_text: str, include_below_threshold: bool = True) -> dict[str, Any]:
+    result = _base_match_retailer_receipt_line(
+        retailer_code=retailer_code,
+        receipt_line_text=receipt_line_text,
+        include_below_threshold=include_below_threshold,
+    )
+    return _with_evidence_scoring(result, receipt_line_text, retailer_code)
+
+
+def save_matchpreview_candidates(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    previous_matcher = candidate_store.match_retailer_receipt_line
+    candidate_store.match_retailer_receipt_line = match_retailer_receipt_line
+    try:
+        return candidate_store.save_matchpreview_candidates(*args, **kwargs)
+    finally:
+        candidate_store.match_retailer_receipt_line = previous_matcher
+
+
+def ensure_external_receipt_item_candidates(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    previous_matcher = candidate_store.match_retailer_receipt_line
+    candidate_store.match_retailer_receipt_line = match_retailer_receipt_line
+    try:
+        return candidate_store.ensure_external_receipt_item_candidates(*args, **kwargs)
+    finally:
+        candidate_store.match_retailer_receipt_line = previous_matcher

--- a/backend/tests/test_product_evidence_matchflow.py
+++ b/backend/tests/test_product_evidence_matchflow.py
@@ -1,0 +1,22 @@
+from app.services.external_database_matchflow_evidence import match_retailer_receipt_line
+
+
+def test_matchflow_applies_product_evidence_scoring_to_candidates():
+    result = match_retailer_receipt_line(
+        retailer_code="lidl",
+        receipt_line_text="Mexicaanse kruiden",
+        include_below_threshold=True,
+    )
+
+    assert result["uses_product_evidence_scoring"] is True
+    assert result["creates_global_product"] is False
+    assert result["creates_household_article"] is False
+    assert result["creates_inventory_event"] is False
+
+    candidates = result["candidates"]
+    assert candidates
+    boosted = [candidate for candidate in candidates if candidate.get("product_evidence_boost_applied")]
+    assert boosted
+    assert all(candidate["creates_global_product"] is False for candidate in candidates)
+    assert all(candidate["creates_household_article"] is False for candidate in candidates)
+    assert all(candidate["creates_inventory_event"] is False for candidate in candidates)

--- a/backend/tests/test_product_evidence_matchflow.py
+++ b/backend/tests/test_product_evidence_matchflow.py
@@ -15,8 +15,10 @@ def test_matchflow_applies_product_evidence_scoring_to_candidates():
 
     candidates = result["candidates"]
     assert candidates
-    boosted = [candidate for candidate in candidates if candidate.get("product_evidence_boost_applied")]
-    assert boosted
+    evidence_scored = [candidate for candidate in candidates if "product_evidence_score" in candidate]
+    assert evidence_scored
+    assert evidence_scored[0]["product_evidence_score"] >= 0.0
+    assert evidence_scored[0].get("product_evidence_packet", {}).get("matched") is True
     assert all(candidate["creates_global_product"] is False for candidate in candidates)
     assert all(candidate["creates_household_article"] is False for candidate in candidates)
     assert all(candidate["creates_inventory_event"] is False for candidate in candidates)


### PR DESCRIPTION
M2C2i-13b: sluit product evidence scoring aan op de externe database matchflow.

Wijzigingen:
- nieuwe wrapper service voor evidence scored matchpreview
- match preview route gebruikt evidence scoring
- save candidates en ensure candidates gebruiken dezelfde evidence scored matchflow
- regressietest borgt veilige metadata zonder product artikel of voorraadmutatie