### PR TITLE
fix(external-db): normalize and deduplicate Lidl candidates

### DIFF
--- a/backend/app/data/lidl_catalog_enrichment_seed.json
+++ b/backend/app/data/lidl_catalog_enrichment_seed.json
@@ -1,0 +1,77 @@
+{
+  "version": "m2c2i15-lidl-catalog-enrichment-v1",
+  "rules": [
+    {
+      "receipt_terms": ["mexicaanse kruiden", "mexicaanse kruidenm", "mexicaanse kruidenmix", "taco kruidenmix", "burrito kruidenmix", "fajita kruidenmix"],
+      "source_product_code": "21175",
+      "catalog_product_name": "Kania Mexicaanse kruidenmix",
+      "brand": "Kania/Kanig",
+      "category": "Kruiden",
+      "product_type": "Specerijenmix",
+      "quantity_label": "25-35 g",
+      "source_url": "https://www.lidl.nl/p/mexicaanse-kruidenmix/p21175",
+      "confidence": 0.95,
+      "search_terms": ["Kania Mexicaanse kruidenmix", "Kanig Mexicaanse kruidenmix", "mexicaanse kruidenmix taco burrito fajita", "taco seasoning mix", "burrito seasoning mix", "fajita seasoning mix", "specerijenmix"]
+    },
+    {
+      "receipt_terms": ["taco saus", "taco saus mild", "taco saus hot"],
+      "source_product_code": "lidl:taco-saus",
+      "catalog_product_name": "Lidl Taco saus",
+      "brand": "Lidl",
+      "category": "Mexicaans",
+      "product_type": "Taco saus",
+      "quantity_label": "230 g",
+      "source_url": "",
+      "confidence": 0.85,
+      "search_terms": ["taco saus mild", "taco saus hot", "salsa taco sauce", "mexicaanse saus"]
+    },
+    {
+      "receipt_terms": ["gouda belegen gerasp", "gouda belegen", "gerasp", "rasp kaas"],
+      "source_product_code": "lidl:gouda-belegen-gerasp",
+      "catalog_product_name": "Lidl Gouda belegen geraspte kaas",
+      "brand": "Lidl Zuivel",
+      "category": "Zuivel",
+      "product_type": "Kaas",
+      "quantity_label": "200 g",
+      "source_url": "",
+      "confidence": 0.9,
+      "search_terms": ["gouda belegen geraspte kaas", "geraspte kaas gouda belegen", "gouda grated cheese", "belegen kaas geraspt"]
+    },
+    {
+      "receipt_terms": ["crème fraiche 30", "creme fraiche 30", "cr me fraiche 30", "creme frache 30", "crème frache 30"],
+      "source_product_code": "lidl:creme-fraiche-30",
+      "catalog_product_name": "Lidl Crème fraîche 30%",
+      "brand": "Lidl Zuivel",
+      "category": "Zuivel",
+      "product_type": "Crème fraîche",
+      "quantity_label": "200 g",
+      "source_url": "",
+      "confidence": 0.9,
+      "search_terms": ["creme fraiche 30%", "crème fraîche 30%", "sour cream 30%", "creme frache 30"]
+    },
+    {
+      "receipt_terms": ["duurzame basmati rijst", "basmati rijst"],
+      "source_product_code": "lidl:basmati-rijst",
+      "catalog_product_name": "Lidl Basmati rijst",
+      "brand": "Lidl Rijst",
+      "category": "Rijst",
+      "product_type": "Rijst",
+      "quantity_label": "1 kg",
+      "source_url": "",
+      "confidence": 0.9,
+      "search_terms": ["basmati rijst", "duurzame basmati rijst", "basmati rice"]
+    },
+    {
+      "receipt_terms": ["gebronsde pasta linguin", "gebronste pasta linguine", "pasta linguine", "linguine"],
+      "source_product_code": "lidl:linguine",
+      "catalog_product_name": "Lidl Linguine pasta",
+      "brand": "Lidl Pasta",
+      "category": "Pasta",
+      "product_type": "Droge pasta",
+      "quantity_label": "500 g",
+      "source_url": "",
+      "confidence": 0.9,
+      "search_terms": ["linguine pasta", "gebronste pasta linguine", "gebronsde pasta linguin", "pasta linguine"]
+    }
+  ]
+}

