### PR TITLE
feat(external-db): skip candidate search for resolved receipt lines

### DIFF
--- a/backend/app/services/external_database_matchflow_evidence.py
+++ b/backend/app/services/external_database_matchflow_evidence.py
@@ -9,6 +9,24 @@ from app.services.external_product_alias_store import find_alias_candidates, sav
 from app.services.product_evidence_packet import apply_product_evidence_to_candidates, build_product_evidence_packet_dict
 
 
+M2C2I20_RESOLVED_EXTERNAL_STATUSES = {
+    "resolved",
+    "external_resolved",
+    "linked_to_catalog",
+    "user_confirmed",
+}
+
+M2C2I20_EXTERNAL_CODE_FIELDS = (
+    "external_product_code",
+    "external_source_product_code",
+    "external_product_index_id",
+    "external_article_code",
+    "retailer_article_number",
+    "gtin",
+    "ean",
+)
+
+
 def _with_evidence_scoring(result: dict[str, Any], receipt_line_text: str, retailer_code: str) -> dict[str, Any]:
     base_candidates = list(result.get("candidates") or [])
     alias_candidates = find_alias_candidates(retailer_code, receipt_line_text)
@@ -65,6 +83,100 @@ def match_retailer_receipt_line(retailer_code: str, receipt_line_text: str, incl
     return _with_evidence_scoring(result, receipt_line_text, retailer_code)
 
 
+def _m2c2i20_truthy(value: Any) -> bool:
+    normalized = str(value if value is not None else "").strip().lower()
+    return bool(normalized and normalized not in {"-", "0", "none", "null", "undefined", "false", "unknown", "onbekend"})
+
+
+def m2c2i20_external_product_code(item: dict[str, Any] | None) -> str:
+    if not isinstance(item, dict):
+        return ""
+    for field_name in M2C2I20_EXTERNAL_CODE_FIELDS:
+        value = str(item.get(field_name) if item.get(field_name) is not None else "").strip()
+        if _m2c2i20_truthy(value):
+            return value
+    return ""
+
+
+def is_m2c2i20_external_resolved_item(item: dict[str, Any] | None) -> bool:
+    """Return True when a receipt item already has a usable external article code.
+
+    M2C2i-20 rule: a receipt item that already has an external product code is resolved
+    for the external-database flow and must not be searched again.
+    """
+    if not isinstance(item, dict):
+        return False
+
+    external_code = m2c2i20_external_product_code(item)
+    if not external_code:
+        return False
+
+    status_values = {
+        str(item.get("external_match_status") or "").strip().lower(),
+        str(item.get("status") or "").strip().lower(),
+        str(item.get("candidate_status") or "").strip().lower(),
+    }
+    if status_values & M2C2I20_RESOLVED_EXTERNAL_STATUSES:
+        return True
+
+    if bool(item.get("is_external_resolved")) or bool(item.get("is_linked_to_catalog")):
+        return True
+
+    # Bovenste tabelrijen zijn bonartikelgedreven. Als zo'n rij al een externe code
+    # heeft, dan is zoeken op bontekst niet meer nodig.
+    if bool(item.get("is_receipt_item_placeholder")):
+        return True
+    if _m2c2i20_truthy(item.get("purchase_import_line_id")) or _m2c2i20_truthy(item.get("receipt_line_id")):
+        return True
+
+    return False
+
+
+def _m2c2i20_resolved_skip_entry(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "reason": "external_product_code_resolved",
+        "receipt_line_text": str(item.get("receipt_line_text") or item.get("receiptLineText") or "").strip(),
+        "retailer_code": str(item.get("retailer_code") or item.get("retailerCode") or "").strip().lower(),
+        "receipt_line_id": str(item.get("receipt_line_id") or item.get("receiptLineId") or "").strip() or None,
+        "purchase_import_line_id": str(item.get("purchase_import_line_id") or item.get("purchaseImportLineId") or "").strip() or None,
+        "external_product_code": m2c2i20_external_product_code(item),
+    }
+
+
+def _m2c2i20_split_resolved_items(items: list[dict[str, Any]] | None) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    unresolved: list[dict[str, Any]] = []
+    resolved: list[dict[str, Any]] = []
+    for item in items or []:
+        next_item = dict(item) if isinstance(item, dict) else item
+        if is_m2c2i20_external_resolved_item(next_item):
+            resolved.append(next_item)
+        else:
+            unresolved.append(next_item)
+    return unresolved, resolved
+
+
+def _m2c2i20_call_candidate_store_ensure(args: tuple[Any, ...], kwargs: dict[str, Any], unresolved_items: list[dict[str, Any]]) -> dict[str, Any]:
+    next_kwargs = dict(kwargs)
+    if "items" in next_kwargs:
+        next_kwargs["items"] = unresolved_items
+        return candidate_store.ensure_external_receipt_item_candidates(*args, **next_kwargs)
+    return candidate_store.ensure_external_receipt_item_candidates(unresolved_items, *args[1:], **next_kwargs)
+
+
+def _m2c2i20_enrich_ensure_result(result: dict[str, Any], original_total: int, resolved_items: list[dict[str, Any]]) -> dict[str, Any]:
+    enriched = dict(result or {})
+    resolved_skips = [_m2c2i20_resolved_skip_entry(item) for item in resolved_items]
+    enriched["total"] = original_total
+    enriched["skipped_count"] = int(enriched.get("skipped_count") or 0) + len(resolved_skips)
+    enriched["external_resolved_skipped_count"] = len(resolved_skips)
+    enriched["external_resolved_skipped"] = resolved_skips
+    enriched["m2c2i20_resolved_state_gate"] = True
+    enriched["creates_global_product"] = False
+    enriched["creates_household_article"] = False
+    enriched["creates_inventory_event"] = False
+    return enriched
+
+
 def save_matchpreview_candidates(*args: Any, **kwargs: Any) -> dict[str, Any]:
     previous_matcher = candidate_store.match_retailer_receipt_line
     candidate_store.match_retailer_receipt_line = match_retailer_receipt_line
@@ -75,9 +187,21 @@ def save_matchpreview_candidates(*args: Any, **kwargs: Any) -> dict[str, Any]:
 
 
 def ensure_external_receipt_item_candidates(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    items = kwargs.get("items") if "items" in kwargs else (args[0] if args else None)
+    if items is not None:
+        normalized_items = [dict(item) for item in (items or []) if isinstance(item, dict)]
+        unresolved_items, resolved_items = _m2c2i20_split_resolved_items(normalized_items)
+    else:
+        normalized_items = []
+        unresolved_items = []
+        resolved_items = []
+
     previous_matcher = candidate_store.match_retailer_receipt_line
     candidate_store.match_retailer_receipt_line = match_retailer_receipt_line
     try:
-        return candidate_store.ensure_external_receipt_item_candidates(*args, **kwargs)
+        if items is None:
+            return candidate_store.ensure_external_receipt_item_candidates(*args, **kwargs)
+        result = _m2c2i20_call_candidate_store_ensure(args, kwargs, unresolved_items)
+        return _m2c2i20_enrich_ensure_result(result, len(normalized_items), resolved_items)
     finally:
         candidate_store.match_retailer_receipt_line = previous_matcher

--- a/backend/tests/test_m2c2i20_external_resolved_state.py
+++ b/backend/tests/test_m2c2i20_external_resolved_state.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from app.services import external_database_matchflow_evidence as matchflow
+
+
+def test_m2c2i20_item_with_external_product_code_is_resolved() -> None:
+    item = {
+        "is_receipt_item_placeholder": True,
+        "purchase_import_line_id": "pil-1",
+        "receipt_line_text": "Veldsla",
+        "retailer_code": "lidl",
+        "retailer_article_number": "lidl:groente.veldsla",
+    }
+
+    assert matchflow.is_m2c2i20_external_resolved_item(item) is True
+    assert matchflow.m2c2i20_external_product_code(item) == "lidl:groente.veldsla"
+
+
+def test_m2c2i20_item_without_external_product_code_is_not_resolved() -> None:
+    item = {
+        "is_receipt_item_placeholder": True,
+        "purchase_import_line_id": "pil-2",
+        "receipt_line_text": "Onbekend artikel",
+        "retailer_code": "lidl",
+        "candidate_status": "no_candidate",
+    }
+
+    assert matchflow.is_m2c2i20_external_resolved_item(item) is False
+    assert matchflow.m2c2i20_external_product_code(item) == ""
+
+
+def test_m2c2i20_ensure_skips_resolved_items(monkeypatch) -> None:
+    captured = {}
+
+    def fake_ensure_external_receipt_item_candidates(*args, **kwargs):
+        items = kwargs.get("items") if "items" in kwargs else (args[0] if args else [])
+        captured["items"] = list(items or [])
+        return {
+            "ok": True,
+            "total": len(items or []),
+            "processed": len(items or []),
+            "saved_count": 0,
+            "updated_count": 0,
+            "skipped_count": 0,
+            "errors": [],
+            "creates_global_product": False,
+            "creates_household_article": False,
+            "creates_inventory_event": False,
+        }
+
+    monkeypatch.setattr(
+        matchflow.candidate_store,
+        "ensure_external_receipt_item_candidates",
+        fake_ensure_external_receipt_item_candidates,
+    )
+
+    resolved_item = {
+        "is_receipt_item_placeholder": True,
+        "purchase_import_line_id": "pil-1",
+        "receipt_line_text": "Veldsla",
+        "retailer_code": "lidl",
+        "retailer_article_number": "lidl:groente.veldsla",
+    }
+    unresolved_item = {
+        "is_receipt_item_placeholder": True,
+        "purchase_import_line_id": "pil-2",
+        "receipt_line_text": "Nieuw onbekend artikel",
+        "retailer_code": "lidl",
+    }
+
+    result = matchflow.ensure_external_receipt_item_candidates(
+        items=[resolved_item, unresolved_item],
+        include_below_threshold=True,
+    )
+
+    assert captured["items"] == [unresolved_item]
+    assert result["total"] == 2
+    assert result["processed"] == 1
+    assert result["external_resolved_skipped_count"] == 1
+    assert result["external_resolved_skipped"][0]["external_product_code"] == "lidl:groente.veldsla"
+    assert result["m2c2i20_resolved_state_gate"] is True
+    assert result["creates_global_product"] is False
+    assert result["creates_household_article"] is False
+    assert result["creates_inventory_event"] is False

--- a/docs/architecture/M2C2i20_external_resolved_state.md
+++ b/docs/architecture/M2C2i20_external_resolved_state.md
@@ -1,0 +1,67 @@
+# M2C2i-20 — Externe artikelcode als resolved-state op bonregels
+
+## Doel
+
+Een bonregel die al een externe artikelcode heeft, is voor de externe-databaseflow klaar. Rezzerv zoekt dan niet opnieuw op bontekst naar externe productkandidaten.
+
+```text
+bonregel met externe artikelcode
+→ external_match_status = resolved / external_resolved
+→ geen kandidaatzoekactie
+→ productinformatie komt voortaan via externe artikelcode
+```
+
+## Functionele regel
+
+Als een bonartikel een bruikbare externe artikelcode heeft, dan wordt het artikel beschouwd als resolved voor externe productherkenning.
+
+Voorbeelden van velden die als externe code kunnen tellen:
+
+- `external_product_code`
+- `external_source_product_code`
+- `external_product_index_id`
+- `external_article_code`
+- `retailer_article_number`
+- `gtin`
+- `ean`
+
+## Gedrag
+
+### Niet-resolved bonregel
+
+```text
+bonregel zonder externe code
+→ zoek kandidaten via seed / alias / matchflow
+→ bewaar kandidaatregels
+```
+
+### Resolved bonregel
+
+```text
+bonregel met externe code
+→ sla kandidaatzoekactie over
+→ geef expliciet terug dat deze regel is overgeslagen wegens resolved-state
+```
+
+## Veiligheidsgrenzen
+
+M2C2i-20 maakt nog steeds geen definitieve gebruikersartikelen of voorraadmutaties.
+
+```text
+creates_global_product = false
+creates_household_article = false
+creates_inventory_event = false
+```
+
+## Relatie met PR #95 en PR #96
+
+- PR #95 aliaslearning helpt om onbekende bontekst naar een externe code te brengen.
+- PR #96 Lidl-catalogusdekking geeft bekende Lidl-artikelen meer externe codes.
+- M2C2i-20 borgt dat een artikel na het verkrijgen van die externe code niet opnieuw door de zoekflow gaat.
+
+## Buiten scope
+
+- Geen bonregeltypes zoals verzendkosten, statiegeld of zegels.
+- Geen brede Lidl-catalogusimport.
+- Geen automatische Mijn-artikel-aanmaak.
+- Geen voorraadmutatie.

--- a/docs/release/M2C2i20_validation.md
+++ b/docs/release/M2C2i20_validation.md
@@ -1,0 +1,48 @@
+# M2C2i-20 — Validatie
+
+## Doelvalidatie
+
+Aantonen dat bonartikelen met een externe artikelcode niet opnieuw door de kandidaatzoekflow gaan.
+
+## Technische test
+
+```powershell
+docker compose exec backend python -m pytest backend/tests/test_m2c2i20_external_resolved_state.py -q
+```
+
+Verwacht:
+
+```text
+3 passed
+```
+
+## Functionele test in Externe databases
+
+1. Open `http://localhost:5174/externe-databases`.
+2. Controleer een bonartikel dat al een artikelnummer/externe code heeft.
+3. Klik op vernieuwen/kandidaten ophalen.
+4. Controleer dat dit artikel niet opnieuw als onbekend kandidaatzoekitem wordt behandeld.
+5. Controleer dat artikelen zonder externe code nog wel kandidaatzoekacties kunnen krijgen.
+
+## Verwachte technische output
+
+De ensure-flow geeft expliciet terug:
+
+```json
+{
+  "m2c2i20_resolved_state_gate": true,
+  "external_resolved_skipped_count": 1,
+  "creates_global_product": false,
+  "creates_household_article": false,
+  "creates_inventory_event": false
+}
+```
+
+## Releasebesluit
+
+GO als:
+
+- resolved bonregels worden overgeslagen;
+- unresolved bonregels nog kandidaten kunnen ophalen;
+- safety flags false blijven;
+- bestaande Lidl-catalogus- en aliaslearningflow niet regressief wijzigt.

--- a/docs/release/M2C2i20_validation.md
+++ b/docs/release/M2C2i20_validation.md
@@ -4,16 +4,71 @@
 
 Aantonen dat bonartikelen met een externe artikelcode niet opnieuw door de kandidaatzoekflow gaan.
 
-## Technische test
+## Technische smoke zonder pytest
+
+De backend-container bevat geen pytest. Gebruik daarom een gewone Python-smoke via stdin.
 
 ```powershell
-docker compose exec backend python -m pytest backend/tests/test_m2c2i20_external_resolved_state.py -q
+@'
+from app.services import external_database_matchflow_evidence as m
+
+resolved = {
+    "is_receipt_item_placeholder": True,
+    "purchase_import_line_id": "pil-1",
+    "receipt_line_text": "Veldsla",
+    "retailer_code": "lidl",
+    "retailer_article_number": "lidl:groente.veldsla",
+}
+
+unresolved = {
+    "is_receipt_item_placeholder": True,
+    "purchase_import_line_id": "pil-2",
+    "receipt_line_text": "Nieuw onbekend artikel",
+    "retailer_code": "lidl",
+}
+
+assert m.is_m2c2i20_external_resolved_item(resolved) is True
+assert m.m2c2i20_external_product_code(resolved) == "lidl:groente.veldsla"
+assert m.is_m2c2i20_external_resolved_item(unresolved) is False
+
+unresolved_items, resolved_items = m._m2c2i20_split_resolved_items([resolved, unresolved])
+
+assert unresolved_items == [unresolved]
+assert resolved_items == [resolved]
+
+result = m._m2c2i20_enrich_ensure_result(
+    {
+        "ok": True,
+        "total": 1,
+        "processed": 1,
+        "saved_count": 0,
+        "updated_count": 0,
+        "skipped_count": 0,
+        "errors": [],
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+    },
+    original_total=2,
+    resolved_items=resolved_items,
+)
+
+assert result["total"] == 2
+assert result["external_resolved_skipped_count"] == 1
+assert result["external_resolved_skipped"][0]["external_product_code"] == "lidl:groente.veldsla"
+assert result["m2c2i20_resolved_state_gate"] is True
+assert result["creates_global_product"] is False
+assert result["creates_household_article"] is False
+assert result["creates_inventory_event"] is False
+
+print("M2C2i-20 smoke OK: resolved bonartikelen worden niet opnieuw gezocht.")
+'@ | docker compose exec -T backend python
 ```
 
 Verwacht:
 
 ```text
-3 passed
+M2C2i-20 smoke OK: resolved bonartikelen worden niet opnieuw gezocht.
 ```
 
 ## Functionele test in Externe databases


### PR DESCRIPTION
M2C2i-20 — Externe artikelcode als resolved-state op bonregels.

Wijzigingen:
- Resolved-state gate toegevoegd aan de externe matchflow.
- Bonartikelen met een bruikbare externe artikelcode worden niet opnieuw gezocht.
- Ensure-flow splitst invoer in resolved en unresolved items.
- Alleen unresolved items gaan door naar kandidaatzoeken.
- Resultaat rapporteert `m2c2i20_resolved_state_gate`, `external_resolved_skipped_count` en `external_resolved_skipped`.
- Tests toegevoegd voor resolved-detectie en skipgedrag.
- Architectuur- en validatiedocumentatie toegevoegd.
- Validatie-instructie gecorrigeerd naar pytest-vrije smoke, omdat de backend-container geen pytest bevat.

Niet gewijzigd:
- Geen bonregeltypes.
- Geen brede Lidl-catalogusimport.
- Geen UI-layoutwijziging.
- Geen automatische Mijn-artikel-aanmaak.
- Geen voorraadmutatie.

Safety:
- `creates_global_product = False`
- `creates_household_article = False`
- `creates_inventory_event = False`

Lokale validatie:
- Pytest-vrije smoke uitgevoerd door PO: geslaagd.
- Verwachte output: `M2C2i-20 smoke OK: resolved bonartikelen worden niet opnieuw gezocht.`