### PR TITLE
feat(external-db): add local Lidl catalog index candidates

### DIFF
--- a/backend/app/services/external_candidate_normalization.py
+++ b/backend/app/services/external_candidate_normalization.py
@@ -63,10 +63,32 @@ def _identity_key(candidate: dict[str, Any], evidence_packet: dict[str, Any] | N
     return f"name:{source_name}:{candidate_name}"
 
 
+def _append_unique(target: list[str], value: Any) -> None:
+    text = str(value or "").strip()
+    if text and text not in target:
+        target.append(text)
+
+
+def _collect_source_names(*candidates: dict[str, Any]) -> list[str]:
+    values: list[str] = []
+    for candidate in candidates:
+        for merged in candidate.get("merged_source_names") or []:
+            _append_unique(values, merged)
+        _append_unique(values, _source_name(candidate))
+    return values
+
+
+def _collect_source_codes(*candidates: dict[str, Any]) -> list[str]:
+    values: list[str] = []
+    for candidate in candidates:
+        for merged in candidate.get("merged_source_product_codes") or []:
+            _append_unique(values, merged)
+        _append_unique(values, _source_code(candidate))
+    return values
+
+
 def _has_lidl_catalog_source(candidate: dict[str, Any]) -> bool:
-    if _source_name(candidate) == "lidl_catalog_index":
-        return True
-    return "lidl_catalog_index" in (candidate.get("merged_source_names") or [])
+    return _source_name(candidate) == "lidl_catalog_index" or "lidl_catalog_index" in (candidate.get("merged_source_names") or [])
 
 
 def _merge_candidates(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
@@ -81,15 +103,8 @@ def _merge_candidates(existing: dict[str, Any], incoming: dict[str, Any]) -> dic
     if evidence_packet:
         result["product_evidence_packet"] = evidence_packet
 
-    source_names = []
-    source_codes = []
-    for candidate in [existing, incoming]:
-        source_name = _source_name(candidate)
-        source_code = _source_code(candidate)
-        if source_name and source_name not in source_names:
-            source_names.append(source_name)
-        if source_code and source_code not in source_codes:
-            source_codes.append(source_code)
+    source_names = _collect_source_names(existing, incoming)
+    source_codes = _collect_source_codes(existing, incoming)
 
     result["merged_source_names"] = source_names
     result["merged_source_product_codes"] = source_codes

--- a/backend/app/services/external_candidate_normalization.py
+++ b/backend/app/services/external_candidate_normalization.py
@@ -7,6 +7,7 @@ from app.services.product_taxonomy_store import normalize_taxonomy_text
 SOURCE_PRIORITY = {
     "lidl_catalog_enrichment": 100,
     "retailer_alias_learning": 95,
+    "lidl_catalog_index": 92,
     "lidl_product_group": 90,
     "product_taxonomy_seed": 80,
     "OFF-index": 70,
@@ -62,6 +63,12 @@ def _identity_key(candidate: dict[str, Any], evidence_packet: dict[str, Any] | N
     return f"name:{source_name}:{candidate_name}"
 
 
+def _has_lidl_catalog_source(candidate: dict[str, Any]) -> bool:
+    if _source_name(candidate) == "lidl_catalog_index":
+        return True
+    return "lidl_catalog_index" in (candidate.get("merged_source_names") or [])
+
+
 def _merge_candidates(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
     primary, secondary = (incoming, existing) if _priority(incoming) > _priority(existing) else (existing, incoming)
     result = dict(primary)
@@ -86,6 +93,7 @@ def _merge_candidates(existing: dict[str, Any], incoming: dict[str, Any]) -> dic
 
     result["merged_source_names"] = source_names
     result["merged_source_product_codes"] = source_codes
+    result["has_lidl_local_catalog_index_source"] = "lidl_catalog_index" in source_names
     result["deduplicated_candidate_count"] = int(existing.get("deduplicated_candidate_count") or 1) + int(incoming.get("deduplicated_candidate_count") or 1)
     result.setdefault("score_breakdown", {})["deduplicated_candidate_count"] = result["deduplicated_candidate_count"]
 
@@ -104,6 +112,7 @@ def normalize_external_candidates(candidates: list[dict[str, Any]], evidence_pac
         item.setdefault("source_name", item.get("candidate_source_name"))
         item.setdefault("source_product_code", item.get("candidate_source_product_code"))
         item.setdefault("retailer_article_number", item.get("candidate_source_product_code"))
+        item.setdefault("has_lidl_local_catalog_index_source", _has_lidl_catalog_source(item))
         for flag in ["creates_global_product", "creates_household_article", "creates_inventory_event"]:
             item[flag] = False
 

--- a/backend/app/services/external_database_matchflow_evidence.py
+++ b/backend/app/services/external_database_matchflow_evidence.py
@@ -9,6 +9,7 @@ from app.services import external_product_candidate_store as candidate_store
 from app.services.external_candidate_normalization import normalize_external_candidates
 from app.services.external_database_matchers import match_retailer_receipt_line as _base_match_retailer_receipt_line
 from app.services.external_product_alias_store import find_alias_candidates, save_alias_from_candidate
+from app.services.lidl_local_catalog_index import search_lidl_local_catalog_candidates
 from app.services.product_evidence_packet import apply_product_evidence_to_candidates, build_product_evidence_packet_dict
 
 
@@ -32,15 +33,24 @@ M2C2I20_EXTERNAL_CODE_FIELDS = (
 _M2C2I20A_PERFORMANCE_INDEXES_READY = False
 
 
+def _m2c2i21_catalog_candidates(retailer_code: str, receipt_line_text: str) -> list[dict[str, Any]]:
+    if str(retailer_code or "").strip().lower() != "lidl":
+        return []
+    return search_lidl_local_catalog_candidates(receipt_line_text, limit=5)
+
+
 def _with_evidence_scoring(result: dict[str, Any], receipt_line_text: str, retailer_code: str) -> dict[str, Any]:
     base_candidates = list(result.get("candidates") or [])
     alias_candidates = find_alias_candidates(retailer_code, receipt_line_text)
-    candidates = alias_candidates + base_candidates
+    catalog_candidates = _m2c2i21_catalog_candidates(retailer_code, receipt_line_text)
+    candidates = alias_candidates + catalog_candidates + base_candidates
     if not candidates:
         enriched_empty = dict(result)
         enriched_empty["uses_product_evidence_scoring"] = True
         enriched_empty["uses_candidate_deduplication"] = False
         enriched_empty["uses_retailer_alias_learning"] = bool(alias_candidates)
+        enriched_empty["uses_lidl_local_catalog_index"] = bool(catalog_candidates)
+        enriched_empty["lidl_local_catalog_candidate_count"] = len(catalog_candidates)
         enriched_empty["candidate_count_before_deduplication"] = 0
         enriched_empty["candidate_count_after_deduplication"] = 0
         enriched_empty["creates_global_product"] = False
@@ -70,6 +80,8 @@ def _with_evidence_scoring(result: dict[str, Any], receipt_line_text: str, retai
     enriched["uses_product_evidence_scoring"] = True
     enriched["uses_candidate_deduplication"] = len(normalized) < len(rescored)
     enriched["uses_retailer_alias_learning"] = bool(alias_candidates)
+    enriched["uses_lidl_local_catalog_index"] = bool(catalog_candidates)
+    enriched["lidl_local_catalog_candidate_count"] = len(catalog_candidates)
     enriched["candidate_count_before_deduplication"] = len(rescored)
     enriched["candidate_count_after_deduplication"] = len(normalized[:5])
     enriched["alias_candidate_count"] = len(alias_candidates)

--- a/backend/app/services/lidl_local_catalog_index.py
+++ b/backend/app/services/lidl_local_catalog_index.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import difflib
 import json
+import re
 import uuid
 from datetime import datetime, timezone
 from functools import lru_cache
@@ -226,3 +228,135 @@ def ensure_lidl_local_catalog_index() -> dict[str, Any]:
         "creates_household_article": False,
         "creates_inventory_event": False,
     }
+
+
+def _normalize(value: str | None) -> str:
+    normalized = normalize_taxonomy_text(value)
+    normalized = re.sub(r"[^a-z0-9áéíóúàèìòùäëïöüçñ\s-]+", " ", normalized, flags=re.IGNORECASE)
+    return " ".join(normalized.split())
+
+
+def _text_similarity(left: str, right: str) -> float:
+    left_normalized = _normalize(left)
+    right_normalized = _normalize(right)
+    if not left_normalized or not right_normalized:
+        return 0.0
+    if left_normalized == right_normalized:
+        return 1.0
+    if left_normalized in right_normalized or right_normalized in left_normalized:
+        return 0.92
+    return difflib.SequenceMatcher(None, left_normalized, right_normalized).ratio()
+
+
+def _token_overlap(left: str, right: str) -> float:
+    left_tokens = {token for token in _normalize(left).split() if len(token) >= 3}
+    right_tokens = {token for token in _normalize(right).split() if len(token) >= 3}
+    if not left_tokens or not right_tokens:
+        return 0.0
+    return len(left_tokens & right_tokens) / max(1, len(left_tokens | right_tokens))
+
+
+def _score_catalog_row(receipt_line_text: str, row: dict[str, Any]) -> dict[str, Any]:
+    product_name = str(row.get("product_name") or "").strip()
+    brand = str(row.get("brand") or "").strip()
+    category = str(row.get("category") or "").strip()
+    product_type = str(row.get("product_type") or "").strip()
+    quantity_label = str(row.get("quantity_label") or "").strip()
+    search_terms = str(row.get("search_terms") or "").strip()
+    source_product_code = str(row.get("source_product_code") or "").strip()
+    confidence_base = float(row.get("confidence_base") or 0.0)
+
+    text_score = max(
+        _text_similarity(receipt_line_text, product_name),
+        _token_overlap(receipt_line_text, product_name),
+        _token_overlap(receipt_line_text, search_terms),
+    )
+    brand_score = 1.0 if brand and _normalize(brand) in _normalize(receipt_line_text) else (0.70 if brand else 0.45)
+    product_type_score = max(_text_similarity(receipt_line_text, product_type), _token_overlap(receipt_line_text, category))
+    quantity_score = 0.80 if quantity_label else 0.50
+    source_score = max(0.80, min(confidence_base, 0.96))
+    variant_score = max(0.70, _token_overlap(receipt_line_text, category))
+
+    breakdown = {
+        "text_score": round(text_score, 3),
+        "brand_score": round(brand_score, 3),
+        "product_type_score": round(product_type_score, 3),
+        "quantity_score": round(quantity_score, 3),
+        "variant_score": round(variant_score, 3),
+        "source_score": round(source_score, 3),
+    }
+    score = round(
+        breakdown["text_score"] * 0.30
+        + breakdown["brand_score"] * 0.20
+        + breakdown["product_type_score"] * 0.20
+        + breakdown["quantity_score"] * 0.10
+        + breakdown["variant_score"] * 0.10
+        + breakdown["source_score"] * 0.10,
+        3,
+    )
+    candidate_status = "probable_candidate" if score >= 0.85 else "possible_candidate" if score >= 0.70 else "weak_candidate"
+    return {
+        "candidate_name": product_name or source_product_code or "Onbekend Lidl-catalogusproduct",
+        "candidate_brand": brand,
+        "candidate_source_name": LIDL_CATALOG_INDEX_SOURCE,
+        "candidate_source_product_code": source_product_code or "unknown",
+        "source_name": LIDL_CATALOG_INDEX_SOURCE,
+        "source_product_code": source_product_code or "unknown",
+        "retailer_article_number": source_product_code or "",
+        "quantity_label": quantity_label,
+        "variant": product_type or category,
+        "source_url": str(row.get("source_url") or "").strip(),
+        "score": score,
+        "score_breakdown": breakdown,
+        "candidate_status": candidate_status,
+        "is_probable": score >= 0.85,
+        "is_user_confirmed": False,
+        "is_external_database_override": False,
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+        "created_by": "m2c2i21_lidl_local_catalog_index",
+    }
+
+
+def search_lidl_local_catalog_candidates(receipt_line_text: str, limit: int = 5) -> list[dict[str, Any]]:
+    ensure_lidl_local_catalog_index()
+    normalized = _normalize(receipt_line_text)
+    tokens = [token for token in normalized.split() if len(token) >= 3]
+    if not tokens:
+        return []
+
+    params: dict[str, Any] = {"source_name": LIDL_CATALOG_INDEX_SOURCE, "retailer_code": "lidl", "limit": 80}
+    where_parts: list[str] = []
+    search_expr = """
+        lower(COALESCE(product_name, '') || ' ' ||
+              COALESCE(brand, '') || ' ' ||
+              COALESCE(category, '') || ' ' ||
+              COALESCE(product_type, '') || ' ' ||
+              COALESCE(quantity_label, '') || ' ' ||
+              COALESCE(search_terms, '') || ' ' ||
+              COALESCE(source_product_code, ''))
+    """
+    for index, token in enumerate(tokens[:8]):
+        key = f"token_{index}"
+        where_parts.append(f"{search_expr} LIKE :{key}")
+        params[key] = f"%{token}%"
+
+    with engine.begin() as conn:
+        rows = conn.execute(
+            text(
+                f"""
+                SELECT *
+                FROM external_product_index
+                WHERE source_name = :source_name
+                  AND retailer_code = :retailer_code
+                  AND ({' OR '.join(where_parts)})
+                LIMIT :limit
+                """
+            ),
+            params,
+        ).mappings().all()
+
+    scored = [_score_catalog_row(receipt_line_text, dict(row)) for row in rows]
+    scored.sort(key=lambda item: (-float(item.get("score") or 0.0), str(item.get("candidate_name") or "")))
+    return scored[: max(1, min(int(limit or 5), 5))]

--- a/backend/app/services/lidl_local_catalog_index.py
+++ b/backend/app/services/lidl_local_catalog_index.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db import engine
+from app.services.product_taxonomy_store import normalize_taxonomy_text
+
+LIDL_CATALOG_INDEX_SOURCE = "lidl_catalog_index"
+LIDL_CATALOG_INDEX_SEED_PATH = Path(__file__).resolve().parents[1] / "data" / "lidl_catalog_enrichment_seed.json"
+
+CREATE_EXTERNAL_PRODUCT_INDEX_SQL = """
+CREATE TABLE IF NOT EXISTS external_product_index (
+    id TEXT PRIMARY KEY,
+    source_name TEXT NOT NULL,
+    source_product_code TEXT NOT NULL,
+    retailer_code TEXT,
+    gtin TEXT,
+    product_name TEXT NOT NULL,
+    brand TEXT,
+    category TEXT,
+    product_type TEXT,
+    quantity_label TEXT,
+    search_terms TEXT,
+    source_url TEXT,
+    confidence_base REAL,
+    raw_payload_json TEXT,
+    created_at TEXT,
+    updated_at TEXT
+)
+"""
+
+EXTERNAL_PRODUCT_INDEX_COLUMNS: dict[str, str] = {
+    "id": "TEXT PRIMARY KEY",
+    "source_name": "TEXT NOT NULL DEFAULT ''",
+    "source_product_code": "TEXT NOT NULL DEFAULT ''",
+    "retailer_code": "TEXT",
+    "gtin": "TEXT",
+    "product_name": "TEXT NOT NULL DEFAULT ''",
+    "brand": "TEXT",
+    "category": "TEXT",
+    "product_type": "TEXT",
+    "quantity_label": "TEXT",
+    "search_terms": "TEXT",
+    "source_url": "TEXT",
+    "confidence_base": "REAL",
+    "raw_payload_json": "TEXT",
+    "created_at": "TEXT",
+    "updated_at": "TEXT",
+}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _sqlite_columns(conn) -> set[str]:
+    rows = conn.execute(text("PRAGMA table_info(external_product_index)")).mappings().all()
+    return {str(row.get("name") or "") for row in rows}
+
+
+def _postgres_columns(conn) -> set[str]:
+    rows = conn.execute(
+        text(
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_name = 'external_product_index'
+            """
+        )
+    ).mappings().all()
+    return {str(row.get("column_name") or "") for row in rows}
+
+
+def _ensure_columns(conn) -> None:
+    dialect_name = str(conn.engine.dialect.name or "").lower()
+    existing_columns = _sqlite_columns(conn) if dialect_name == "sqlite" else _postgres_columns(conn)
+    for column_name, column_definition in EXTERNAL_PRODUCT_INDEX_COLUMNS.items():
+        if column_name in existing_columns or column_name == "id":
+            continue
+        conn.execute(text(f"ALTER TABLE external_product_index ADD COLUMN {column_name} {column_definition}"))
+
+
+def ensure_external_product_index_schema() -> None:
+    with engine.begin() as conn:
+        conn.execute(text(CREATE_EXTERNAL_PRODUCT_INDEX_SQL))
+        _ensure_columns(conn)
+        conn.execute(
+            text(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_external_product_index_source_code
+                ON external_product_index (source_name, source_product_code)
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE INDEX IF NOT EXISTS idx_external_product_index_retailer_source
+                ON external_product_index (retailer_code, source_name)
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE INDEX IF NOT EXISTS idx_external_product_index_product_name
+                ON external_product_index (product_name)
+                """
+            )
+        )
+
+
+@lru_cache(maxsize=1)
+def _load_lidl_catalog_seed_rules() -> tuple[dict[str, Any], ...]:
+    if not LIDL_CATALOG_INDEX_SEED_PATH.exists():
+        return tuple()
+    payload = json.loads(LIDL_CATALOG_INDEX_SEED_PATH.read_text(encoding="utf-8"))
+    return tuple(dict(rule) for rule in (payload.get("rules") or []))
+
+
+def _dedupe_terms(values: list[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = normalize_taxonomy_text(value)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
+def _catalog_index_record(rule: dict[str, Any]) -> dict[str, Any]:
+    source_product_code = str(rule.get("source_product_code") or "").strip()
+    product_name = str(rule.get("catalog_product_name") or "").strip()
+    record_id = f"{LIDL_CATALOG_INDEX_SOURCE}:{source_product_code or uuid.uuid4()}"
+    search_terms = _dedupe_terms([
+        product_name,
+        str(rule.get("brand") or ""),
+        str(rule.get("category") or ""),
+        str(rule.get("product_type") or ""),
+        str(rule.get("quantity_label") or ""),
+        *(rule.get("receipt_terms") or []),
+        *(rule.get("search_terms") or []),
+    ])
+    return {
+        "id": record_id,
+        "source_name": LIDL_CATALOG_INDEX_SOURCE,
+        "source_product_code": source_product_code,
+        "retailer_code": "lidl",
+        "gtin": "",
+        "product_name": product_name,
+        "brand": str(rule.get("brand") or "").strip(),
+        "category": str(rule.get("category") or "").strip(),
+        "product_type": str(rule.get("product_type") or "").strip(),
+        "quantity_label": str(rule.get("quantity_label") or "").strip(),
+        "search_terms": " ".join(search_terms),
+        "source_url": str(rule.get("source_url") or "").strip(),
+        "confidence_base": float(rule.get("confidence") or 0.0),
+        "raw_payload_json": json.dumps(rule, ensure_ascii=False, sort_keys=True),
+    }
+
+
+def ensure_lidl_local_catalog_index() -> dict[str, Any]:
+    """Load the local Lidl catalog seed into external_product_index.
+
+    This keeps product knowledge in data/import form. It does not create global products,
+    household articles, or inventory events.
+    """
+    ensure_external_product_index_schema()
+    rules = _load_lidl_catalog_seed_rules()
+    timestamp = _now_iso()
+    written = 0
+
+    with engine.begin() as conn:
+        for rule in rules:
+            record = _catalog_index_record(rule)
+            if not record["source_product_code"] or not record["product_name"]:
+                continue
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO external_product_index (
+                        id, source_name, source_product_code, retailer_code, gtin,
+                        product_name, brand, category, product_type, quantity_label,
+                        search_terms, source_url, confidence_base, raw_payload_json,
+                        created_at, updated_at
+                    ) VALUES (
+                        :id, :source_name, :source_product_code, :retailer_code, :gtin,
+                        :product_name, :brand, :category, :product_type, :quantity_label,
+                        :search_terms, :source_url, :confidence_base, :raw_payload_json,
+                        :created_at, :updated_at
+                    )
+                    ON CONFLICT(source_name, source_product_code)
+                    DO UPDATE SET
+                        retailer_code = excluded.retailer_code,
+                        gtin = excluded.gtin,
+                        product_name = excluded.product_name,
+                        brand = excluded.brand,
+                        category = excluded.category,
+                        product_type = excluded.product_type,
+                        quantity_label = excluded.quantity_label,
+                        search_terms = excluded.search_terms,
+                        source_url = excluded.source_url,
+                        confidence_base = excluded.confidence_base,
+                        raw_payload_json = excluded.raw_payload_json,
+                        updated_at = excluded.updated_at
+                    """
+                ),
+                {**record, "created_at": timestamp, "updated_at": timestamp},
+            )
+            written += 1
+
+    return {
+        "ok": True,
+        "source_name": LIDL_CATALOG_INDEX_SOURCE,
+        "loaded_count": written,
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+    }

--- a/docs/architecture/M2C2i21_lidl_local_catalog_index.md
+++ b/docs/architecture/M2C2i21_lidl_local_catalog_index.md
@@ -1,0 +1,58 @@
+# M2C2i-21 — Lokale Lidl-catalogusindex voor onbekende bonartikelen
+
+## Doel
+
+Rezzerv kan bij een onbekende Lidl-bonregel zoeken in een lokale catalogusindex en maximaal 5 externe productkandidaten tonen, zonder codewijziging per nieuw artikel.
+
+```text
+onbekende Lidl-bonregel
+→ lokale Lidl-catalogusindex
+→ externe productkandidaten
+→ gebruiker bevestigt eventueel later
+→ pas daarna resolved / aliaslearning
+```
+
+## Architectuurgrens
+
+```text
+external_product_index ≠ global_products ≠ Mijn artikel
+```
+
+De catalogusindex is een externe kennisbron. M2C2i-21 maakt geen huishoudartikelen en doet geen voorraadmutaties.
+
+```text
+creates_global_product = false
+creates_household_article = false
+creates_inventory_event = false
+```
+
+## Datalaag
+
+M2C2i-21 introduceert een loader voor `external_product_index` op basis van bestaande Lidl-catalogusdata:
+
+- bronbestand: `backend/app/data/lidl_catalog_enrichment_seed.json`
+- indexbron: `source_name = lidl_catalog_index`
+- sleutel: `source_product_code`
+- velden: productnaam, merk, categorie, producttype, hoeveelheid, zoektermen en bron-url
+
+Productkennis blijft daarmee in data/importvorm en niet in productie-Python.
+
+## Matchflow
+
+De bestaande flow blijft leidend:
+
+1. resolved bonregels worden overgeslagen;
+2. alias candidates worden opgehaald;
+3. Lidl-catalogusindex levert lokale kandidaten;
+4. bestaande base/fallback candidates blijven beschikbaar;
+5. kandidaten worden genormaliseerd, gescoord en gededuped;
+6. maximaal 5 kandidaten worden teruggegeven.
+
+## Buiten scope
+
+- Geen live Lidl-scraping.
+- Geen Open Food Facts-live afhankelijkheid.
+- Geen bonregeltypeclassificatie.
+- Geen Mijn-artikel-aanmaak.
+- Geen voorraadmutatie.
+- Geen definitieve productkoppeling zonder vervolgactie.

--- a/docs/release/M2C2i21_validation.md
+++ b/docs/release/M2C2i21_validation.md
@@ -40,12 +40,8 @@ match = m.match_retailer_receipt_line("lidl", "Veldsla", include_below_threshold
 assert match["uses_lidl_local_catalog_index"] is True
 assert match["lidl_local_catalog_candidate_count"] >= 1
 assert len(match["candidates"]) <= 5
-assert any(
-    c.get("candidate_source_name") == "lidl_catalog_index"
-    or c.get("has_lidl_local_catalog_index_source") is True
-    or "lidl_catalog_index" in (c.get("merged_source_names") or [])
-    for c in match["candidates"]
-)
+assert any("lidl_catalog_index" in (c.get("merged_source_names") or [c.get("candidate_source_name")]) for c in match["candidates"])
+assert any(c.get("has_lidl_local_catalog_index_source") is True for c in match["candidates"])
 assert match["creates_global_product"] is False
 assert match["creates_household_article"] is False
 assert match["creates_inventory_event"] is False

--- a/docs/release/M2C2i21_validation.md
+++ b/docs/release/M2C2i21_validation.md
@@ -40,7 +40,12 @@ match = m.match_retailer_receipt_line("lidl", "Veldsla", include_below_threshold
 assert match["uses_lidl_local_catalog_index"] is True
 assert match["lidl_local_catalog_candidate_count"] >= 1
 assert len(match["candidates"]) <= 5
-assert any(c["candidate_source_name"] == "lidl_catalog_index" for c in match["candidates"])
+assert any(
+    c.get("candidate_source_name") == "lidl_catalog_index"
+    or c.get("has_lidl_local_catalog_index_source") is True
+    or "lidl_catalog_index" in (c.get("merged_source_names") or [])
+    for c in match["candidates"]
+)
 assert match["creates_global_product"] is False
 assert match["creates_household_article"] is False
 assert match["creates_inventory_event"] is False
@@ -61,7 +66,7 @@ M2C2i-21 smoke OK: lokale Lidl-catalogusindex levert kandidaten zonder mutaties.
 2. Gebruik een Lidl-bonregel die nog geen externe artikelcode heeft maar wel als product in de Lidl-catalogusdata voorkomt.
 3. Ververs/haal kandidaten op.
 4. Controleer dat maximaal 5 kandidaten worden getoond.
-5. Controleer dat minimaal één kandidaat bron `lidl_catalog_index` heeft.
+5. Controleer dat de kandidaatbron direct of via samengevoegde bronnen herleidbaar is naar `lidl_catalog_index`.
 6. Controleer dat er geen Mijn-artikel wordt aangemaakt.
 7. Controleer dat er geen voorraadmutatie ontstaat.
 
@@ -69,6 +74,6 @@ M2C2i-21 smoke OK: lokale Lidl-catalogusindex levert kandidaten zonder mutaties.
 
 - Onbekende Lidl-bonregel krijgt cataloguskandidaat uit lokale index.
 - Kandidaten zijn maximaal 5.
-- Bron is herkenbaar als `lidl_catalog_index`.
+- Bron is direct of via samengevoegde bronnen herkenbaar als `lidl_catalog_index`.
 - Geen live externe afhankelijkheid.
 - Geen global product, household article of inventory event.

--- a/docs/release/M2C2i21_validation.md
+++ b/docs/release/M2C2i21_validation.md
@@ -1,0 +1,74 @@
+# M2C2i-21 — Validatie
+
+## Doelvalidatie
+
+Aantonen dat onbekende Lidl-bonregels lokale cataloguskandidaten kunnen krijgen uit `external_product_index`, zonder live externe bron en zonder product-/voorraadmutaties.
+
+## Opstartroutine
+
+```powershell
+cd C:\Users\Gebruiker\Rezzerv_Github
+git fetch origin
+git switch m2c2i21-lidl-local-catalog-index
+git pull --ff-only origin m2c2i21-lidl-local-catalog-index
+docker compose up -d --build backend frontend
+Start-Sleep -Seconds 90
+```
+
+## Smoke zonder pytest
+
+```powershell
+@'
+from app.services.lidl_local_catalog_index import ensure_lidl_local_catalog_index, search_lidl_local_catalog_candidates
+from app.services import external_database_matchflow_evidence as m
+
+loaded = ensure_lidl_local_catalog_index()
+assert loaded["loaded_count"] > 0
+assert loaded["creates_global_product"] is False
+assert loaded["creates_household_article"] is False
+assert loaded["creates_inventory_event"] is False
+
+catalog_candidates = search_lidl_local_catalog_candidates("Veldsla", limit=5)
+assert catalog_candidates
+assert len(catalog_candidates) <= 5
+assert catalog_candidates[0]["candidate_source_name"] == "lidl_catalog_index"
+assert catalog_candidates[0]["creates_global_product"] is False
+assert catalog_candidates[0]["creates_household_article"] is False
+assert catalog_candidates[0]["creates_inventory_event"] is False
+
+match = m.match_retailer_receipt_line("lidl", "Veldsla", include_below_threshold=True)
+assert match["uses_lidl_local_catalog_index"] is True
+assert match["lidl_local_catalog_candidate_count"] >= 1
+assert len(match["candidates"]) <= 5
+assert any(c["candidate_source_name"] == "lidl_catalog_index" for c in match["candidates"])
+assert match["creates_global_product"] is False
+assert match["creates_household_article"] is False
+assert match["creates_inventory_event"] is False
+
+print("M2C2i-21 smoke OK: lokale Lidl-catalogusindex levert kandidaten zonder mutaties.")
+'@ | docker compose exec -T backend python
+```
+
+Verwacht:
+
+```text
+M2C2i-21 smoke OK: lokale Lidl-catalogusindex levert kandidaten zonder mutaties.
+```
+
+## PO-test in de UI
+
+1. Open `http://localhost:5174/externe-databases`.
+2. Gebruik een Lidl-bonregel die nog geen externe artikelcode heeft maar wel als product in de Lidl-catalogusdata voorkomt.
+3. Ververs/haal kandidaten op.
+4. Controleer dat maximaal 5 kandidaten worden getoond.
+5. Controleer dat minimaal één kandidaat bron `lidl_catalog_index` heeft.
+6. Controleer dat er geen Mijn-artikel wordt aangemaakt.
+7. Controleer dat er geen voorraadmutatie ontstaat.
+
+## GO-criteria
+
+- Onbekende Lidl-bonregel krijgt cataloguskandidaat uit lokale index.
+- Kandidaten zijn maximaal 5.
+- Bron is herkenbaar als `lidl_catalog_index`.
+- Geen live externe afhankelijkheid.
+- Geen global product, household article of inventory event.


### PR DESCRIPTION
M2C2i-21 — Lokale Lidl-catalogusindex voor onbekende bonartikelen.

Doel:
- Onbekende Lidl-bonregels kunnen lokale cataloguskandidaten krijgen zonder codewijziging per nieuw artikel.
- Productkennis blijft in data/importvorm en wordt geladen naar `external_product_index`.

Wijzigingen:
- Nieuwe service `lidl_local_catalog_index.py`.
- `external_product_index` schema/loader toegevoegd voor lokale Lidl-catalogusdata.
- Bestaande Lidl seeddata wordt geladen met `source_name = lidl_catalog_index`.
- Zoekfunctie op lokale catalogusindex toegevoegd.
- Matchflow verrijkt met lokale Lidl-cataloguskandidaten tussen alias candidates en bestaande base/fallback candidates.
- Result payload toont `uses_lidl_local_catalog_index` en `lidl_local_catalog_candidate_count`.
- Architectuur- en validatiedocumentatie toegevoegd.

Niet gewijzigd:
- Geen live Lidl-scraping.
- Geen Open Food Facts-live afhankelijkheid.
- Geen bonregeltypes.
- Geen automatische Mijn-artikel-aanmaak.
- Geen voorraadmutatie.
- Geen definitieve productkoppeling zonder vervolgactie.

Safety:
- `creates_global_product = False`
- `creates_household_article = False`
- `creates_inventory_event = False`

Validatie:
- Pytest-vrije smoke opgenomen in `docs/release/M2C2i21_validation.md`.
- Opstartroutine bevat `Start-Sleep -Seconds 90`.