### PR TITLE
feat(external-db): add dynamic retailer alias learning

### DIFF
--- a/backend/app/services/external_candidate_normalization.py
+++ b/backend/app/services/external_candidate_normalization.py
@@ -6,6 +6,7 @@ from app.services.product_taxonomy_store import normalize_taxonomy_text
 
 SOURCE_PRIORITY = {
     "lidl_catalog_enrichment": 100,
+    "retailer_alias_learning": 95,
     "lidl_product_group": 90,
     "product_taxonomy_seed": 80,
     "OFF-index": 70,

--- a/backend/app/services/external_database_matchflow_evidence.py
+++ b/backend/app/services/external_database_matchflow_evidence.py
@@ -5,13 +5,25 @@ from typing import Any
 from app.services import external_product_candidate_store as candidate_store
 from app.services.external_candidate_normalization import normalize_external_candidates
 from app.services.external_database_matchers import match_retailer_receipt_line as _base_match_retailer_receipt_line
+from app.services.external_product_alias_store import find_alias_candidates, save_alias_from_candidate
 from app.services.product_evidence_packet import apply_product_evidence_to_candidates, build_product_evidence_packet_dict
 
 
 def _with_evidence_scoring(result: dict[str, Any], receipt_line_text: str, retailer_code: str) -> dict[str, Any]:
-    candidates = list(result.get("candidates") or [])
+    base_candidates = list(result.get("candidates") or [])
+    alias_candidates = find_alias_candidates(retailer_code, receipt_line_text)
+    candidates = alias_candidates + base_candidates
     if not candidates:
-        return result
+        enriched_empty = dict(result)
+        enriched_empty["uses_product_evidence_scoring"] = True
+        enriched_empty["uses_candidate_deduplication"] = False
+        enriched_empty["uses_retailer_alias_learning"] = bool(alias_candidates)
+        enriched_empty["candidate_count_before_deduplication"] = 0
+        enriched_empty["candidate_count_after_deduplication"] = 0
+        enriched_empty["creates_global_product"] = False
+        enriched_empty["creates_household_article"] = False
+        enriched_empty["creates_inventory_event"] = False
+        return enriched_empty
 
     evidence_packet = build_product_evidence_packet_dict(receipt_line_text, retailer_code=retailer_code)
     rescored = apply_product_evidence_to_candidates(
@@ -22,12 +34,22 @@ def _with_evidence_scoring(result: dict[str, Any], receipt_line_text: str, retai
     )
     normalized = normalize_external_candidates(rescored, evidence_packet=evidence_packet)
 
+    if normalized:
+        save_alias_from_candidate(
+            retailer_code=retailer_code,
+            receipt_line_text=receipt_line_text,
+            candidate=normalized[0],
+            learned_from="matchflow_evidence",
+        )
+
     enriched = dict(result)
     enriched["candidates"] = normalized[:5]
     enriched["uses_product_evidence_scoring"] = True
     enriched["uses_candidate_deduplication"] = len(normalized) < len(rescored)
+    enriched["uses_retailer_alias_learning"] = bool(alias_candidates)
     enriched["candidate_count_before_deduplication"] = len(rescored)
     enriched["candidate_count_after_deduplication"] = len(normalized[:5])
+    enriched["alias_candidate_count"] = len(alias_candidates)
     enriched["creates_global_product"] = False
     enriched["creates_household_article"] = False
     enriched["creates_inventory_event"] = False

--- a/backend/app/services/external_product_alias_store.py
+++ b/backend/app/services/external_product_alias_store.py
@@ -1,0 +1,436 @@
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db import engine
+from app.services.product_taxonomy_store import normalize_taxonomy_text
+from app.services.retailer_catalog_enrichment import CATALOG_SEED_PATH
+
+ALIAS_SOURCE_NAME = "retailer_alias_learning"
+MIN_ALIAS_CONFIDENCE = 0.90
+
+ALIAS_COLUMNS: dict[str, str] = {
+    "id": "TEXT PRIMARY KEY",
+    "retailer_code": "TEXT",
+    "normalized_receipt_line_text": "TEXT",
+    "raw_receipt_line_text": "TEXT",
+    "candidate_source_name": "TEXT",
+    "candidate_source_product_code": "TEXT",
+    "candidate_name": "TEXT",
+    "candidate_brand": "TEXT",
+    "category": "TEXT",
+    "product_type": "TEXT",
+    "quantity_label": "TEXT",
+    "source_url": "TEXT",
+    "confidence": "REAL",
+    "learned_from": "TEXT",
+    "created_at": "TEXT",
+    "updated_at": "TEXT",
+}
+
+CREATE_EXTERNAL_PRODUCT_ALIASES_SQL = """
+CREATE TABLE IF NOT EXISTS external_product_aliases (
+    id TEXT PRIMARY KEY,
+    retailer_code TEXT,
+    normalized_receipt_line_text TEXT,
+    raw_receipt_line_text TEXT,
+    candidate_source_name TEXT,
+    candidate_source_product_code TEXT,
+    candidate_name TEXT,
+    candidate_brand TEXT,
+    category TEXT,
+    product_type TEXT,
+    quantity_label TEXT,
+    source_url TEXT,
+    confidence REAL,
+    learned_from TEXT,
+    created_at TEXT,
+    updated_at TEXT
+)
+"""
+
+CREATE_EXTERNAL_PRODUCT_ALIASES_INDEX_SQL = """
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_product_aliases_lookup
+ON external_product_aliases (retailer_code, normalized_receipt_line_text, candidate_source_name, candidate_source_product_code)
+"""
+
+CREATE_EXTERNAL_PRODUCT_ALIASES_CODE_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_external_product_aliases_code
+ON external_product_aliases (retailer_code, candidate_source_product_code)
+"""
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def normalize_alias_text(value: str | None) -> str:
+    return normalize_taxonomy_text(value)
+
+
+def _sqlite_columns(conn) -> set[str]:
+    rows = conn.execute(text("PRAGMA table_info(external_product_aliases)")).mappings().all()
+    return {str(row.get("name") or "") for row in rows}
+
+
+def _postgres_columns(conn) -> set[str]:
+    rows = conn.execute(
+        text(
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_name = 'external_product_aliases'
+            """
+        )
+    ).mappings().all()
+    return {str(row.get("column_name") or "") for row in rows}
+
+
+def _add_missing_columns(conn) -> None:
+    dialect_name = str(engine.dialect.name or "").lower()
+    existing_columns = _sqlite_columns(conn) if dialect_name == "sqlite" else _postgres_columns(conn)
+    for column_name, column_definition in ALIAS_COLUMNS.items():
+        if column_name in existing_columns or column_name == "id":
+            continue
+        conn.execute(text(f"ALTER TABLE external_product_aliases ADD COLUMN {column_name} {column_definition}"))
+
+
+def ensure_external_product_aliases_schema() -> None:
+    with engine.begin() as conn:
+        conn.execute(text(CREATE_EXTERNAL_PRODUCT_ALIASES_SQL))
+        _add_missing_columns(conn)
+        conn.execute(text(CREATE_EXTERNAL_PRODUCT_ALIASES_INDEX_SQL))
+        conn.execute(text(CREATE_EXTERNAL_PRODUCT_ALIASES_CODE_INDEX_SQL))
+
+
+def _field(mapping: dict[str, Any], names: list[str]) -> str:
+    for name in names:
+        value = mapping.get(name)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return ""
+
+
+def _candidate_source_name(candidate: dict[str, Any]) -> str:
+    return _field(candidate, ["candidate_source_name", "source_name"]) or "external_product_index"
+
+
+def _candidate_source_code(candidate: dict[str, Any]) -> str:
+    return _field(candidate, ["candidate_source_product_code", "source_product_code", "retailer_article_number", "gtin", "ean", "code"])
+
+
+def _is_usable_source_code(value: str | None) -> bool:
+    normalized = str(value or "").strip().lower()
+    return bool(normalized) and normalized not in {"unknown", "onbekend", "-"}
+
+
+def _stem_set(value: str | None) -> set[str]:
+    stems: set[str] = set()
+    for token in normalize_alias_text(value).split():
+        if len(token) >= 4:
+            stems.add(token[:5])
+    return stems
+
+
+def _stem_overlap(left: str | None, right: str | None) -> float:
+    left_stems = _stem_set(left)
+    right_stems = _stem_set(right)
+    if not left_stems or not right_stems:
+        return 0.0
+    return len(left_stems & right_stems) / max(1, len(left_stems | right_stems))
+
+
+def _alias_candidate(row: dict[str, Any], receipt_line_text: str | None, fuzzy_score: float | None = None) -> dict[str, Any]:
+    confidence = float(row.get("confidence") or 0.0)
+    if fuzzy_score is not None:
+        confidence = min(confidence, max(MIN_ALIAS_CONFIDENCE, round(0.88 + fuzzy_score / 10, 3)))
+    score = round(max(MIN_ALIAS_CONFIDENCE, confidence), 3)
+    candidate_source_name = str(row.get("candidate_source_name") or ALIAS_SOURCE_NAME).strip()
+    candidate_source_product_code = str(row.get("candidate_source_product_code") or "").strip()
+    candidate = {
+        "candidate_name": str(row.get("candidate_name") or "").strip(),
+        "candidate_brand": str(row.get("candidate_brand") or "").strip(),
+        "candidate_source_name": ALIAS_SOURCE_NAME,
+        "candidate_source_product_code": candidate_source_product_code,
+        "source_name": ALIAS_SOURCE_NAME,
+        "source_product_code": candidate_source_product_code,
+        "retailer_article_number": candidate_source_product_code,
+        "quantity_label": str(row.get("quantity_label") or "").strip(),
+        "variant": "",
+        "source_url": str(row.get("source_url") or "").strip(),
+        "score": score,
+        "score_breakdown": {
+            "retailer_alias_learning": True,
+            "alias_source_name": candidate_source_name,
+            "alias_confidence": confidence,
+            "fuzzy_alias_score": fuzzy_score,
+        },
+        "candidate_status": "probable_candidate" if score >= 0.85 else "possible_candidate",
+        "is_probable": score >= 0.85,
+        "created_by": ALIAS_SOURCE_NAME,
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+    }
+    if receipt_line_text:
+        candidate["matched_receipt_line_text"] = str(receipt_line_text).strip()
+    return candidate
+
+
+def _existing_alias(conn, retailer_code: str, normalized_text: str, source_name: str, source_code: str) -> dict[str, Any] | None:
+    row = conn.execute(
+        text(
+            """
+            SELECT *
+            FROM external_product_aliases
+            WHERE retailer_code = :retailer_code
+              AND normalized_receipt_line_text = :normalized_text
+              AND candidate_source_name = :source_name
+              AND candidate_source_product_code = :source_code
+            LIMIT 1
+            """
+        ),
+        {
+            "retailer_code": retailer_code,
+            "normalized_text": normalized_text,
+            "source_name": source_name,
+            "source_code": source_code,
+        },
+    ).mappings().first()
+    return dict(row) if row else None
+
+
+def upsert_external_product_alias(
+    retailer_code: str | None,
+    receipt_line_text: str | None,
+    candidate: dict[str, Any],
+    learned_from: str,
+    confidence: float | None = None,
+) -> dict[str, Any]:
+    ensure_external_product_aliases_schema()
+    normalized_retailer = normalize_alias_text(retailer_code)
+    normalized_text = normalize_alias_text(receipt_line_text)
+    if not normalized_retailer or not normalized_text:
+        return {"ok": False, "reason": "missing_alias_context"}
+
+    source_name = _candidate_source_name(candidate)
+    source_code = _candidate_source_code(candidate)
+    if not _is_usable_source_code(source_code):
+        return {"ok": False, "reason": "missing_source_code"}
+
+    alias_confidence = float(confidence if confidence is not None else candidate.get("score") or 0.0)
+    if alias_confidence < MIN_ALIAS_CONFIDENCE:
+        return {"ok": False, "reason": "confidence_below_threshold", "confidence": alias_confidence}
+
+    timestamp = now_iso()
+    params = {
+        "retailer_code": normalized_retailer,
+        "normalized_receipt_line_text": normalized_text,
+        "raw_receipt_line_text": str(receipt_line_text or "").strip(),
+        "candidate_source_name": source_name,
+        "candidate_source_product_code": source_code,
+        "candidate_name": _field(candidate, ["candidate_name", "product_name", "name"]),
+        "candidate_brand": _field(candidate, ["candidate_brand", "brand"]),
+        "category": _field(candidate, ["category", "candidate_category"]),
+        "product_type": _field(candidate, ["product_type", "candidate_product_type"]),
+        "quantity_label": _field(candidate, ["quantity_label", "quantity"]),
+        "source_url": _field(candidate, ["source_url", "url"]),
+        "confidence": alias_confidence,
+        "learned_from": str(learned_from or "retailer_alias_learning").strip(),
+        "updated_at": timestamp,
+    }
+
+    with engine.begin() as conn:
+        existing = _existing_alias(conn, normalized_retailer, normalized_text, source_name, source_code)
+        if existing:
+            conn.execute(
+                text(
+                    """
+                    UPDATE external_product_aliases
+                    SET raw_receipt_line_text = :raw_receipt_line_text,
+                        candidate_name = :candidate_name,
+                        candidate_brand = :candidate_brand,
+                        category = :category,
+                        product_type = :product_type,
+                        quantity_label = :quantity_label,
+                        source_url = :source_url,
+                        confidence = CASE WHEN confidence >= :confidence THEN confidence ELSE :confidence END,
+                        learned_from = :learned_from,
+                        updated_at = :updated_at
+                    WHERE id = :id
+                    """
+                ),
+                {**params, "id": existing.get("id")},
+            )
+            return {"ok": True, "id": existing.get("id"), "updated": True, "created": False}
+
+        alias_id = str(uuid.uuid4())
+        conn.execute(
+            text(
+                """
+                INSERT INTO external_product_aliases (
+                    id,
+                    retailer_code,
+                    normalized_receipt_line_text,
+                    raw_receipt_line_text,
+                    candidate_source_name,
+                    candidate_source_product_code,
+                    candidate_name,
+                    candidate_brand,
+                    category,
+                    product_type,
+                    quantity_label,
+                    source_url,
+                    confidence,
+                    learned_from,
+                    created_at,
+                    updated_at
+                ) VALUES (
+                    :id,
+                    :retailer_code,
+                    :normalized_receipt_line_text,
+                    :raw_receipt_line_text,
+                    :candidate_source_name,
+                    :candidate_source_product_code,
+                    :candidate_name,
+                    :candidate_brand,
+                    :category,
+                    :product_type,
+                    :quantity_label,
+                    :source_url,
+                    :confidence,
+                    :learned_from,
+                    :created_at,
+                    :updated_at
+                )
+                """
+            ),
+            {**params, "id": alias_id, "created_at": timestamp},
+        )
+        return {"ok": True, "id": alias_id, "updated": False, "created": True}
+
+
+def save_alias_from_candidate(
+    retailer_code: str | None,
+    receipt_line_text: str | None,
+    candidate: dict[str, Any],
+    learned_from: str = "matchflow_evidence",
+    min_score: float = MIN_ALIAS_CONFIDENCE,
+) -> dict[str, Any]:
+    score = float(candidate.get("score") or 0.0)
+    if score < min_score:
+        return {"ok": False, "reason": "score_below_threshold", "score": score}
+    return upsert_external_product_alias(
+        retailer_code=retailer_code,
+        receipt_line_text=receipt_line_text,
+        candidate=candidate,
+        learned_from=learned_from,
+        confidence=score,
+    )
+
+
+def _catalog_rules() -> list[dict[str, Any]]:
+    path = Path(CATALOG_SEED_PATH)
+    if not path.exists():
+        return []
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return [dict(rule) for rule in (payload.get("rules") or [])]
+
+
+def ensure_catalog_aliases(retailer_code: str | None = "lidl") -> dict[str, Any]:
+    normalized_retailer = normalize_alias_text(retailer_code)
+    if normalized_retailer != "lidl":
+        return {"ok": True, "created_or_updated": 0, "reason": "unsupported_retailer"}
+
+    changed = 0
+    for rule in _catalog_rules():
+        source_code = str(rule.get("source_product_code") or "").strip()
+        if not _is_usable_source_code(source_code):
+            continue
+        candidate = {
+            "candidate_name": str(rule.get("catalog_product_name") or "").strip(),
+            "candidate_brand": str(rule.get("brand") or "").strip(),
+            "candidate_source_name": "lidl_catalog_enrichment",
+            "candidate_source_product_code": source_code,
+            "source_url": str(rule.get("source_url") or "").strip(),
+            "category": str(rule.get("category") or "").strip(),
+            "product_type": str(rule.get("product_type") or "").strip(),
+            "quantity_label": str(rule.get("quantity_label") or "").strip(),
+            "score": float(rule.get("confidence") or MIN_ALIAS_CONFIDENCE),
+        }
+        for term in rule.get("receipt_terms") or []:
+            result = upsert_external_product_alias(
+                retailer_code=normalized_retailer,
+                receipt_line_text=str(term or ""),
+                candidate=candidate,
+                learned_from="catalog_seed",
+                confidence=float(rule.get("confidence") or MIN_ALIAS_CONFIDENCE),
+            )
+            if result.get("ok"):
+                changed += 1
+    return {"ok": True, "created_or_updated": changed}
+
+
+def _exact_alias_rows(conn, retailer_code: str, normalized_text: str) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        text(
+            """
+            SELECT *
+            FROM external_product_aliases
+            WHERE retailer_code = :retailer_code
+              AND normalized_receipt_line_text = :normalized_text
+            ORDER BY confidence DESC, updated_at DESC
+            LIMIT 10
+            """
+        ),
+        {"retailer_code": retailer_code, "normalized_text": normalized_text},
+    ).mappings().all()
+    return [dict(row) for row in rows]
+
+
+def _fuzzy_alias_rows(conn, retailer_code: str, normalized_text: str) -> list[tuple[dict[str, Any], float]]:
+    rows = conn.execute(
+        text(
+            """
+            SELECT *
+            FROM external_product_aliases
+            WHERE retailer_code = :retailer_code
+              AND confidence >= :min_confidence
+            ORDER BY confidence DESC, updated_at DESC
+            LIMIT 200
+            """
+        ),
+        {"retailer_code": retailer_code, "min_confidence": MIN_ALIAS_CONFIDENCE},
+    ).mappings().all()
+    scored: list[tuple[dict[str, Any], float]] = []
+    for row in rows:
+        item = dict(row)
+        overlap = _stem_overlap(normalized_text, str(item.get("normalized_receipt_line_text") or ""))
+        if overlap >= 0.65:
+            scored.append((item, overlap))
+    scored.sort(key=lambda pair: (-pair[1], -float(pair[0].get("confidence") or 0.0)))
+    return scored[:5]
+
+
+def find_alias_candidates(retailer_code: str | None, receipt_line_text: str | None) -> list[dict[str, Any]]:
+    ensure_external_product_aliases_schema()
+    normalized_retailer = normalize_alias_text(retailer_code)
+    normalized_text = normalize_alias_text(receipt_line_text)
+    if not normalized_retailer or not normalized_text:
+        return []
+
+    ensure_catalog_aliases(normalized_retailer)
+
+    with engine.begin() as conn:
+        exact_rows = _exact_alias_rows(conn, normalized_retailer, normalized_text)
+        if exact_rows:
+            return [_alias_candidate(row, receipt_line_text) for row in exact_rows]
+
+        fuzzy_rows = _fuzzy_alias_rows(conn, normalized_retailer, normalized_text)
+        return [_alias_candidate(row, receipt_line_text, fuzzy_score=score) for row, score in fuzzy_rows]

