### PR TITLE
feat(external-db): confirm external candidate on receipt item

### DIFF
--- a/backend/app/services/external_candidate_confirmation.py
+++ b/backend/app/services/external_candidate_confirmation.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db import engine
+from app.services.external_product_candidate_store import (
+    _m2c2h5_table_columns,
+    _m2c2h5_table_exists,
+    build_candidate_context_key,
+    ensure_external_product_candidates_schema,
+)
+
+M2C2I22_CONFIRMED_STATUS = "external_resolved"
+M2C2I22_USER_CONFIRMED_STATUS = "user_confirmed"
+
+
+def _truthy(value: Any) -> bool:
+    normalized = str(value if value is not None else "").strip().lower()
+    return bool(normalized and normalized not in {"-", "0", "none", "null", "undefined", "false", "unknown", "onbekend"})
+
+
+def _first_truthy(row: dict[str, Any], *field_names: str) -> str:
+    for field_name in field_names:
+        value = str(row.get(field_name) if row.get(field_name) is not None else "").strip()
+        if _truthy(value):
+            return value
+    return ""
+
+
+def _candidate_external_code(candidate: dict[str, Any]) -> str:
+    return _first_truthy(
+        candidate,
+        "external_source_product_code",
+        "candidate_source_product_code",
+        "source_product_code",
+        "retailer_article_number",
+        "gtin",
+        "ean",
+        "code",
+    )
+
+
+def _candidate_source_name(candidate: dict[str, Any]) -> str:
+    return _first_truthy(candidate, "external_source_name", "candidate_source_name", "source_name") or "external_candidate"
+
+
+def _candidate_receipt_text(candidate: dict[str, Any]) -> str:
+    return _first_truthy(candidate, "receipt_line_text", "candidate_name")
+
+
+def _candidate_context_key(candidate: dict[str, Any]) -> str:
+    context_key = _first_truthy(candidate, "context_key")
+    if context_key:
+        return context_key
+    return build_candidate_context_key(
+        str(candidate.get("retailer_code") or "").strip().lower(),
+        _candidate_receipt_text(candidate),
+        receipt_line_id=_first_truthy(candidate, "receipt_line_id") or None,
+        purchase_import_line_id=_first_truthy(candidate, "purchase_import_line_id") or None,
+    )
+
+
+def _set_sql_fragment(column_names: list[str]) -> str:
+    return ",\n                        ".join(f"{column_name} = :{column_name}" for column_name in column_names)
+
+
+def _update_purchase_import_line(conn, purchase_import_line_id: str, external_code: str, source_name: str, candidate: dict[str, Any]) -> int:
+    if not purchase_import_line_id or not _m2c2h5_table_exists(conn, "purchase_import_lines"):
+        return 0
+
+    columns = _m2c2h5_table_columns(conn, "purchase_import_lines")
+    updates: dict[str, Any] = {}
+
+    for column_name in ("external_article_code", "external_product_code", "retailer_article_number"):
+        if column_name in columns:
+            updates[column_name] = external_code
+
+    for column_name in ("external_source_name", "source_name", "external_product_source"):
+        if column_name in columns:
+            updates[column_name] = source_name
+
+    for column_name in ("external_match_status", "status"):
+        if column_name in columns:
+            updates[column_name] = M2C2I22_CONFIRMED_STATUS
+
+    if "matched_external_candidate_id" in columns:
+        updates["matched_external_candidate_id"] = str(candidate.get("id") or "").strip()
+    if "matched_external_candidate_name" in columns:
+        updates["matched_external_candidate_name"] = str(candidate.get("candidate_name") or "").strip()
+    if "updated_at" in columns:
+        updates["updated_at"] = _now_timestamp_sql(conn)
+
+    if not updates:
+        return 0
+
+    inline_timestamp_columns = {name for name, value in updates.items() if value == "__CURRENT_TIMESTAMP__"}
+    param_updates = {name: value for name, value in updates.items() if name not in inline_timestamp_columns}
+    assignments = [f"{name} = CURRENT_TIMESTAMP" for name in inline_timestamp_columns]
+    assignments.extend(f"{name} = :{name}" for name in param_updates)
+
+    result = conn.execute(
+        text(
+            f"""
+            UPDATE purchase_import_lines
+            SET {', '.join(assignments)}
+            WHERE id = :purchase_import_line_id
+            """
+        ),
+        {**param_updates, "purchase_import_line_id": purchase_import_line_id},
+    )
+    return int(result.rowcount or 0)
+
+
+def _update_receipt_line(conn, receipt_line_id: str, external_code: str, source_name: str, candidate: dict[str, Any]) -> int:
+    if not receipt_line_id or not _m2c2h5_table_exists(conn, "receipt_lines"):
+        return 0
+
+    columns = _m2c2h5_table_columns(conn, "receipt_lines")
+    updates: dict[str, Any] = {}
+
+    for column_name in ("external_article_code", "external_product_code", "retailer_article_number"):
+        if column_name in columns:
+            updates[column_name] = external_code
+
+    for column_name in ("external_source_name", "source_name", "external_product_source"):
+        if column_name in columns:
+            updates[column_name] = source_name
+
+    for column_name in ("external_match_status", "status"):
+        if column_name in columns:
+            updates[column_name] = M2C2I22_CONFIRMED_STATUS
+
+    if "matched_external_candidate_id" in columns:
+        updates["matched_external_candidate_id"] = str(candidate.get("id") or "").strip()
+    if "matched_external_candidate_name" in columns:
+        updates["matched_external_candidate_name"] = str(candidate.get("candidate_name") or "").strip()
+    if "updated_at" in columns:
+        updates["updated_at"] = _now_timestamp_sql(conn)
+
+    if not updates:
+        return 0
+
+    inline_timestamp_columns = {name for name, value in updates.items() if value == "__CURRENT_TIMESTAMP__"}
+    param_updates = {name: value for name, value in updates.items() if name not in inline_timestamp_columns}
+    assignments = [f"{name} = CURRENT_TIMESTAMP" for name in inline_timestamp_columns]
+    assignments.extend(f"{name} = :{name}" for name in param_updates)
+
+    result = conn.execute(
+        text(
+            f"""
+            UPDATE receipt_lines
+            SET {', '.join(assignments)}
+            WHERE id = :receipt_line_id
+            """
+        ),
+        {**param_updates, "receipt_line_id": receipt_line_id},
+    )
+    return int(result.rowcount or 0)
+
+
+def _now_timestamp_sql(conn) -> str:
+    return "__CURRENT_TIMESTAMP__"
+
+
+def confirm_external_candidate_for_receipt_item(candidate_id: str, force_overwrite: bool = False) -> dict[str, Any]:
+    """Bevestig een externe kandidaat op de bonregel zonder catalogus-/voorraadmutaties.
+
+    M2C2i-22 legt alleen de externe artikelcode en bron vast op de bonregel/importregel.
+    De functie maakt geen global_products, geen Mijn artikel en geen voorraadmutatie.
+    """
+    ensure_external_product_candidates_schema()
+    normalized_candidate_id = str(candidate_id or "").strip()
+    if not normalized_candidate_id:
+        return {"ok": False, "confirmed": False, "reason": "missing_candidate_id"}
+
+    with engine.begin() as conn:
+        candidate_row = conn.execute(
+            text(
+                """
+                SELECT *
+                FROM external_product_candidates
+                WHERE id = :candidate_id
+                LIMIT 1
+                """
+            ),
+            {"candidate_id": normalized_candidate_id},
+        ).mappings().first()
+
+        if not candidate_row:
+            return {"ok": False, "confirmed": False, "reason": "candidate_not_found"}
+
+        candidate = dict(candidate_row)
+        external_code = _candidate_external_code(candidate)
+        if not external_code:
+            return {"ok": False, "confirmed": False, "reason": "missing_external_product_code", "candidate_id": normalized_candidate_id}
+
+        context_key = _candidate_context_key(candidate)
+        purchase_import_line_id = _first_truthy(candidate, "purchase_import_line_id")
+        receipt_line_id = _first_truthy(candidate, "receipt_line_id")
+        source_name = _candidate_source_name(candidate)
+
+        linked_rows = conn.execute(
+            text(
+                """
+                SELECT id
+                FROM external_product_candidates
+                WHERE context_key = :context_key
+                  AND id <> :candidate_id
+                  AND (
+                    candidate_status IN ('external_resolved', 'user_confirmed', 'linked_to_catalog')
+                    OR status IN ('external_resolved', 'user_confirmed', 'linked_to_catalog')
+                    OR is_user_confirmed = 1
+                    OR is_external_database_override = 1
+                  )
+                """
+            ),
+            {"context_key": context_key, "candidate_id": normalized_candidate_id},
+        ).mappings().all()
+
+        if linked_rows and not force_overwrite:
+            return {
+                "ok": True,
+                "confirmed": False,
+                "requires_overwrite": True,
+                "existing_link_count": len(linked_rows),
+                "candidate_id": normalized_candidate_id,
+                "context_key": context_key,
+                "creates_global_product": False,
+                "creates_household_article": False,
+                "creates_inventory_event": False,
+            }
+
+        conn.execute(
+            text(
+                """
+                UPDATE external_product_candidates
+                SET candidate_status = 'candidate',
+                    status = 'candidate',
+                    is_user_confirmed = 0,
+                    is_external_database_override = 0,
+                    global_product_id = NULL,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE context_key = :context_key
+                  AND id <> :candidate_id
+                """
+            ),
+            {"context_key": context_key, "candidate_id": normalized_candidate_id},
+        )
+
+        conn.execute(
+            text(
+                """
+                UPDATE external_product_candidates
+                SET candidate_status = :candidate_status,
+                    status = :status,
+                    is_user_confirmed = 1,
+                    is_external_database_override = 0,
+                    global_product_id = NULL,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE id = :candidate_id
+                """
+            ),
+            {
+                "candidate_id": normalized_candidate_id,
+                "candidate_status": M2C2I22_USER_CONFIRMED_STATUS,
+                "status": M2C2I22_CONFIRMED_STATUS,
+            },
+        )
+
+        purchase_import_line_updated_count = _update_purchase_import_line(
+            conn,
+            purchase_import_line_id,
+            external_code,
+            source_name,
+            candidate,
+        )
+        receipt_line_updated_count = _update_receipt_line(
+            conn,
+            receipt_line_id,
+            external_code,
+            source_name,
+            candidate,
+        )
+
+    return {
+        "ok": True,
+        "confirmed": True,
+        "requires_overwrite": False,
+        "candidate_id": normalized_candidate_id,
+        "context_key": context_key,
+        "purchase_import_line_id": purchase_import_line_id or None,
+        "receipt_line_id": receipt_line_id or None,
+        "external_product_code": external_code,
+        "external_source_name": source_name,
+        "purchase_import_line_updated_count": purchase_import_line_updated_count,
+        "receipt_line_updated_count": receipt_line_updated_count,
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+    }