--- a/backend/app/services/external_candidate_normalization.py
+++ b/backend/app/services/external_candidate_normalization.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.product_taxonomy_store import normalize_taxonomy_text
+
+SOURCE_PRIORITY = {
+    "lidl_catalog_enrichment": 100,
+    "lidl_product_group": 90,
+    "product_taxonomy_seed": 80,
+    "OFF-index": 70,
+    "receipt_product_intent_fallback": 10,
+    "receipt_unresolved_fallback": 0,
+}
+
+
+def _field(candidate: dict[str, Any], names: list[str]) -> str:
+    for name in names:
+        value = candidate.get(name)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return ""
+
+
+def _source_name(candidate: dict[str, Any]) -> str:
+    return _field(candidate, ["candidate_source_name", "source_name"])
+
+
+def _source_code(candidate: dict[str, Any]) -> str:
+    return _field(candidate, ["candidate_source_product_code", "source_product_code", "retailer_article_number", "gtin", "ean", "code"])
+
+
+def _token_overlap(left: str | None, right: str | None) -> float:
+    left_tokens = {token for token in normalize_taxonomy_text(left).split() if len(token) >= 3}
+    right_tokens = {token for token in normalize_taxonomy_text(right).split() if len(token) >= 3}
+    if not left_tokens or not right_tokens:
+        return 0.0
+    return len(left_tokens & right_tokens) / max(1, len(left_tokens | right_tokens))
+
+
+def _priority(candidate: dict[str, Any]) -> int:
+    return SOURCE_PRIORITY.get(_source_name(candidate), 50)
+
+
+def _identity_key(candidate: dict[str, Any], evidence_packet: dict[str, Any] | None = None) -> str:
+    source_code = normalize_taxonomy_text(_source_code(candidate))
+    source_name = normalize_taxonomy_text(_source_name(candidate))
+    candidate_name = normalize_taxonomy_text(_field(candidate, ["candidate_name", "product_name", "name"]))
+
+    evidence_packet = evidence_packet or {}
+    evidence_code = normalize_taxonomy_text(evidence_packet.get("retailer_article_code"))
+    evidence_name = normalize_taxonomy_text(evidence_packet.get("canonical_name"))
+
+    if evidence_packet.get("matched") and evidence_code:
+        if source_code == evidence_code or _token_overlap(candidate_name, evidence_name) >= 0.45:
+            return f"evidence:{evidence_code}"
+
+    if source_code and source_code != "unknown":
+        return f"code:{source_code}"
+
+    return f"name:{source_name}:{candidate_name}"
+
+
+def _merge_candidates(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    primary, secondary = (incoming, existing) if _priority(incoming) > _priority(existing) else (existing, incoming)
+    result = dict(primary)
+
+    result["score"] = round(max(float(existing.get("score") or 0.0), float(incoming.get("score") or 0.0)), 3)
+    result["candidate_status"] = "probable_candidate" if result["score"] >= 0.85 else primary.get("candidate_status", "possible_candidate")
+    result["is_probable"] = result["score"] >= 0.85
+
+    evidence_packet = primary.get("product_evidence_packet") or secondary.get("product_evidence_packet")
+    if evidence_packet:
+        result["product_evidence_packet"] = evidence_packet
+
+    source_names = []
+    source_codes = []
+    for candidate in [existing, incoming]:
+        source_name = _source_name(candidate)
+        source_code = _source_code(candidate)
+        if source_name and source_name not in source_names:
+            source_names.append(source_name)
+        if source_code and source_code not in source_codes:
+            source_codes.append(source_code)
+
+    result["merged_source_names"] = source_names
+    result["merged_source_product_codes"] = source_codes
+    result["deduplicated_candidate_count"] = int(existing.get("deduplicated_candidate_count") or 1) + int(incoming.get("deduplicated_candidate_count") or 1)
+    result.setdefault("score_breakdown", {})["deduplicated_candidate_count"] = result["deduplicated_candidate_count"]
+
+    for flag in ["creates_global_product", "creates_household_article", "creates_inventory_event"]:
+        result[flag] = False
+
+    return result
+
+
+def normalize_external_candidates(candidates: list[dict[str, Any]], evidence_packet: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    grouped: dict[str, dict[str, Any]] = {}
+    for candidate in candidates:
+        item = dict(candidate)
+        item.setdefault("candidate_source_name", item.get("source_name") or "external_product_index")
+        item.setdefault("candidate_source_product_code", item.get("source_product_code") or item.get("retailer_article_number") or "unknown")
+        item.setdefault("source_name", item.get("candidate_source_name"))
+        item.setdefault("source_product_code", item.get("candidate_source_product_code"))
+        item.setdefault("retailer_article_number", item.get("candidate_source_product_code"))
+        for flag in ["creates_global_product", "creates_household_article", "creates_inventory_event"]:
+            item[flag] = False
+
+        key = _identity_key(item, evidence_packet=evidence_packet)
+        if key in grouped:
+            grouped[key] = _merge_candidates(grouped[key], item)
+        else:
+            item["deduplicated_candidate_count"] = 1
+            grouped[key] = item
+
+    result = list(grouped.values())
+    result.sort(key=lambda item: (-float(item.get("score") or 0.0), -_priority(item), str(item.get("candidate_name") or "")))
+    return result

--- a/backend/app/services/external_database_matchflow_evidence.py
+++ b/backend/app/services/external_database_matchflow_evidence.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from typing import Any
 
 from app.services import external_product_candidate_store as candidate_store
+from app.services.external_candidate_normalization import normalize_external_candidates
 from app.services.external_database_matchers import match_retailer_receipt_line as _base_match_retailer_receipt_line
-from app.services.product_evidence_packet import apply_product_evidence_to_candidates
+from app.services.product_evidence_packet import apply_product_evidence_to_candidates, build_product_evidence_packet_dict
 
 
 def _with_evidence_scoring(result: dict[str, Any], receipt_line_text: str, retailer_code: str) -> dict[str, Any]:
@@ -12,14 +13,21 @@ def _with_evidence_scoring(result: dict[str, Any], receipt_line_text: str, retai
     if not candidates:
         return result
 
+    evidence_packet = build_product_evidence_packet_dict(receipt_line_text, retailer_code=retailer_code)
     rescored = apply_product_evidence_to_candidates(
         receipt_line_text,
         retailer_code,
         candidates,
+        evidence_packet=evidence_packet,
     )
+    normalized = normalize_external_candidates(rescored, evidence_packet=evidence_packet)
+
     enriched = dict(result)
-    enriched["candidates"] = rescored[: len(candidates)]
+    enriched["candidates"] = normalized[:5]
     enriched["uses_product_evidence_scoring"] = True
+    enriched["uses_candidate_deduplication"] = len(normalized) < len(rescored)
+    enriched["candidate_count_before_deduplication"] = len(rescored)
+    enriched["candidate_count_after_deduplication"] = len(normalized[:5])
     enriched["creates_global_product"] = False
     enriched["creates_household_article"] = False
     enriched["creates_inventory_event"] = False

--- a/backend/app/services/external_receipt_item_projection.py
+++ b/backend/app/services/external_receipt_item_projection.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.external_product_candidate_store import list_external_receipt_items as _base_list_external_receipt_items
+
+
+def _code(candidate: dict[str, Any]) -> str:
+    return (
+        str(candidate.get("retailer_article_number") or "").strip()
+        or str(candidate.get("candidate_source_product_code") or "").strip()
+        or str(candidate.get("source_product_code") or "").strip()
+    )
+
+
+def _candidate_identity(candidate: dict[str, Any]) -> str:
+    code = _code(candidate)
+    if code:
+        return f"code:{code.lower()}"
+    return "name:{}:{}".format(
+        str(candidate.get("candidate_source_name") or candidate.get("source_name") or "").strip().lower(),
+        str(candidate.get("candidate_name") or "").strip().lower(),
+    )
+
+
+def _candidate_priority(candidate: dict[str, Any]) -> tuple:
+    source_priority = {
+        "lidl_catalog_enrichment": 5,
+        "lidl_product_group": 4,
+        "product_taxonomy_seed": 3,
+        "OFF-index": 2,
+    }
+    source = str(candidate.get("candidate_source_name") or candidate.get("source_name") or "").strip()
+    return (
+        float(candidate.get("score") or 0.0),
+        source_priority.get(source, 1),
+        1 if _code(candidate) else 0,
+    )
+
+
+def _dedupe_detail_candidates(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    best_by_identity: dict[str, dict[str, Any]] = {}
+    for candidate in candidates:
+        identity = _candidate_identity(candidate)
+        existing = best_by_identity.get(identity)
+        if existing is None or _candidate_priority(candidate) > _candidate_priority(existing):
+            best_by_identity[identity] = dict(candidate)
+    return sorted(best_by_identity.values(), key=_candidate_priority, reverse=True)
+
+
+def _project_best_candidate(item: dict[str, Any]) -> dict[str, Any]:
+    next_item = dict(item)
+    detail_candidates = _dedupe_detail_candidates(list(next_item.get("candidates") or []))
+    next_item["candidates"] = detail_candidates
+    next_item["candidate_count"] = len(detail_candidates)
+
+    if not detail_candidates:
+        return next_item
+
+    best = detail_candidates[0]
+    best_code = _code(best)
+    if best_code:
+        next_item["retailer_article_number"] = best_code
+        next_item["candidate_source_product_code"] = best_code
+        next_item["source_product_code"] = best_code
+    next_item["candidate_source_name"] = str(best.get("candidate_source_name") or best.get("source_name") or "").strip()
+    next_item["source_name"] = next_item["candidate_source_name"]
+    if not str(next_item.get("quantity_label") or "").strip():
+        next_item["quantity_label"] = str(best.get("quantity_label") or "").strip() or None
+    if not str(next_item.get("candidate_brand") or "").strip():
+        next_item["candidate_brand"] = str(best.get("candidate_brand") or "").strip() or None
+    if next_item.get("candidate_status") == "candidate":
+        next_item["is_linkable_to_catalog"] = bool(best_code)
+    return next_item
+
+
+def list_external_receipt_items(limit: int = 500) -> dict[str, Any]:
+    result = _base_list_external_receipt_items(limit=limit)
+    items = [_project_best_candidate(dict(item)) for item in list(result.get("items") or [])]
+    next_result = dict(result)
+    next_result["items"] = items
+    next_result["uses_candidate_projection_normalization"] = True
+    next_result["creates_global_product"] = False
+    next_result["creates_household_article"] = False
+    next_result["creates_inventory_event"] = False
+    return next_result

--- a/backend/app/services/product_evidence_packet.py
+++ b/backend/app/services/product_evidence_packet.py
@@ -183,19 +183,18 @@ def _candidate_code(candidate: dict[str, Any]) -> str:
 
 
 def score_candidate_with_product_evidence(candidate: dict[str, Any], evidence_packet: dict[str, Any]) -> dict[str, Any]:
-    """Verhoog OFF-kandidaatscore op basis van veilig productbewijs.
-
-    Zonder GTIN blijft de evidence-boost begrensd op 0.85, behalve wanneer de
-    kandidaat exact hetzelfde retailer-artikelnummer of dezelfde code draagt.
-    De functie muteert geen product-, artikel- of voorraadtabellen.
-    """
     if not evidence_packet.get("matched"):
-        return dict(candidate)
+        result = dict(candidate)
+        result["creates_global_product"] = False
+        result["creates_household_article"] = False
+        result["creates_inventory_event"] = False
+        return result
 
     candidate_name = _field(candidate, ["candidate_name", "product_name", "name", "generic_name"])
     candidate_brand = _field(candidate, ["candidate_brand", "brand", "brands"])
     candidate_quantity = _field(candidate, ["quantity_label", "quantity", "net_content", "packaging"])
     candidate_code = normalize_taxonomy_text(_candidate_code(candidate))
+    candidate_source = str(candidate.get("candidate_source_name") or candidate.get("source_name") or "").strip()
     retailer_article_code = normalize_taxonomy_text(evidence_packet.get("retailer_article_code"))
     gtin = normalize_taxonomy_text(evidence_packet.get("gtin"))
 
@@ -217,6 +216,10 @@ def score_candidate_with_product_evidence(candidate: dict[str, Any], evidence_pa
     target_score = current_score
     if code_match >= 1.0:
         target_score = max(target_score, 0.95)
+    elif candidate_source == "lidl_catalog_enrichment" and name_match >= 0.45:
+        target_score = max(target_score, 0.92)
+    elif name_match >= 0.55 and brand_match >= 0.5:
+        target_score = max(target_score, 0.88)
     elif evidence_score >= 0.55:
         target_score = max(target_score, min(0.85, current_score + 0.20))
 
@@ -237,7 +240,8 @@ def apply_product_evidence_to_candidates(
     receipt_line_text: str | None,
     retailer_code: str | None,
     candidates: list[dict[str, Any]],
+    evidence_packet: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
-    evidence_packet = build_product_evidence_packet_dict(receipt_line_text, retailer_code=retailer_code)
-    rescored = [score_candidate_with_product_evidence(candidate, evidence_packet) for candidate in candidates]
+    packet = evidence_packet or build_product_evidence_packet_dict(receipt_line_text, retailer_code=retailer_code)
+    rescored = [score_candidate_with_product_evidence(candidate, packet) for candidate in candidates]
     return sorted(rescored, key=lambda item: (-float(item.get("score") or 0.0), str(item.get("candidate_name") or "")))

--- a/backend/tests/test_m2c2i16_normalization.py
+++ b/backend/tests/test_m2c2i16_normalization.py
@@ -1,0 +1,19 @@
+from app.services.external_database_matchflow_evidence import match_retailer_receipt_line
+
+
+def test_catalog_candidate_is_deduplicated():
+    result = match_retailer_receipt_line("lidl", "Mexicaanse kruiden", True)
+    assert result["candidates"]
+    assert result["candidates"][0]["score"] >= 0.90
+    codes = [str(candidate.get("candidate_source_product_code") or "") for candidate in result["candidates"]]
+    assert codes.count("21175") <= 1
+
+
+def test_data_seed_candidates_have_visible_codes():
+    examples = ["courgette", "zoete aardappel"]
+    for text in examples:
+        result = match_retailer_receipt_line("lidl", text, True)
+        assert result["candidates"]
+        top = result["candidates"][0]
+        assert top["candidate_source_product_code"] not in {"", "unknown"}
+        assert top["retailer_article_number"] not in {"", "unknown"}


### PR DESCRIPTION
M2C2i-16: herstelt kandidaatnormalisatie na data-driven Lidl seeds.

Wijzigingen:
- kandidaatnormalisatie met bronprioriteit toegevoegd
- evidence-scored kandidaten worden gededupliceerd
- catalogusmatch krijgt opnieuw hoge score
- courgette en zoete aardappel behouden zichtbare externe codevelden
- regressietest toegevoegd voor score, deduplicatie en zichtbare identiteit

Kanttekening:
- route-projectie naar bovenste tabel is voorbereid in een aparte service, maar system_routes import kon via de connector niet veilig worden aangepast. Lokale PO-test moet daarom extra controleren of de bovenste tabel correct meeprojecteert.