--- a/backend/tests/test_m2c2i17_retailer_alias_learning.py
+++ b/backend/tests/test_m2c2i17_retailer_alias_learning.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+import uuid
+
+from app.services.external_database_matchflow_evidence import match_retailer_receipt_line
+from app.services.external_product_alias_store import find_alias_candidates, save_alias_from_candidate
+from app.services.product_evidence_packet import build_product_evidence_packet_dict
+from app.services.retailer_catalog_enrichment import CATALOG_SEED_PATH
+
+
+def _first_catalog_rule() -> dict:
+    payload = json.loads(CATALOG_SEED_PATH.read_text(encoding="utf-8"))
+    return dict((payload.get("rules") or [])[0])
+
+
+def test_m2c2i17_catalog_seed_is_packaged_and_matchable() -> None:
+    rule = _first_catalog_rule()
+    receipt_term = str((rule.get("receipt_terms") or [])[0])
+    expected_code = str(rule.get("source_product_code") or "")
+
+    evidence = build_product_evidence_packet_dict(receipt_term, "lidl")
+
+    assert evidence["matched"] is True
+    assert evidence["retailer_article_code"] == expected_code
+    assert evidence["creates_global_product"] is False
+    assert evidence["creates_household_article"] is False
+    assert evidence["creates_inventory_event"] is False
+
+
+def test_m2c2i17_alias_is_learned_and_reused_for_new_receipt_text() -> None:
+    rule = _first_catalog_rule()
+    receipt_term = str((rule.get("receipt_terms") or [])[0])
+    expected_code = str(rule.get("source_product_code") or "")
+
+    initial_result = match_retailer_receipt_line("lidl", receipt_term, True)
+    initial_candidate = initial_result["candidates"][0]
+    alias_text = f"alias-probe-{uuid.uuid4().hex[:12]}"
+
+    saved = save_alias_from_candidate("lidl", alias_text, initial_candidate, learned_from="test_alias_learning")
+    assert saved["ok"] is True
+
+    alias_candidates = find_alias_candidates("lidl", alias_text)
+    assert alias_candidates
+    assert alias_candidates[0]["candidate_source_product_code"] == expected_code
+    assert alias_candidates[0]["creates_global_product"] is False
+    assert alias_candidates[0]["creates_household_article"] is False
+    assert alias_candidates[0]["creates_inventory_event"] is False
+
+    learned_result = match_retailer_receipt_line("lidl", alias_text, True)
+    learned_candidate = learned_result["candidates"][0]
+
+    assert learned_candidate["candidate_source_product_code"] == expected_code
+    assert learned_candidate["score"] >= 0.90
+    assert learned_result["creates_global_product"] is False
+    assert learned_result["creates_household_article"] is False
+    assert learned_result["creates_inventory_event"] is False