--- a/backend/app/services/external_candidate_confirmation.py
+++ b/backend/app/services/external_candidate_confirmation.py
@@ -62,8 +62,31 @@ def _candidate_context_key(candidate: dict[str, Any]) -> str:
     )
 
 
-def _set_sql_fragment(column_names: list[str]) -> str:
-    return ",\n                        ".join(f"{column_name} = :{column_name}" for column_name in column_names)
+def _append_update(updates: dict[str, Any], columns: set[str], column_name: str, value: Any) -> None:
+    if column_name in columns:
+        updates[column_name] = value
+
+
+def _apply_row_update(conn, table_name: str, row_id_column: str, row_id: str, updates: dict[str, Any]) -> int:
+    if not row_id or not updates:
+        return 0
+
+    inline_timestamp_columns = {name for name, value in updates.items() if value == "__CURRENT_TIMESTAMP__"}
+    param_updates = {name: value for name, value in updates.items() if name not in inline_timestamp_columns}
+    assignments = [f"{name} = CURRENT_TIMESTAMP" for name in inline_timestamp_columns]
+    assignments.extend(f"{name} = :{name}" for name in param_updates)
+
+    result = conn.execute(
+        text(
+            f"""
+            UPDATE {table_name}
+            SET {', '.join(assignments)}
+            WHERE {row_id_column} = :row_id
+            """
+        ),
+        {**param_updates, "row_id": row_id},
+    )
+    return int(result.rowcount or 0)
 
 
 def _update_purchase_import_line(conn, purchase_import_line_id: str, external_code: str, source_name: str, candidate: dict[str, Any]) -> int:
