### PR TITLE
perf(external-db): speed up resolved receipt item refresh

### DIFF
--- a/backend/app/services/external_database_matchflow_evidence.py
+++ b/backend/app/services/external_database_matchflow_evidence.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from sqlalchemy import text
+
+from app.db import engine
 from app.services import external_product_candidate_store as candidate_store
 from app.services.external_candidate_normalization import normalize_external_candidates
 from app.services.external_database_matchers import match_retailer_receipt_line as _base_match_retailer_receipt_line
@@ -25,6 +28,8 @@ M2C2I20_EXTERNAL_CODE_FIELDS = (
     "gtin",
     "ean",
 )
+
+_M2C2I20A_PERFORMANCE_INDEXES_READY = False
 
 
 def _with_evidence_scoring(result: dict[str, Any], receipt_line_text: str, retailer_code: str) -> dict[str, Any]:
@@ -155,6 +160,54 @@ def _m2c2i20_split_resolved_items(items: list[dict[str, Any]] | None) -> tuple[l
     return unresolved, resolved
 
 
+def _m2c2i20a_ensure_performance_indexes() -> None:
+    """Maak lichte indexen voor de Externe databases paging/refresh-flow.
+
+    De UI werkt bonartikelgedreven. Bij paginawissels en refreshes filteren we vooral op
+    context_key, purchase_import_line_id en receipt_line_id. Zonder indexen groeit de
+    reactietijd merkbaar zodra external_product_candidates meer historie bevat.
+    """
+    global _M2C2I20A_PERFORMANCE_INDEXES_READY
+    if _M2C2I20A_PERFORMANCE_INDEXES_READY:
+        return
+
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE INDEX IF NOT EXISTS idx_m2c2i20a_candidates_context_updated
+                ON external_product_candidates (context_key, updated_at)
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE INDEX IF NOT EXISTS idx_m2c2i20a_candidates_purchase_line
+                ON external_product_candidates (purchase_import_line_id, updated_at)
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE INDEX IF NOT EXISTS idx_m2c2i20a_candidates_receipt_line
+                ON external_product_candidates (receipt_line_id, updated_at)
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE INDEX IF NOT EXISTS idx_m2c2i20a_candidates_status_context
+                ON external_product_candidates (candidate_status, status, context_key)
+                """
+            )
+        )
+
+    _M2C2I20A_PERFORMANCE_INDEXES_READY = True
+
+
 def _m2c2i20_call_candidate_store_ensure(args: tuple[Any, ...], kwargs: dict[str, Any], unresolved_items: list[dict[str, Any]]) -> dict[str, Any]:
     next_kwargs = dict(kwargs)
     if "items" in next_kwargs:
@@ -171,6 +224,7 @@ def _m2c2i20_enrich_ensure_result(result: dict[str, Any], original_total: int, r
     enriched["external_resolved_skipped_count"] = len(resolved_skips)
     enriched["external_resolved_skipped"] = resolved_skips
     enriched["m2c2i20_resolved_state_gate"] = True
+    enriched["m2c2i20a_performance_indexes"] = True
     enriched["creates_global_product"] = False
     enriched["creates_household_article"] = False
     enriched["creates_inventory_event"] = False
@@ -187,6 +241,8 @@ def save_matchpreview_candidates(*args: Any, **kwargs: Any) -> dict[str, Any]:
 
 
 def ensure_external_receipt_item_candidates(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    _m2c2i20a_ensure_performance_indexes()
+
     items = kwargs.get("items") if "items" in kwargs else (args[0] if args else None)
     if items is not None:
         normalized_items = [dict(item) for item in (items or []) if isinstance(item, dict)]
@@ -201,6 +257,19 @@ def ensure_external_receipt_item_candidates(*args: Any, **kwargs: Any) -> dict[s
     try:
         if items is None:
             return candidate_store.ensure_external_receipt_item_candidates(*args, **kwargs)
+        if not unresolved_items:
+            return _m2c2i20_enrich_ensure_result(
+                {
+                    "ok": True,
+                    "processed": 0,
+                    "saved_count": 0,
+                    "updated_count": 0,
+                    "skipped_count": 0,
+                    "errors": [],
+                },
+                len(normalized_items),
+                resolved_items,
+            )
         result = _m2c2i20_call_candidate_store_ensure(args, kwargs, unresolved_items)
         return _m2c2i20_enrich_ensure_result(result, len(normalized_items), resolved_items)
     finally:

--- a/docs/release/M2C2i20a_validation.md
+++ b/docs/release/M2C2i20a_validation.md
@@ -15,9 +15,22 @@ M2C2i-20a voegt lichte database-indexen toe rond de bestaande resolved-state flo
 
 Daarnaast stopt de ensure-flow direct als de aangeleverde zichtbare items allemaal al resolved zijn. Dan wordt geen lege kandidaatzoekronde meer doorgezet.
 
+## Opstartroutine
+
+Gebruik bij lokale validatie altijd een wachttijd van 90 seconden na het starten of rebuilden van containers. Daarmee krijgen backend, frontend en database genoeg tijd om stabiel op te komen voordat de UI of smoke wordt getest.
+
+```powershell
+cd C:\Users\Gebruiker\Rezzerv_Github
+git fetch origin
+git switch m2c2i20a-external-db-pagination-performance
+git pull --ff-only origin m2c2i20a-external-db-pagination-performance
+docker compose up -d --build backend frontend
+Start-Sleep -Seconds 90
+```
+
 ## PO-test
 
-1. Start lokaal vanaf `main` na merge.
+1. Start lokaal volgens de opstartroutine hierboven.
 2. Open `http://localhost:5174/externe-databases`.
 3. Ga naar een volgende pagina in de tabel.
 4. Herhaal dit een paar keer.

--- a/docs/release/M2C2i20a_validation.md
+++ b/docs/release/M2C2i20a_validation.md
@@ -1,0 +1,69 @@
+# M2C2i-20a — Performancevalidatie Externe databases
+
+## Doel
+
+De Externe databases-tabel moet bij het bijlezen van een nieuwe pagina merkbaar sneller reageren, zonder functionele wijziging in kandidaatlogica.
+
+## Wijziging
+
+M2C2i-20a voegt lichte database-indexen toe rond de bestaande resolved-state flow:
+
+- `external_product_candidates(context_key, updated_at)`
+- `external_product_candidates(purchase_import_line_id, updated_at)`
+- `external_product_candidates(receipt_line_id, updated_at)`
+- `external_product_candidates(candidate_status, status, context_key)`
+
+Daarnaast stopt de ensure-flow direct als de aangeleverde zichtbare items allemaal al resolved zijn. Dan wordt geen lege kandidaatzoekronde meer doorgezet.
+
+## PO-test
+
+1. Start lokaal vanaf `main` na merge.
+2. Open `http://localhost:5174/externe-databases`.
+3. Ga naar een volgende pagina in de tabel.
+4. Herhaal dit een paar keer.
+5. Controleer of het bijlezen merkbaar sneller en stabieler is.
+6. Controleer dat bekende artikelen met externe artikelcode resolved blijven.
+7. Controleer dat onbekende artikelen zonder externe artikelcode nog kandidaatzoekbaar blijven.
+
+## Smoke zonder pytest
+
+```powershell
+@'
+from app.services import external_database_matchflow_evidence as m
+
+m._m2c2i20a_ensure_performance_indexes()
+
+resolved = {
+    "is_receipt_item_placeholder": True,
+    "purchase_import_line_id": "pil-1",
+    "receipt_line_text": "Veldsla",
+    "retailer_code": "lidl",
+    "retailer_article_number": "lidl:groente.veldsla",
+}
+
+result = m.ensure_external_receipt_item_candidates(items=[resolved], include_below_threshold=True)
+
+assert result["processed"] == 0
+assert result["external_resolved_skipped_count"] == 1
+assert result["m2c2i20a_performance_indexes"] is True
+assert result["creates_global_product"] is False
+assert result["creates_household_article"] is False
+assert result["creates_inventory_event"] is False
+
+print("M2C2i-20a smoke OK: resolved-only refresh stopt direct en indexen zijn aanwezig.")
+'@ | docker compose exec -T backend python
+```
+
+Verwacht:
+
+```text
+M2C2i-20a smoke OK: resolved-only refresh stopt direct en indexen zijn aanwezig.
+```
+
+## GO-criteria
+
+- Nieuwe pagina in Externe databases laadt merkbaar sneller of in ieder geval niet trager.
+- Artikelen met externe artikelcode blijven resolved.
+- Onbekende artikelen blijven kandidaatzoekbaar.
+- Geen Mijn-artikel-aanmaak.
+- Geen voorraadmutatie.


### PR DESCRIPTION
M2C2i-20a — Performance-optimalisatie Externe databases paginering.

Aanleiding:
- PO ziet geen functionele fouten na M2C2i-20.
- Bij het bijlezen van een nieuwe tabelpagina is de performance merkbaar slechter.

Wijzigingen:
- Lichte indexen toegevoegd voor de bestaande Externe databases-flow:
  - `external_product_candidates(context_key, updated_at)`
  - `external_product_candidates(purchase_import_line_id, updated_at)`
  - `external_product_candidates(receipt_line_id, updated_at)`
  - `external_product_candidates(candidate_status, status, context_key)`
- Ensure-flow stopt direct als alle aangeleverde zichtbare items al resolved zijn.
- Result payload krijgt `m2c2i20a_performance_indexes = true`.
- Pytest-vrije smoke toegevoegd in validatiedocumentatie.
- Opstartroutine uitgebreid met `Start-Sleep -Seconds 90` na `docker compose up -d --build backend frontend`.

Niet gewijzigd:
- Geen bonregeltypes.
- Geen bredere Lidl-catalogussearch.
- Geen UI-layoutwijziging.
- Geen Mijn-artikel-aanmaak.
- Geen voorraadmutatie.

Safety:
- `creates_global_product = False`
- `creates_household_article = False`
- `creates_inventory_event = False`

PO-validatie:
- Start lokaal met rebuild en wacht 90 seconden.
- Nieuwe pagina in Externe databases moet merkbaar sneller of in ieder geval niet trager laden.
- Artikelen met externe artikelcode blijven resolved.
- Artikelen zonder externe artikelcode blijven kandidaatzoekbaar.