--- a/docs/architecture/M2C2i17_retailer_alias_learning.md
+++ b/docs/architecture/M2C2i17_retailer_alias_learning.md
@@ -1,0 +1,28 @@
+# M2C2i-17 — Dynamische retailer-aliaslearning
+
+## Doel
+
+Nieuwe bontekstvarianten moeten dezelfde externe productkandidaat kunnen krijgen als een eerder betrouwbaar herkende bonregel, zonder dat productkennis in Python-code wordt vastgelegd.
+
+## Besluit
+
+Rezzerv leert alleen externe kandidaat-herkenning:
+
+- geen `global_products` aanmaken
+- geen huishoudartikel aanmaken
+- geen voorraadmutatie aanmaken
+
+## Implementatie
+
+- Nieuwe tabel: `external_product_aliases`
+- Nieuwe service: `backend/app/services/external_product_alias_store.py`
+- Matchflow gebruikt aliaskandidaten naast de bestaande index-, catalogus- en taxonomy-kandidaten.
+- Bij score >= 0.90 en een bruikbare externe code wordt de bontekst als alias opgeslagen.
+- Canonieke seedregels worden als aliasbasis ingelezen vanuit `lidl_catalog_enrichment_seed.json`.
+
+## Acceptatie
+
+- Een betrouwbare match wordt als alias opgeslagen.
+- Een latere bontekstvariant kan via de aliaslaag opnieuw dezelfde kandidaat tonen.
+- Safety flags blijven false.
+- Productkennis blijft in JSON/data of database, niet in Python-code.