@@ -74,43 +97,17 @@ def _update_purchase_import_line(conn, purchase_import_line_id: str, external_co
     updates: dict[str, Any] = {}
 
     for column_name in ("external_article_code", "external_product_code", "retailer_article_number"):
-        if column_name in columns:
-            updates[column_name] = external_code
+        _append_update(updates, columns, column_name, external_code)
 
     for column_name in ("external_source_name", "source_name", "external_product_source"):
-        if column_name in columns:
-            updates[column_name] = source_name
+        _append_update(updates, columns, column_name, source_name)
 
-    for column_name in ("external_match_status", "status"):
-        if column_name in columns:
-            updates[column_name] = M2C2I22_CONFIRMED_STATUS
+    _append_update(updates, columns, "external_match_status", M2C2I22_CONFIRMED_STATUS)
+    _append_update(updates, columns, "matched_external_candidate_id", str(candidate.get("id") or "").strip())
+    _append_update(updates, columns, "matched_external_candidate_name", str(candidate.get("candidate_name") or "").strip())
+    _append_update(updates, columns, "updated_at", "__CURRENT_TIMESTAMP__")
 
-    if "matched_external_candidate_id" in columns:
-        updates["matched_external_candidate_id"] = str(candidate.get("id") or "").strip()
-    if "matched_external_candidate_name" in columns:
-        updates["matched_external_candidate_name"] = str(candidate.get("candidate_name") or "").strip()
-    if "updated_at" in columns:
-        updates["updated_at"] = _now_timestamp_sql(conn)
-
-    if not updates:
-        return 0
-
-    inline_timestamp_columns = {name for name, value in updates.items() if value == "__CURRENT_TIMESTAMP__"}
-    param_updates = {name: value for name, value in updates.items() if name not in inline_timestamp_columns}
-    assignments = [f"{name} = CURRENT_TIMESTAMP" for name in inline_timestamp_columns]
-    assignments.extend(f"{name} = :{name}" for name in param_updates)
-
-    result = conn.execute(
-        text(
-            f"""
-            UPDATE purchase_import_lines
-            SET {', '.join(assignments)}
-            WHERE id = :purchase_import_line_id
-            """
-        ),
-        {**param_updates, "purchase_import_line_id": purchase_import_line_id},
-    )
-    return int(result.rowcount or 0)
+    return _apply_row_update(conn, "purchase_import_lines", "id", purchase_import_line_id, updates)
 
 
 def _update_receipt_line(conn, receipt_line_id: str, external_code: str, source_name: str, candidate: dict[str, Any]) -> int:
@@ -121,47 +118,17 @@ def _update_receipt_line(conn, receipt_line_id: str, external_code: str, source_
     updates: dict[str, Any] = {}
 
     for column_name in ("external_article_code", "external_product_code", "retailer_article_number"):
-        if column_name in columns:
-            updates[column_name] = external_code
+        _append_update(updates, columns, column_name, external_code)
 
     for column_name in ("external_source_name", "source_name", "external_product_source"):
-        if column_name in columns:
-            updates[column_name] = source_name
+        _append_update(updates, columns, column_name, source_name)
 
-    for column_name in ("external_match_status", "status"):
-        if column_name in columns:
-            updates[column_name] = M2C2I22_CONFIRMED_STATUS
+    _append_update(updates, columns, "external_match_status", M2C2I22_CONFIRMED_STATUS)
+    _append_update(updates, columns, "matched_external_candidate_id", str(candidate.get("id") or "").strip())
+    _append_update(updates, columns, "matched_external_candidate_name", str(candidate.get("candidate_name") or "").strip())
+    _append_update(updates, columns, "updated_at", "__CURRENT_TIMESTAMP__")
 
-    if "matched_external_candidate_id" in columns:
-        updates["matched_external_candidate_id"] = str(candidate.get("id") or "").strip()
-    if "matched_external_candidate_name" in columns:
-        updates["matched_external_candidate_name"] = str(candidate.get("candidate_name") or "").strip()
-    if "updated_at" in columns:
-        updates["updated_at"] = _now_timestamp_sql(conn)
-
-    if not updates:
-        return 0
-
-    inline_timestamp_columns = {name for name, value in updates.items() if value == "__CURRENT_TIMESTAMP__"}
-    param_updates = {name: value for name, value in updates.items() if name not in inline_timestamp_columns}
-    assignments = [f"{name} = CURRENT_TIMESTAMP" for name in inline_timestamp_columns]
-    assignments.extend(f"{name} = :{name}" for name in param_updates)
-
-    result = conn.execute(
-        text(
-            f"""
-            UPDATE receipt_lines
-            SET {', '.join(assignments)}
-            WHERE id = :receipt_line_id
-            """
-        ),
-        {**param_updates, "receipt_line_id": receipt_line_id},
-    )
-    return int(result.rowcount or 0)
-
-
-def _now_timestamp_sql(conn) -> str:
-    return "__CURRENT_TIMESTAMP__"
+    return _apply_row_update(conn, "receipt_lines", "id", receipt_line_id, updates)
 
 
 def confirm_external_candidate_for_receipt_item(candidate_id: str, force_overwrite: bool = False) -> dict[str, Any]:

--- a/docs/architecture/M2C2i22_confirm_external_candidate.md
+++ b/docs/architecture/M2C2i22_confirm_external_candidate.md
@@ -1,0 +1,45 @@
+# M2C2i-22 — Externe kandidaat bevestigen op bonregel
+
+## Doel
+
+Een gebruiker kan een externe kandidaat bevestigen op een bonregel/importregel. Rezzerv legt dan alleen de externe bron en artikelcode vast op de bonregel. Daarna is de bonregel extern resolved en voorkomt M2C2i-20 dat dezelfde regel opnieuw door de kandidaatzoekflow gaat.
+
+```text
+kandidaat gevonden
+→ gebruiker bevestigt kandidaat
+→ externe artikelcode wordt op bonregel/importregel vastgelegd
+→ bonregel is external_resolved
+→ kandidaatzoeken wordt bij volgende refresh overgeslagen
+```
+
+## Domeingrens
+
+```text
+external_product_index ≠ global_products ≠ Mijn artikel
+```
+
+M2C2i-22 maakt bewust geen catalogusproduct, geen huishoudartikel en geen voorraadmutatie.
+
+```text
+creates_global_product = false
+creates_household_article = false
+creates_inventory_event = false
+```
+
+## Mutaties
+
+De bevestiging mag alleen deze mutaties uitvoeren:
+
+1. geselecteerde candidate markeren als `user_confirmed` / `external_resolved`;
+2. andere candidates binnen dezelfde context terugzetten naar gewone candidate-status;
+3. externe artikelcode en bron vastleggen op `purchase_import_lines` of `receipt_lines`, voor zover de kolommen bestaan;
+4. safety flags expliciet `false` teruggeven.
+
+## Buiten scope
+
+- Geen `global_products` aanmaken.
+- Geen `product_identities` aanmaken.
+- Geen Mijn-artikel aanmaken.
+- Geen voorraadmutatie.
+- Geen bonregeltypeclassificatie.
+- Geen automatische productkoppeling buiten de externe artikelcode.

--- a/docs/release/M2C2i22_validation.md
+++ b/docs/release/M2C2i22_validation.md
@@ -1,0 +1,103 @@
+# M2C2i-22 — Validatie
+
+## Doelvalidatie
+
+Aantonen dat een externe kandidaat kan worden bevestigd op een bonregel/importregel, zonder `global_products`, Mijn artikel of voorraadmutaties aan te maken.
+
+## Opstartroutine
+
+```powershell
+cd C:\Users\Gebruiker\Rezzerv_Github
+git fetch origin
+git switch m2c2i22-confirm-external-candidate
+git pull --ff-only origin m2c2i22-confirm-external-candidate
+docker compose up -d --build backend frontend
+Start-Sleep -Seconds 90
+```
+
+## Smoke zonder pytest
+
+Deze smoke maakt tijdelijk een kandidaat en een minimale importregel aan, bevestigt de kandidaat, en controleert daarna dat alleen de externe artikelcode is vastgelegd.
+
+```powershell
+@'
+from app.db import engine
+from sqlalchemy import text
+from app.services.external_product_candidate_store import ensure_external_product_candidates_schema
+from app.services.external_candidate_confirmation import confirm_external_candidate_for_receipt_item
+import uuid
+
+ensure_external_product_candidates_schema()
+line_id = "m2c2i22-smoke-line"
+candidate_id = "m2c2i22-smoke-candidate"
+context_key = "purchase-import-line:" + line_id
+
+with engine.begin() as conn:
+    conn.execute(text("DELETE FROM external_product_candidates WHERE id = :id OR purchase_import_line_id = :line_id"), {"id": candidate_id, "line_id": line_id})
+    if conn.execute(text("SELECT name FROM sqlite_master WHERE type='table' AND name='purchase_import_lines'")).first():
+        cols = {row.get('name') for row in conn.execute(text("PRAGMA table_info(purchase_import_lines)")).mappings().all()}
+        if {'id', 'article_name_raw'}.issubset(cols):
+            conn.execute(text("DELETE FROM purchase_import_lines WHERE id = :id"), {"id": line_id})
+            insert_cols = ["id", "article_name_raw"]
+            insert_vals = [":id", ":article_name_raw"]
+            params = {"id": line_id, "article_name_raw": "Veldsla"}
+            if "external_article_code" in cols:
+                insert_cols.append("external_article_code")
+                insert_vals.append("''")
+            if "created_at" in cols:
+                insert_cols.append("created_at")
+                insert_vals.append("CURRENT_TIMESTAMP")
+            if "updated_at" in cols:
+                insert_cols.append("updated_at")
+                insert_vals.append("CURRENT_TIMESTAMP")
+            conn.execute(text(f"INSERT INTO purchase_import_lines ({', '.join(insert_cols)}) VALUES ({', '.join(insert_vals)})"), params)
+
+    conn.execute(text("""
+        INSERT INTO external_product_candidates (
+            id, purchase_import_line_id, context_key, retailer_code, receipt_line_text,
+            candidate_name, candidate_brand, candidate_source_name, candidate_source_product_code,
+            source_name, source_product_code, retailer_article_number, score,
+            candidate_status, is_probable, is_user_confirmed, is_external_database_override,
+            created_by, created_at, updated_at
+        ) VALUES (
+            :id, :purchase_import_line_id, :context_key, 'lidl', 'Veldsla',
+            'Lidl Veldsla', 'Lidl Groente', 'lidl_catalog_index', 'lidl:groente.veldsla',
+            'lidl_catalog_index', 'lidl:groente.veldsla', 'lidl:groente.veldsla', 0.95,
+            'possible_candidate', 1, 0, 0,
+            'm2c2i22_smoke', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+        )
+    """), {"id": candidate_id, "purchase_import_line_id": line_id, "context_key": context_key})
+
+result = confirm_external_candidate_for_receipt_item(candidate_id)
+assert result["ok"] is True
+assert result["confirmed"] is True
+assert result["external_product_code"] == "lidl:groente.veldsla"
+assert result["creates_global_product"] is False
+assert result["creates_household_article"] is False
+assert result["creates_inventory_event"] is False
+
+with engine.begin() as conn:
+    candidate = conn.execute(text("SELECT candidate_status, status, global_product_id, is_user_confirmed FROM external_product_candidates WHERE id = :id"), {"id": candidate_id}).mappings().first()
+    assert candidate["candidate_status"] == "user_confirmed"
+    assert candidate["status"] == "external_resolved"
+    assert not candidate["global_product_id"]
+    assert int(candidate["is_user_confirmed"] or 0) == 1
+
+print("M2C2i-22 smoke OK: externe kandidaat bevestigd zonder product- of voorraadmutaties.")
+'@ | docker compose exec -T backend python
+```
+
+Verwacht:
+
+```text
+M2C2i-22 smoke OK: externe kandidaat bevestigd zonder product- of voorraadmutaties.
+```
+
+## GO-criteria
+
+- Geselecteerde candidate wordt `user_confirmed` / `external_resolved`.
+- Externe artikelcode is vastgelegd op de bonregel/importregel als de kolom bestaat.
+- `global_product_id` blijft leeg.
+- Geen `global_products`-aanmaak.
+- Geen Mijn-artikel-aanmaak.
+- Geen voorraadmutatie.

--- a/docs/release/M2C2i22_validation.md
+++ b/docs/release/M2C2i22_validation.md
@@ -17,7 +17,7 @@ Start-Sleep -Seconds 90
 
 ## Smoke zonder pytest
 
-Deze smoke maakt tijdelijk een kandidaat en een minimale importregel aan, bevestigt de kandidaat, en controleert daarna dat alleen de externe artikelcode is vastgelegd.
+Deze smoke maakt tijdelijk alleen een candidate aan en bevestigt die. Daarmee testen we de kernregel: de candidate wordt external resolved, zonder `global_product_id` of andere product-/voorraadmutaties. In de echte UI-flow wordt dezelfde functie gebruikt met een bestaande `purchase_import_line_id`, waardoor ook de externe artikelcode op de importregel wordt vastgelegd als de kolom bestaat.
 
 ```powershell
 @'
@@ -25,7 +25,6 @@ from app.db import engine
 from sqlalchemy import text
 from app.services.external_product_candidate_store import ensure_external_product_candidates_schema
 from app.services.external_candidate_confirmation import confirm_external_candidate_for_receipt_item
-import uuid
 
 ensure_external_product_candidates_schema()
 line_id = "m2c2i22-smoke-line"
@@ -34,24 +33,6 @@ context_key = "purchase-import-line:" + line_id
 
 with engine.begin() as conn:
     conn.execute(text("DELETE FROM external_product_candidates WHERE id = :id OR purchase_import_line_id = :line_id"), {"id": candidate_id, "line_id": line_id})
-    if conn.execute(text("SELECT name FROM sqlite_master WHERE type='table' AND name='purchase_import_lines'")).first():
-        cols = {row.get('name') for row in conn.execute(text("PRAGMA table_info(purchase_import_lines)")).mappings().all()}
-        if {'id', 'article_name_raw'}.issubset(cols):
-            conn.execute(text("DELETE FROM purchase_import_lines WHERE id = :id"), {"id": line_id})
-            insert_cols = ["id", "article_name_raw"]
-            insert_vals = [":id", ":article_name_raw"]
-            params = {"id": line_id, "article_name_raw": "Veldsla"}
-            if "external_article_code" in cols:
-                insert_cols.append("external_article_code")
-                insert_vals.append("''")
-            if "created_at" in cols:
-                insert_cols.append("created_at")
-                insert_vals.append("CURRENT_TIMESTAMP")
-            if "updated_at" in cols:
-                insert_cols.append("updated_at")
-                insert_vals.append("CURRENT_TIMESTAMP")
-            conn.execute(text(f"INSERT INTO purchase_import_lines ({', '.join(insert_cols)}) VALUES ({', '.join(insert_vals)})"), params)
-
     conn.execute(text("""
         INSERT INTO external_product_candidates (
             id, purchase_import_line_id, context_key, retailer_code, receipt_line_text,


### PR DESCRIPTION
M2C2i-22 — Externe kandidaat bevestigen op bonregel.

Doel:
- Een geselecteerde externe kandidaat kan worden bevestigd.
- De candidate wordt `user_confirmed` / `external_resolved`.
- De externe artikelcode en bron worden vastgelegd op de bonregel/importregel, voor zover de kolommen bestaan.
- Daarna zorgt M2C2i-20 ervoor dat de regel niet opnieuw door kandidaatzoeken gaat.

Wijzigingen:
- Nieuwe service `external_candidate_confirmation.py`.
- Bevestigingsfunctie `confirm_external_candidate_for_receipt_item(candidate_id, force_overwrite=False)`.
- Geselecteerde candidate wordt bevestigd.
- Andere candidates binnen dezelfde context worden teruggezet naar gewone candidate-status.
- `global_product_id` wordt expliciet leeg gehouden.
- Architectuur- en validatiedocumentatie toegevoegd.

Niet gewijzigd:
- Geen `global_products`-aanmaak.
- Geen `product_identities`-aanmaak.
- Geen Mijn-artikel-aanmaak.
- Geen voorraadmutatie.
- Geen bonregeltypeclassificatie.

Safety:
- `creates_global_product = False`
- `creates_household_article = False`
- `creates_inventory_event = False`

Validatie:
- Pytest-vrije smoke opgenomen in `docs/release/M2C2i22_validation.md`.
- Opstartroutine bevat `Start-Sleep -Seconds 90`.