--- a/docs/release/M2C2i17_change_summary.md
+++ b/docs/release/M2C2i17_change_summary.md
@@ -1,0 +1,19 @@
+# M2C2i-17 change summary
+
+## Gewijzigd
+
+- Nieuwe aliasstore voor externe productkandidaten.
+- Matchflow voegt aliaskandidaten toe aan bestaande kandidaatset.
+- Betrouwbare topkandidaat kan bontekst als alias opslaan.
+- Aliasbron krijgt prioriteit onder catalogusbron en boven generieke bronnen.
+- Tests toegevoegd voor seedcontract en aliashergebruik.
+
+## Niet gewijzigd
+
+- Geen voorraadverwerking.
+- Geen definitieve productkoppeling.
+- Geen UI-layout.
+
+## QA-status
+
+Nog niet lokaal gevalideerd in Docker. PR mag pas worden gemerged na lokale backend-smoke en UI-check.

--- a/docs/release/M2C2i17_known_limitations.md
+++ b/docs/release/M2C2i17_known_limitations.md
@@ -1,0 +1,6 @@
+# M2C2i-17 bekende beperkingen
+
+- De PR is via GitHub voorbereid en niet lokaal in Docker gevalideerd.
+- De aliaslaag gebruikt een nieuwe runtime-tabel; databasevalidatie is verplicht.
+- Fuzzy aliasherkenning is conservatief en bedoeld als hulpmiddel, niet als definitieve productkoppeling.
+- Kandidaten blijven externe kandidaten; de gebruiker moet nog steeds expliciet bevestigen.

--- a/docs/release/M2C2i17_merge_policy.md
+++ b/docs/release/M2C2i17_merge_policy.md
@@ -1,0 +1,11 @@
+# M2C2i-17 mergebeleid
+
+Deze PR mag pas worden gemerged nadat lokaal is bevestigd:
+
+1. Docker backend build slaagt.
+2. `/api/health` is ok.
+3. Seedcontract werkt.
+4. Aliaslearning werkt.
+5. UI-route `Externe databases` toont geen regressie.
+
+Geen lokale validatie betekent: niet mergen.

--- a/docs/release/M2C2i17_no_product_names_note.md
+++ b/docs/release/M2C2i17_no_product_names_note.md
@@ -1,0 +1,7 @@
+# M2C2i-17 no product names in Python
+
+Deze PR houdt productkennis buiten Python-code.
+
+De test leest de benodigde receipt terms en productcodes dynamisch uit `lidl_catalog_enrichment_seed.json`.
+
+Daarmee wordt getest op gedrag en configuratiecontract, zonder productnamen als Python-literals toe te voegen.

--- a/docs/release/M2C2i17_po_test.md
+++ b/docs/release/M2C2i17_po_test.md
@@ -1,0 +1,18 @@
+# M2C2i-17 PO-test
+
+## Doel
+
+Controleren dat Rezzerv geleerde Lidl-bonvarianten opnieuw als externe kandidaat toont.
+
+## Teststappen
+
+1. Start de app lokaal.
+2. Open `Externe databases`.
+3. Controleer bestaande Lidl-kandidaten.
+4. Controleer dat kandidaatregels geen automatische voorraad- of artikelmutatie veroorzaken.
+
+## Verwacht gedrag
+
+- Bekende Lidl-regels tonen een kandidaat met externe code.
+- Nieuwe of afwijkende bontekstvarianten kunnen via de aliaslaag opnieuw dezelfde kandidaat tonen.
+- De gebruiker moet nog steeds expliciet bevestigen voordat iets definitief wordt.

--- a/docs/release/M2C2i17_ready_for_local_validation.md
+++ b/docs/release/M2C2i17_ready_for_local_validation.md
@@ -1,0 +1,9 @@
+# M2C2i-17 klaar voor lokale validatie
+
+Deze branch is klaar om lokaal te valideren.
+
+Status:
+
+- Implementatie aanwezig.
+- PR mag worden geopend.
+- Nog geen merge zonder lokale validatie.

--- a/docs/release/M2C2i17_release_gate.md
+++ b/docs/release/M2C2i17_release_gate.md
@@ -1,0 +1,37 @@
+# M2C2i-17 Release Gate
+
+## Release Gate v1.10 – Compliance Check
+
+Basisversie: `main` na PR #94 (`9524eca627ff264e4d859309c2685015b5fd733c`)
+
+Nieuwe versie: nog niet vastgesteld; dit is een PR, geen release.
+
+Releasecategorie: backend feature.
+
+Wijzigingsdoel: dynamische retailer-aliaslearning voor externe productkandidaten.
+
+Niet gewijzigd:
+- UI-layout
+- voorraadmutaties
+- definitive productkoppelingen
+- huishoudartikelen
+
+Getest:
+- Nog niet lokaal uitgevoerd in Docker.
+
+Niet getest:
+- Docker build
+- backend runtime smoke
+- UI bovenste tabel
+
+Risiconiveau: middel. Nieuwe runtime-tabel en matchflowwijziging.
+
+Database locatie: moet lokaal bevestigd worden via `/api/health`.
+
+Database validatie: verplicht vóór merge.
+
+Scope Gate: groen op afbakening.
+
+QA/QC Gate: nog niet groen.
+
+Packaging Gate: niet van toepassing voor PR; wel verplicht bij release.

--- a/docs/release/M2C2i17_scope_gate.md
+++ b/docs/release/M2C2i17_scope_gate.md
@@ -1,0 +1,25 @@
+# M2C2i-17 Scope Gate
+
+## Basis
+
+- Basiscommit: `9524eca627ff264e4d859309c2685015b5fd733c`
+- Basis: `main` na M2C2i-16 / PR #94
+
+## Releasecategorie
+
+Backend feature.
+
+## Hoofddoel
+
+Dynamische retailer-aliaslearning voor externe productkandidaten.
+
+## Niet wijzigen
+
+- Geen UI-componenten.
+- Geen voorraadmutaties.
+- Geen definitieve product- of huishoudartikelkoppeling.
+- Geen productnamen in Python-code.
+
+## Risico
+
+Nieuwe tabel wordt runtime via service aangemaakt. Lokale databasevalidatie is verplicht vóór merge.

--- a/docs/release/M2C2i17_test_result_placeholder.md
+++ b/docs/release/M2C2i17_test_result_placeholder.md
@@ -1,0 +1,10 @@
+# M2C2i-17 testresultaat
+
+Nog in te vullen na lokale validatie.
+
+Te bevestigen:
+
+- Backend build: open
+- Health check: open
+- Aliaslearning smoke: open
+- UI-check: open

--- a/docs/release/M2C2i17_validation.md
+++ b/docs/release/M2C2i17_validation.md
@@ -1,0 +1,33 @@
+# M2C2i-17 validatie
+
+## Scope
+
+Backend feature: dynamische retailer-aliaslearning voor externe productkandidaten.
+
+## Niet gewijzigd
+
+- Geen UI-componenten aangepast.
+- Geen voorraadlogica aangepast.
+- Geen `global_products` of huishoudartikelen aangemaakt.
+
+## Testen
+
+Aanbevolen lokale checks:
+
+```powershell
+docker compose up -d --build backend
+```
+
+```powershell
+docker compose exec backend python -c "from app.services.external_database_matchflow_evidence import match_retailer_receipt_line; r=match_retailer_receipt_line('lidl','Mexicaanse kruiden',True); c=r['candidates'][0]; print(c.get('candidate_name'), c.get('score'), c.get('candidate_source_product_code'), r.get('creates_global_product'), r.get('creates_household_article'), r.get('creates_inventory_event'))"
+```
+
+```powershell
+docker compose exec backend python -c "from app.services.external_database_matchflow_evidence import match_retailer_receipt_line; r=match_retailer_receipt_line('lidl','MEXICAANSE KRUIDENM',True); c=r['candidates'][0]; print(c.get('candidate_name'), c.get('score'), c.get('candidate_source_name'), c.get('candidate_source_product_code'))"
+```
+
+## Verwachting
+
+- Herkende kandidaat heeft een externe code.
+- Score is hoog genoeg voor een betrouwbare alias.
+- Safety flags blijven false.

--- a/docs/technical/M2C2i17_local_commands.md
+++ b/docs/technical/M2C2i17_local_commands.md
@@ -1,0 +1,21 @@
+# M2C2i-17 lokale validatiecommando's
+
+```powershell
+cd C:\Users\Gebruiker\Rezzerv_Github
+git switch main
+git pull --ff-only
+git switch m2c2i17-retailer-alias-learning
+git pull --ff-only
+```
+
+```powershell
+docker compose up -d --build backend
+```
+
+```powershell
+docker compose exec backend python -c "from app.services.external_database_matchflow_evidence import match_retailer_receipt_line; r=match_retailer_receipt_line('lidl','Mexicaanse kruiden',True); c=r['candidates'][0]; print(c.get('candidate_name'), c.get('score'), c.get('candidate_source_product_code'), r.get('creates_global_product'), r.get('creates_household_article'), r.get('creates_inventory_event'))"
+```
+
+```powershell
+docker compose exec backend python -c "from app.services.external_database_matchflow_evidence import match_retailer_receipt_line; r=match_retailer_receipt_line('lidl','MEXICAANSE KRUIDENM',True); c=r['candidates'][0]; print(c.get('candidate_name'), c.get('score'), c.get('candidate_source_name'), c.get('candidate_source_product_code'))"
+```


### PR DESCRIPTION
M2C2i-17 — Dynamische retailer-aliaslearning voor externe productkandidaten.

Wijzigingen:
- Nieuwe backendservice `external_product_alias_store.py` met runtime-tabel `external_product_aliases`.
- Matchflow gebruikt geleerde aliaskandidaten naast bestaande catalogus/index/taxonomy-kandidaten.
- Betrouwbare topkandidaten kunnen bontekst als alias opslaan voor hergebruik.
- Aliasbron krijgt prioriteit onder catalogusbron en boven generieke bronnen.
- Tests toegevoegd zonder productnamen als Python-literals; testdata wordt dynamisch uit de JSON-seed gelezen.
- Documentatie, scope gate, release gate en lokale validatiecommando's toegevoegd.

Niet gewijzigd:
- Geen UI-layoutwijziging.
- Geen voorraadmutatie.
- Geen automatische global_product- of household_article-aanmaak.

Belangrijk:
- Deze PR is via GitHub voorbereid en is nog niet lokaal in Docker gevalideerd.
- Niet mergen vóór lokale backend-smoke, databasevalidatie en UI-check Externe databases.