### PR TITLE
feat(external-db): show confirmed recognitions in UI

### DIFF
--- a/backend/app/api/system_routes.py
+++ b/backend/app/api/system_routes.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, Body, HTTPException, Query
 
 from app.api.route_governance import build_route_governance_manifest
 from app.db import get_runtime_datastore_info
+from app.services.external_candidate_confirmation import confirm_external_candidate_for_receipt_item
 from app.services.external_database_matchers import (
     get_external_database_summary,
     list_external_database_retailers,
@@ -75,6 +76,18 @@ def api_version():
 @router.post('/api/external-databases/catalog/promote-candidate')
 def external_databases_promote_selected_candidate(payload: dict[str, Any] = Body(default_factory=dict)):
     return promote_external_product_candidate(
+        candidate_id=str(payload.get('candidate_id') or ''),
+        force_overwrite=bool(payload.get('force_overwrite', False)),
+    )
+
+
+@router.post('/api/external-databases/candidates/confirm-external')
+def external_databases_confirm_external_candidate(payload: dict[str, Any] = Body(default_factory=dict)):
+    """Bevestig alleen externe kandidaat op bonregel/importregel.
+
+    Deze route maakt geen global_product, geen Mijn artikel en geen voorraadmutatie.
+    """
+    return confirm_external_candidate_for_receipt_item(
         candidate_id=str(payload.get('candidate_id') or ''),
         force_overwrite=bool(payload.get('force_overwrite', False)),
     )

--- a/backend/app/services/external_candidate_confirmation.py
+++ b/backend/app/services/external_candidate_confirmation.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db import engine
+from app.services.external_product_candidate_store import (
+    _m2c2h5_table_columns,
+    _m2c2h5_table_exists,
+    build_candidate_context_key,
+    ensure_external_product_candidates_schema,
+)
+
+M2C2I22_CONFIRMED_STATUS = "external_resolved"
+M2C2I22_USER_CONFIRMED_STATUS = "user_confirmed"
+
+
+def _truthy(value: Any) -> bool:
+    normalized = str(value if value is not None else "").strip().lower()
+    return bool(normalized and normalized not in {"-", "0", "none", "null", "undefined", "false", "unknown", "onbekend"})
+
+
+def _first_truthy(row: dict[str, Any], *field_names: str) -> str:
+    for field_name in field_names:
+        value = str(row.get(field_name) if row.get(field_name) is not None else "").strip()
+        if _truthy(value):
+            return value
+    return ""
+
+
+def _candidate_external_code(candidate: dict[str, Any]) -> str:
+    return _first_truthy(
+        candidate,
+        "external_source_product_code",
+        "candidate_source_product_code",
+        "source_product_code",
+        "retailer_article_number",
+        "gtin",
+        "ean",
+        "code",
+    )
+
+
+def _candidate_source_name(candidate: dict[str, Any]) -> str:
+    return _first_truthy(candidate, "external_source_name", "candidate_source_name", "source_name") or "external_candidate"
+
+
+def _candidate_receipt_text(candidate: dict[str, Any]) -> str:
+    return _first_truthy(candidate, "receipt_line_text", "candidate_name")
+
+
+def _candidate_context_key(candidate: dict[str, Any]) -> str:
+    context_key = _first_truthy(candidate, "context_key")
+    if context_key:
+        return context_key
+    return build_candidate_context_key(
+        str(candidate.get("retailer_code") or "").strip().lower(),
+        _candidate_receipt_text(candidate),
+        receipt_line_id=_first_truthy(candidate, "receipt_line_id") or None,
+        purchase_import_line_id=_first_truthy(candidate, "purchase_import_line_id") or None,
+    )
+
+
+def _append_update(updates: dict[str, Any], columns: set[str], column_name: str, value: Any) -> None:
+    if column_name in columns:
+        updates[column_name] = value
+
+
+def _apply_row_update(conn, table_name: str, row_id_column: str, row_id: str, updates: dict[str, Any]) -> int:
+    if not row_id or not updates:
+        return 0
+
+    inline_timestamp_columns = {name for name, value in updates.items() if value == "__CURRENT_TIMESTAMP__"}
+    param_updates = {name: value for name, value in updates.items() if name not in inline_timestamp_columns}
+    assignments = [f"{name} = CURRENT_TIMESTAMP" for name in inline_timestamp_columns]
+    assignments.extend(f"{name} = :{name}" for name in param_updates)
+
+    result = conn.execute(
+        text(
+            f"""
+            UPDATE {table_name}
+            SET {', '.join(assignments)}
+            WHERE {row_id_column} = :row_id
+            """
+        ),
+        {**param_updates, "row_id": row_id},
+    )
+    return int(result.rowcount or 0)
+
+
+def _update_purchase_import_line(conn, purchase_import_line_id: str, external_code: str, source_name: str, candidate: dict[str, Any]) -> int:
+    if not purchase_import_line_id or not _m2c2h5_table_exists(conn, "purchase_import_lines"):
+        return 0
+
+    columns = _m2c2h5_table_columns(conn, "purchase_import_lines")
+    updates: dict[str, Any] = {}
+
+    for column_name in ("external_article_code", "external_product_code", "retailer_article_number"):
+        _append_update(updates, columns, column_name, external_code)
+
+    for column_name in ("external_source_name", "source_name", "external_product_source"):
+        _append_update(updates, columns, column_name, source_name)
+
+    _append_update(updates, columns, "external_match_status", M2C2I22_CONFIRMED_STATUS)
+    _append_update(updates, columns, "matched_external_candidate_id", str(candidate.get("id") or "").strip())
+    _append_update(updates, columns, "matched_external_candidate_name", str(candidate.get("candidate_name") or "").strip())
+    _append_update(updates, columns, "updated_at", "__CURRENT_TIMESTAMP__")
+
+    return _apply_row_update(conn, "purchase_import_lines", "id", purchase_import_line_id, updates)
+
+
+def _update_receipt_line(conn, receipt_line_id: str, external_code: str, source_name: str, candidate: dict[str, Any]) -> int:
+    if not receipt_line_id or not _m2c2h5_table_exists(conn, "receipt_lines"):
+        return 0
+
+    columns = _m2c2h5_table_columns(conn, "receipt_lines")
+    updates: dict[str, Any] = {}
+
+    for column_name in ("external_article_code", "external_product_code", "retailer_article_number"):
+        _append_update(updates, columns, column_name, external_code)
+
+    for column_name in ("external_source_name", "source_name", "external_product_source"):
+        _append_update(updates, columns, column_name, source_name)
+
+    _append_update(updates, columns, "external_match_status", M2C2I22_CONFIRMED_STATUS)
+    _append_update(updates, columns, "matched_external_candidate_id", str(candidate.get("id") or "").strip())
+    _append_update(updates, columns, "matched_external_candidate_name", str(candidate.get("candidate_name") or "").strip())
+    _append_update(updates, columns, "updated_at", "__CURRENT_TIMESTAMP__")
+
+    return _apply_row_update(conn, "receipt_lines", "id", receipt_line_id, updates)
+
+
+def confirm_external_candidate_for_receipt_item(candidate_id: str, force_overwrite: bool = False) -> dict[str, Any]:
+    """Bevestig een externe kandidaat op de bonregel zonder catalogus-/voorraadmutaties.
+
+    M2C2i-22 legt alleen de externe artikelcode en bron vast op de bonregel/importregel.
+    De functie maakt geen global_products, geen Mijn artikel en geen voorraadmutatie.
+    """
+    ensure_external_product_candidates_schema()
+    normalized_candidate_id = str(candidate_id or "").strip()
+    if not normalized_candidate_id:
+        return {"ok": False, "confirmed": False, "reason": "missing_candidate_id"}
+
+    with engine.begin() as conn:
+        candidate_row = conn.execute(
+            text(
+                """
+                SELECT *
+                FROM external_product_candidates
+                WHERE id = :candidate_id
+                LIMIT 1
+                """
+            ),
+            {"candidate_id": normalized_candidate_id},
+        ).mappings().first()
+
+        if not candidate_row:
+            return {"ok": False, "confirmed": False, "reason": "candidate_not_found"}
+
+        candidate = dict(candidate_row)
+        external_code = _candidate_external_code(candidate)
+        if not external_code:
+            return {"ok": False, "confirmed": False, "reason": "missing_external_product_code", "candidate_id": normalized_candidate_id}
+
+        context_key = _candidate_context_key(candidate)
+        purchase_import_line_id = _first_truthy(candidate, "purchase_import_line_id")
+        receipt_line_id = _first_truthy(candidate, "receipt_line_id")
+        source_name = _candidate_source_name(candidate)
+
+        linked_rows = conn.execute(
+            text(
+                """
+                SELECT id
+                FROM external_product_candidates
+                WHERE context_key = :context_key
+                  AND id <> :candidate_id
+                  AND (
+                    candidate_status IN ('external_resolved', 'user_confirmed', 'linked_to_catalog')
+                    OR status IN ('external_resolved', 'user_confirmed', 'linked_to_catalog')
+                    OR is_user_confirmed = 1
+                    OR is_external_database_override = 1
+                  )
+                """
+            ),
+            {"context_key": context_key, "candidate_id": normalized_candidate_id},
+        ).mappings().all()
+
+        if linked_rows and not force_overwrite:
+            return {
+                "ok": True,
+                "confirmed": False,
+                "requires_overwrite": True,
+                "existing_link_count": len(linked_rows),
+                "candidate_id": normalized_candidate_id,
+                "context_key": context_key,
+                "creates_global_product": False,
+                "creates_household_article": False,
+                "creates_inventory_event": False,
+            }
+
+        conn.execute(
+            text(
+                """
+                UPDATE external_product_candidates
+                SET candidate_status = 'candidate',
+                    status = 'candidate',
+                    is_user_confirmed = 0,
+                    is_external_database_override = 0,
+                    global_product_id = NULL,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE context_key = :context_key
+                  AND id <> :candidate_id
+                """
+            ),
+            {"context_key": context_key, "candidate_id": normalized_candidate_id},
+        )
+
+        conn.execute(
+            text(
+                """
+                UPDATE external_product_candidates
+                SET candidate_status = :candidate_status,
+                    status = :status,
+                    is_user_confirmed = 1,
+                    is_external_database_override = 0,
+                    global_product_id = NULL,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE id = :candidate_id
+                """
+            ),
+            {
+                "candidate_id": normalized_candidate_id,
+                "candidate_status": M2C2I22_USER_CONFIRMED_STATUS,
+                "status": M2C2I22_CONFIRMED_STATUS,
+            },
+        )
+
+        purchase_import_line_updated_count = _update_purchase_import_line(
+            conn,
+            purchase_import_line_id,
+            external_code,
+            source_name,
+            candidate,
+        )
+        receipt_line_updated_count = _update_receipt_line(
+            conn,
+            receipt_line_id,
+            external_code,
+            source_name,
+            candidate,
+        )
+
+    return {
+        "ok": True,
+        "confirmed": True,
+        "requires_overwrite": False,
+        "candidate_id": normalized_candidate_id,
+        "context_key": context_key,
+        "purchase_import_line_id": purchase_import_line_id or None,
+        "receipt_line_id": receipt_line_id or None,
+        "external_product_code": external_code,
+        "external_source_name": source_name,
+        "purchase_import_line_updated_count": purchase_import_line_updated_count,
+        "receipt_line_updated_count": receipt_line_updated_count,
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+    }

--- a/backend/app/services/external_candidate_normalization.py
+++ b/backend/app/services/external_candidate_normalization.py
@@ -7,6 +7,7 @@ from app.services.product_taxonomy_store import normalize_taxonomy_text
 SOURCE_PRIORITY = {
     "lidl_catalog_enrichment": 100,
     "retailer_alias_learning": 95,
+    "lidl_catalog_index": 92,
     "lidl_product_group": 90,
     "product_taxonomy_seed": 80,
     "OFF-index": 70,
@@ -62,6 +63,34 @@ def _identity_key(candidate: dict[str, Any], evidence_packet: dict[str, Any] | N
     return f"name:{source_name}:{candidate_name}"
 
 
+def _append_unique(target: list[str], value: Any) -> None:
+    text = str(value or "").strip()
+    if text and text not in target:
+        target.append(text)
+
+
+def _collect_source_names(*candidates: dict[str, Any]) -> list[str]:
+    values: list[str] = []
+    for candidate in candidates:
+        for merged in candidate.get("merged_source_names") or []:
+            _append_unique(values, merged)
+        _append_unique(values, _source_name(candidate))
+    return values
+
+
+def _collect_source_codes(*candidates: dict[str, Any]) -> list[str]:
+    values: list[str] = []
+    for candidate in candidates:
+        for merged in candidate.get("merged_source_product_codes") or []:
+            _append_unique(values, merged)
+        _append_unique(values, _source_code(candidate))
+    return values
+
+
+def _has_lidl_catalog_source(candidate: dict[str, Any]) -> bool:
+    return _source_name(candidate) == "lidl_catalog_index" or "lidl_catalog_index" in (candidate.get("merged_source_names") or [])
+
+
 def _merge_candidates(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
     primary, secondary = (incoming, existing) if _priority(incoming) > _priority(existing) else (existing, incoming)
     result = dict(primary)
@@ -74,18 +103,12 @@ def _merge_candidates(existing: dict[str, Any], incoming: dict[str, Any]) -> dic
     if evidence_packet:
         result["product_evidence_packet"] = evidence_packet
 
-    source_names = []
-    source_codes = []
-    for candidate in [existing, incoming]:
-        source_name = _source_name(candidate)
-        source_code = _source_code(candidate)
-        if source_name and source_name not in source_names:
-            source_names.append(source_name)
-        if source_code and source_code not in source_codes:
-            source_codes.append(source_code)
+    source_names = _collect_source_names(existing, incoming)
+    source_codes = _collect_source_codes(existing, incoming)
 
     result["merged_source_names"] = source_names
     result["merged_source_product_codes"] = source_codes
+    result["has_lidl_local_catalog_index_source"] = "lidl_catalog_index" in source_names
     result["deduplicated_candidate_count"] = int(existing.get("deduplicated_candidate_count") or 1) + int(incoming.get("deduplicated_candidate_count") or 1)
     result.setdefault("score_breakdown", {})["deduplicated_candidate_count"] = result["deduplicated_candidate_count"]
 
@@ -104,6 +127,7 @@ def normalize_external_candidates(candidates: list[dict[str, Any]], evidence_pac
         item.setdefault("source_name", item.get("candidate_source_name"))
         item.setdefault("source_product_code", item.get("candidate_source_product_code"))
         item.setdefault("retailer_article_number", item.get("candidate_source_product_code"))
+        item.setdefault("has_lidl_local_catalog_index_source", _has_lidl_catalog_source(item))
         for flag in ["creates_global_product", "creates_household_article", "creates_inventory_event"]:
             item[flag] = False
 

--- a/backend/app/services/external_candidate_normalization.py
+++ b/backend/app/services/external_candidate_normalization.py
@@ -6,6 +6,7 @@ from app.services.product_taxonomy_store import normalize_taxonomy_text
 
 SOURCE_PRIORITY = {
     "lidl_catalog_enrichment": 100,
+    "retailer_alias_learning": 95,
     "lidl_product_group": 90,
     "product_taxonomy_seed": 80,
     "OFF-index": 70,

--- a/backend/app/services/external_database_matchflow_evidence.py
+++ b/backend/app/services/external_database_matchflow_evidence.py
@@ -9,6 +9,7 @@ from app.services import external_product_candidate_store as candidate_store
 from app.services.external_candidate_normalization import normalize_external_candidates
 from app.services.external_database_matchers import match_retailer_receipt_line as _base_match_retailer_receipt_line
 from app.services.external_product_alias_store import find_alias_candidates, save_alias_from_candidate
+from app.services.lidl_local_catalog_index import search_lidl_local_catalog_candidates
 from app.services.product_evidence_packet import apply_product_evidence_to_candidates, build_product_evidence_packet_dict
 
 
@@ -32,15 +33,24 @@ M2C2I20_EXTERNAL_CODE_FIELDS = (
 _M2C2I20A_PERFORMANCE_INDEXES_READY = False
 
 
+def _m2c2i21_catalog_candidates(retailer_code: str, receipt_line_text: str) -> list[dict[str, Any]]:
+    if str(retailer_code or "").strip().lower() != "lidl":
+        return []
+    return search_lidl_local_catalog_candidates(receipt_line_text, limit=5)
+
+
 def _with_evidence_scoring(result: dict[str, Any], receipt_line_text: str, retailer_code: str) -> dict[str, Any]:
     base_candidates = list(result.get("candidates") or [])
     alias_candidates = find_alias_candidates(retailer_code, receipt_line_text)
-    candidates = alias_candidates + base_candidates
+    catalog_candidates = _m2c2i21_catalog_candidates(retailer_code, receipt_line_text)
+    candidates = alias_candidates + catalog_candidates + base_candidates
     if not candidates:
         enriched_empty = dict(result)
         enriched_empty["uses_product_evidence_scoring"] = True
         enriched_empty["uses_candidate_deduplication"] = False
         enriched_empty["uses_retailer_alias_learning"] = bool(alias_candidates)
+        enriched_empty["uses_lidl_local_catalog_index"] = bool(catalog_candidates)
+        enriched_empty["lidl_local_catalog_candidate_count"] = len(catalog_candidates)
         enriched_empty["candidate_count_before_deduplication"] = 0
         enriched_empty["candidate_count_after_deduplication"] = 0
         enriched_empty["creates_global_product"] = False
@@ -70,6 +80,8 @@ def _with_evidence_scoring(result: dict[str, Any], receipt_line_text: str, retai
     enriched["uses_product_evidence_scoring"] = True
     enriched["uses_candidate_deduplication"] = len(normalized) < len(rescored)
     enriched["uses_retailer_alias_learning"] = bool(alias_candidates)
+    enriched["uses_lidl_local_catalog_index"] = bool(catalog_candidates)
+    enriched["lidl_local_catalog_candidate_count"] = len(catalog_candidates)
     enriched["candidate_count_before_deduplication"] = len(rescored)
     enriched["candidate_count_after_deduplication"] = len(normalized[:5])
     enriched["alias_candidate_count"] = len(alias_candidates)

--- a/backend/app/services/external_database_matchflow_evidence.py
+++ b/backend/app/services/external_database_matchflow_evidence.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from sqlalchemy import text
+
+from app.db import engine
 from app.services import external_product_candidate_store as candidate_store
 from app.services.external_candidate_normalization import normalize_external_candidates
 from app.services.external_database_matchers import match_retailer_receipt_line as _base_match_retailer_receipt_line
@@ -25,6 +28,8 @@ M2C2I20_EXTERNAL_CODE_FIELDS = (
     "gtin",
     "ean",
 )
+
+_M2C2I20A_PERFORMANCE_INDEXES_READY = False
 
 
 def _with_evidence_scoring(result: dict[str, Any], receipt_line_text: str, retailer_code: str) -> dict[str, Any]:
@@ -155,6 +160,54 @@ def _m2c2i20_split_resolved_items(items: list[dict[str, Any]] | None) -> tuple[l
     return unresolved, resolved
 
 
+def _m2c2i20a_ensure_performance_indexes() -> None:
+    """Maak lichte indexen voor de Externe databases paging/refresh-flow.
+
+    De UI werkt bonartikelgedreven. Bij paginawissels en refreshes filteren we vooral op
+    context_key, purchase_import_line_id en receipt_line_id. Zonder indexen groeit de
+    reactietijd merkbaar zodra external_product_candidates meer historie bevat.
+    """
+    global _M2C2I20A_PERFORMANCE_INDEXES_READY
+    if _M2C2I20A_PERFORMANCE_INDEXES_READY:
+        return
+
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE INDEX IF NOT EXISTS idx_m2c2i20a_candidates_context_updated
+                ON external_product_candidates (context_key, updated_at)
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE INDEX IF NOT EXISTS idx_m2c2i20a_candidates_purchase_line
+                ON external_product_candidates (purchase_import_line_id, updated_at)
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE INDEX IF NOT EXISTS idx_m2c2i20a_candidates_receipt_line
+                ON external_product_candidates (receipt_line_id, updated_at)
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE INDEX IF NOT EXISTS idx_m2c2i20a_candidates_status_context
+                ON external_product_candidates (candidate_status, status, context_key)
+                """
+            )
+        )
+
+    _M2C2I20A_PERFORMANCE_INDEXES_READY = True
+
+
 def _m2c2i20_call_candidate_store_ensure(args: tuple[Any, ...], kwargs: dict[str, Any], unresolved_items: list[dict[str, Any]]) -> dict[str, Any]:
     next_kwargs = dict(kwargs)
     if "items" in next_kwargs:
@@ -171,6 +224,7 @@ def _m2c2i20_enrich_ensure_result(result: dict[str, Any], original_total: int, r
     enriched["external_resolved_skipped_count"] = len(resolved_skips)
     enriched["external_resolved_skipped"] = resolved_skips
     enriched["m2c2i20_resolved_state_gate"] = True
+    enriched["m2c2i20a_performance_indexes"] = True
     enriched["creates_global_product"] = False
     enriched["creates_household_article"] = False
     enriched["creates_inventory_event"] = False
@@ -187,6 +241,8 @@ def save_matchpreview_candidates(*args: Any, **kwargs: Any) -> dict[str, Any]:
 
 
 def ensure_external_receipt_item_candidates(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    _m2c2i20a_ensure_performance_indexes()
+
     items = kwargs.get("items") if "items" in kwargs else (args[0] if args else None)
     if items is not None:
         normalized_items = [dict(item) for item in (items or []) if isinstance(item, dict)]
@@ -201,6 +257,19 @@ def ensure_external_receipt_item_candidates(*args: Any, **kwargs: Any) -> dict[s
     try:
         if items is None:
             return candidate_store.ensure_external_receipt_item_candidates(*args, **kwargs)
+        if not unresolved_items:
+            return _m2c2i20_enrich_ensure_result(
+                {
+                    "ok": True,
+                    "processed": 0,
+                    "saved_count": 0,
+                    "updated_count": 0,
+                    "skipped_count": 0,
+                    "errors": [],
+                },
+                len(normalized_items),
+                resolved_items,
+            )
         result = _m2c2i20_call_candidate_store_ensure(args, kwargs, unresolved_items)
         return _m2c2i20_enrich_ensure_result(result, len(normalized_items), resolved_items)
     finally:

--- a/backend/app/services/external_database_matchflow_evidence.py
+++ b/backend/app/services/external_database_matchflow_evidence.py
@@ -9,6 +9,24 @@ from app.services.external_product_alias_store import find_alias_candidates, sav
 from app.services.product_evidence_packet import apply_product_evidence_to_candidates, build_product_evidence_packet_dict
 
 
+M2C2I20_RESOLVED_EXTERNAL_STATUSES = {
+    "resolved",
+    "external_resolved",
+    "linked_to_catalog",
+    "user_confirmed",
+}
+
+M2C2I20_EXTERNAL_CODE_FIELDS = (
+    "external_product_code",
+    "external_source_product_code",
+    "external_product_index_id",
+    "external_article_code",
+    "retailer_article_number",
+    "gtin",
+    "ean",
+)
+
+
 def _with_evidence_scoring(result: dict[str, Any], receipt_line_text: str, retailer_code: str) -> dict[str, Any]:
     base_candidates = list(result.get("candidates") or [])
     alias_candidates = find_alias_candidates(retailer_code, receipt_line_text)
@@ -65,6 +83,100 @@ def match_retailer_receipt_line(retailer_code: str, receipt_line_text: str, incl
     return _with_evidence_scoring(result, receipt_line_text, retailer_code)
 
 
+def _m2c2i20_truthy(value: Any) -> bool:
+    normalized = str(value if value is not None else "").strip().lower()
+    return bool(normalized and normalized not in {"-", "0", "none", "null", "undefined", "false", "unknown", "onbekend"})
+
+
+def m2c2i20_external_product_code(item: dict[str, Any] | None) -> str:
+    if not isinstance(item, dict):
+        return ""
+    for field_name in M2C2I20_EXTERNAL_CODE_FIELDS:
+        value = str(item.get(field_name) if item.get(field_name) is not None else "").strip()
+        if _m2c2i20_truthy(value):
+            return value
+    return ""
+
+
+def is_m2c2i20_external_resolved_item(item: dict[str, Any] | None) -> bool:
+    """Return True when a receipt item already has a usable external article code.
+
+    M2C2i-20 rule: a receipt item that already has an external product code is resolved
+    for the external-database flow and must not be searched again.
+    """
+    if not isinstance(item, dict):
+        return False
+
+    external_code = m2c2i20_external_product_code(item)
+    if not external_code:
+        return False
+
+    status_values = {
+        str(item.get("external_match_status") or "").strip().lower(),
+        str(item.get("status") or "").strip().lower(),
+        str(item.get("candidate_status") or "").strip().lower(),
+    }
+    if status_values & M2C2I20_RESOLVED_EXTERNAL_STATUSES:
+        return True
+
+    if bool(item.get("is_external_resolved")) or bool(item.get("is_linked_to_catalog")):
+        return True
+
+    # Bovenste tabelrijen zijn bonartikelgedreven. Als zo'n rij al een externe code
+    # heeft, dan is zoeken op bontekst niet meer nodig.
+    if bool(item.get("is_receipt_item_placeholder")):
+        return True
+    if _m2c2i20_truthy(item.get("purchase_import_line_id")) or _m2c2i20_truthy(item.get("receipt_line_id")):
+        return True
+
+    return False
+
+
+def _m2c2i20_resolved_skip_entry(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "reason": "external_product_code_resolved",
+        "receipt_line_text": str(item.get("receipt_line_text") or item.get("receiptLineText") or "").strip(),
+        "retailer_code": str(item.get("retailer_code") or item.get("retailerCode") or "").strip().lower(),
+        "receipt_line_id": str(item.get("receipt_line_id") or item.get("receiptLineId") or "").strip() or None,
+        "purchase_import_line_id": str(item.get("purchase_import_line_id") or item.get("purchaseImportLineId") or "").strip() or None,
+        "external_product_code": m2c2i20_external_product_code(item),
+    }
+
+
+def _m2c2i20_split_resolved_items(items: list[dict[str, Any]] | None) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    unresolved: list[dict[str, Any]] = []
+    resolved: list[dict[str, Any]] = []
+    for item in items or []:
+        next_item = dict(item) if isinstance(item, dict) else item
+        if is_m2c2i20_external_resolved_item(next_item):
+            resolved.append(next_item)
+        else:
+            unresolved.append(next_item)
+    return unresolved, resolved
+
+
+def _m2c2i20_call_candidate_store_ensure(args: tuple[Any, ...], kwargs: dict[str, Any], unresolved_items: list[dict[str, Any]]) -> dict[str, Any]:
+    next_kwargs = dict(kwargs)
+    if "items" in next_kwargs:
+        next_kwargs["items"] = unresolved_items
+        return candidate_store.ensure_external_receipt_item_candidates(*args, **next_kwargs)
+    return candidate_store.ensure_external_receipt_item_candidates(unresolved_items, *args[1:], **next_kwargs)
+
+
+def _m2c2i20_enrich_ensure_result(result: dict[str, Any], original_total: int, resolved_items: list[dict[str, Any]]) -> dict[str, Any]:
+    enriched = dict(result or {})
+    resolved_skips = [_m2c2i20_resolved_skip_entry(item) for item in resolved_items]
+    enriched["total"] = original_total
+    enriched["skipped_count"] = int(enriched.get("skipped_count") or 0) + len(resolved_skips)
+    enriched["external_resolved_skipped_count"] = len(resolved_skips)
+    enriched["external_resolved_skipped"] = resolved_skips
+    enriched["m2c2i20_resolved_state_gate"] = True
+    enriched["creates_global_product"] = False
+    enriched["creates_household_article"] = False
+    enriched["creates_inventory_event"] = False
+    return enriched
+
+
 def save_matchpreview_candidates(*args: Any, **kwargs: Any) -> dict[str, Any]:
     previous_matcher = candidate_store.match_retailer_receipt_line
     candidate_store.match_retailer_receipt_line = match_retailer_receipt_line
@@ -75,9 +187,21 @@ def save_matchpreview_candidates(*args: Any, **kwargs: Any) -> dict[str, Any]:
 
 
 def ensure_external_receipt_item_candidates(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    items = kwargs.get("items") if "items" in kwargs else (args[0] if args else None)
+    if items is not None:
+        normalized_items = [dict(item) for item in (items or []) if isinstance(item, dict)]
+        unresolved_items, resolved_items = _m2c2i20_split_resolved_items(normalized_items)
+    else:
+        normalized_items = []
+        unresolved_items = []
+        resolved_items = []
+
     previous_matcher = candidate_store.match_retailer_receipt_line
     candidate_store.match_retailer_receipt_line = match_retailer_receipt_line
     try:
-        return candidate_store.ensure_external_receipt_item_candidates(*args, **kwargs)
+        if items is None:
+            return candidate_store.ensure_external_receipt_item_candidates(*args, **kwargs)
+        result = _m2c2i20_call_candidate_store_ensure(args, kwargs, unresolved_items)
+        return _m2c2i20_enrich_ensure_result(result, len(normalized_items), resolved_items)
     finally:
         candidate_store.match_retailer_receipt_line = previous_matcher

--- a/backend/app/services/external_database_matchflow_evidence.py
+++ b/backend/app/services/external_database_matchflow_evidence.py
@@ -5,13 +5,25 @@ from typing import Any
 from app.services import external_product_candidate_store as candidate_store
 from app.services.external_candidate_normalization import normalize_external_candidates
 from app.services.external_database_matchers import match_retailer_receipt_line as _base_match_retailer_receipt_line
+from app.services.external_product_alias_store import find_alias_candidates, save_alias_from_candidate
 from app.services.product_evidence_packet import apply_product_evidence_to_candidates, build_product_evidence_packet_dict
 
 
 def _with_evidence_scoring(result: dict[str, Any], receipt_line_text: str, retailer_code: str) -> dict[str, Any]:
-    candidates = list(result.get("candidates") or [])
+    base_candidates = list(result.get("candidates") or [])
+    alias_candidates = find_alias_candidates(retailer_code, receipt_line_text)
+    candidates = alias_candidates + base_candidates
     if not candidates:
-        return result
+        enriched_empty = dict(result)
+        enriched_empty["uses_product_evidence_scoring"] = True
+        enriched_empty["uses_candidate_deduplication"] = False
+        enriched_empty["uses_retailer_alias_learning"] = bool(alias_candidates)
+        enriched_empty["candidate_count_before_deduplication"] = 0
+        enriched_empty["candidate_count_after_deduplication"] = 0
+        enriched_empty["creates_global_product"] = False
+        enriched_empty["creates_household_article"] = False
+        enriched_empty["creates_inventory_event"] = False
+        return enriched_empty
 
     evidence_packet = build_product_evidence_packet_dict(receipt_line_text, retailer_code=retailer_code)
     rescored = apply_product_evidence_to_candidates(
@@ -22,12 +34,22 @@ def _with_evidence_scoring(result: dict[str, Any], receipt_line_text: str, retai
     )
     normalized = normalize_external_candidates(rescored, evidence_packet=evidence_packet)
 
+    if normalized:
+        save_alias_from_candidate(
+            retailer_code=retailer_code,
+            receipt_line_text=receipt_line_text,
+            candidate=normalized[0],
+            learned_from="matchflow_evidence",
+        )
+
     enriched = dict(result)
     enriched["candidates"] = normalized[:5]
     enriched["uses_product_evidence_scoring"] = True
     enriched["uses_candidate_deduplication"] = len(normalized) < len(rescored)
+    enriched["uses_retailer_alias_learning"] = bool(alias_candidates)
     enriched["candidate_count_before_deduplication"] = len(rescored)
     enriched["candidate_count_after_deduplication"] = len(normalized[:5])
+    enriched["alias_candidate_count"] = len(alias_candidates)
     enriched["creates_global_product"] = False
     enriched["creates_household_article"] = False
     enriched["creates_inventory_event"] = False

--- a/backend/app/services/external_product_alias_store.py
+++ b/backend/app/services/external_product_alias_store.py
@@ -1,0 +1,436 @@
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db import engine
+from app.services.product_taxonomy_store import normalize_taxonomy_text
+from app.services.retailer_catalog_enrichment import CATALOG_SEED_PATH
+
+ALIAS_SOURCE_NAME = "retailer_alias_learning"
+MIN_ALIAS_CONFIDENCE = 0.90
+
+ALIAS_COLUMNS: dict[str, str] = {
+    "id": "TEXT PRIMARY KEY",
+    "retailer_code": "TEXT",
+    "normalized_receipt_line_text": "TEXT",
+    "raw_receipt_line_text": "TEXT",
+    "candidate_source_name": "TEXT",
+    "candidate_source_product_code": "TEXT",
+    "candidate_name": "TEXT",
+    "candidate_brand": "TEXT",
+    "category": "TEXT",
+    "product_type": "TEXT",
+    "quantity_label": "TEXT",
+    "source_url": "TEXT",
+    "confidence": "REAL",
+    "learned_from": "TEXT",
+    "created_at": "TEXT",
+    "updated_at": "TEXT",
+}
+
+CREATE_EXTERNAL_PRODUCT_ALIASES_SQL = """
+CREATE TABLE IF NOT EXISTS external_product_aliases (
+    id TEXT PRIMARY KEY,
+    retailer_code TEXT,
+    normalized_receipt_line_text TEXT,
+    raw_receipt_line_text TEXT,
+    candidate_source_name TEXT,
+    candidate_source_product_code TEXT,
+    candidate_name TEXT,
+    candidate_brand TEXT,
+    category TEXT,
+    product_type TEXT,
+    quantity_label TEXT,
+    source_url TEXT,
+    confidence REAL,
+    learned_from TEXT,
+    created_at TEXT,
+    updated_at TEXT
+)
+"""
+
+CREATE_EXTERNAL_PRODUCT_ALIASES_INDEX_SQL = """
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_product_aliases_lookup
+ON external_product_aliases (retailer_code, normalized_receipt_line_text, candidate_source_name, candidate_source_product_code)
+"""
+
+CREATE_EXTERNAL_PRODUCT_ALIASES_CODE_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_external_product_aliases_code
+ON external_product_aliases (retailer_code, candidate_source_product_code)
+"""
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def normalize_alias_text(value: str | None) -> str:
+    return normalize_taxonomy_text(value)
+
+
+def _sqlite_columns(conn) -> set[str]:
+    rows = conn.execute(text("PRAGMA table_info(external_product_aliases)")).mappings().all()
+    return {str(row.get("name") or "") for row in rows}
+
+
+def _postgres_columns(conn) -> set[str]:
+    rows = conn.execute(
+        text(
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_name = 'external_product_aliases'
+            """
+        )
+    ).mappings().all()
+    return {str(row.get("column_name") or "") for row in rows}
+
+
+def _add_missing_columns(conn) -> None:
+    dialect_name = str(engine.dialect.name or "").lower()
+    existing_columns = _sqlite_columns(conn) if dialect_name == "sqlite" else _postgres_columns(conn)
+    for column_name, column_definition in ALIAS_COLUMNS.items():
+        if column_name in existing_columns or column_name == "id":
+            continue
+        conn.execute(text(f"ALTER TABLE external_product_aliases ADD COLUMN {column_name} {column_definition}"))
+
+
+def ensure_external_product_aliases_schema() -> None:
+    with engine.begin() as conn:
+        conn.execute(text(CREATE_EXTERNAL_PRODUCT_ALIASES_SQL))
+        _add_missing_columns(conn)
+        conn.execute(text(CREATE_EXTERNAL_PRODUCT_ALIASES_INDEX_SQL))
+        conn.execute(text(CREATE_EXTERNAL_PRODUCT_ALIASES_CODE_INDEX_SQL))
+
+
+def _field(mapping: dict[str, Any], names: list[str]) -> str:
+    for name in names:
+        value = mapping.get(name)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return ""
+
+
+def _candidate_source_name(candidate: dict[str, Any]) -> str:
+    return _field(candidate, ["candidate_source_name", "source_name"]) or "external_product_index"
+
+
+def _candidate_source_code(candidate: dict[str, Any]) -> str:
+    return _field(candidate, ["candidate_source_product_code", "source_product_code", "retailer_article_number", "gtin", "ean", "code"])
+
+
+def _is_usable_source_code(value: str | None) -> bool:
+    normalized = str(value or "").strip().lower()
+    return bool(normalized) and normalized not in {"unknown", "onbekend", "-"}
+
+
+def _stem_set(value: str | None) -> set[str]:
+    stems: set[str] = set()
+    for token in normalize_alias_text(value).split():
+        if len(token) >= 4:
+            stems.add(token[:5])
+    return stems
+
+
+def _stem_overlap(left: str | None, right: str | None) -> float:
+    left_stems = _stem_set(left)
+    right_stems = _stem_set(right)
+    if not left_stems or not right_stems:
+        return 0.0
+    return len(left_stems & right_stems) / max(1, len(left_stems | right_stems))
+
+
+def _alias_candidate(row: dict[str, Any], receipt_line_text: str | None, fuzzy_score: float | None = None) -> dict[str, Any]:
+    confidence = float(row.get("confidence") or 0.0)
+    if fuzzy_score is not None:
+        confidence = min(confidence, max(MIN_ALIAS_CONFIDENCE, round(0.88 + fuzzy_score / 10, 3)))
+    score = round(max(MIN_ALIAS_CONFIDENCE, confidence), 3)
+    candidate_source_name = str(row.get("candidate_source_name") or ALIAS_SOURCE_NAME).strip()
+    candidate_source_product_code = str(row.get("candidate_source_product_code") or "").strip()
+    candidate = {
+        "candidate_name": str(row.get("candidate_name") or "").strip(),
+        "candidate_brand": str(row.get("candidate_brand") or "").strip(),
+        "candidate_source_name": ALIAS_SOURCE_NAME,
+        "candidate_source_product_code": candidate_source_product_code,
+        "source_name": ALIAS_SOURCE_NAME,
+        "source_product_code": candidate_source_product_code,
+        "retailer_article_number": candidate_source_product_code,
+        "quantity_label": str(row.get("quantity_label") or "").strip(),
+        "variant": "",
+        "source_url": str(row.get("source_url") or "").strip(),
+        "score": score,
+        "score_breakdown": {
+            "retailer_alias_learning": True,
+            "alias_source_name": candidate_source_name,
+            "alias_confidence": confidence,
+            "fuzzy_alias_score": fuzzy_score,
+        },
+        "candidate_status": "probable_candidate" if score >= 0.85 else "possible_candidate",
+        "is_probable": score >= 0.85,
+        "created_by": ALIAS_SOURCE_NAME,
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+    }
+    if receipt_line_text:
+        candidate["matched_receipt_line_text"] = str(receipt_line_text).strip()
+    return candidate
+
+
+def _existing_alias(conn, retailer_code: str, normalized_text: str, source_name: str, source_code: str) -> dict[str, Any] | None:
+    row = conn.execute(
+        text(
+            """
+            SELECT *
+            FROM external_product_aliases
+            WHERE retailer_code = :retailer_code
+              AND normalized_receipt_line_text = :normalized_text
+              AND candidate_source_name = :source_name
+              AND candidate_source_product_code = :source_code
+            LIMIT 1
+            """
+        ),
+        {
+            "retailer_code": retailer_code,
+            "normalized_text": normalized_text,
+            "source_name": source_name,
+            "source_code": source_code,
+        },
+    ).mappings().first()
+    return dict(row) if row else None
+
+
+def upsert_external_product_alias(
+    retailer_code: str | None,
+    receipt_line_text: str | None,
+    candidate: dict[str, Any],
+    learned_from: str,
+    confidence: float | None = None,
+) -> dict[str, Any]:
+    ensure_external_product_aliases_schema()
+    normalized_retailer = normalize_alias_text(retailer_code)
+    normalized_text = normalize_alias_text(receipt_line_text)
+    if not normalized_retailer or not normalized_text:
+        return {"ok": False, "reason": "missing_alias_context"}
+
+    source_name = _candidate_source_name(candidate)
+    source_code = _candidate_source_code(candidate)
+    if not _is_usable_source_code(source_code):
+        return {"ok": False, "reason": "missing_source_code"}
+
+    alias_confidence = float(confidence if confidence is not None else candidate.get("score") or 0.0)
+    if alias_confidence < MIN_ALIAS_CONFIDENCE:
+        return {"ok": False, "reason": "confidence_below_threshold", "confidence": alias_confidence}
+
+    timestamp = now_iso()
+    params = {
+        "retailer_code": normalized_retailer,
+        "normalized_receipt_line_text": normalized_text,
+        "raw_receipt_line_text": str(receipt_line_text or "").strip(),
+        "candidate_source_name": source_name,
+        "candidate_source_product_code": source_code,
+        "candidate_name": _field(candidate, ["candidate_name", "product_name", "name"]),
+        "candidate_brand": _field(candidate, ["candidate_brand", "brand"]),
+        "category": _field(candidate, ["category", "candidate_category"]),
+        "product_type": _field(candidate, ["product_type", "candidate_product_type"]),
+        "quantity_label": _field(candidate, ["quantity_label", "quantity"]),
+        "source_url": _field(candidate, ["source_url", "url"]),
+        "confidence": alias_confidence,
+        "learned_from": str(learned_from or "retailer_alias_learning").strip(),
+        "updated_at": timestamp,
+    }
+
+    with engine.begin() as conn:
+        existing = _existing_alias(conn, normalized_retailer, normalized_text, source_name, source_code)
+        if existing:
+            conn.execute(
+                text(
+                    """
+                    UPDATE external_product_aliases
+                    SET raw_receipt_line_text = :raw_receipt_line_text,
+                        candidate_name = :candidate_name,
+                        candidate_brand = :candidate_brand,
+                        category = :category,
+                        product_type = :product_type,
+                        quantity_label = :quantity_label,
+                        source_url = :source_url,
+                        confidence = CASE WHEN confidence >= :confidence THEN confidence ELSE :confidence END,
+                        learned_from = :learned_from,
+                        updated_at = :updated_at
+                    WHERE id = :id
+                    """
+                ),
+                {**params, "id": existing.get("id")},
+            )
+            return {"ok": True, "id": existing.get("id"), "updated": True, "created": False}
+
+        alias_id = str(uuid.uuid4())
+        conn.execute(
+            text(
+                """
+                INSERT INTO external_product_aliases (
+                    id,
+                    retailer_code,
+                    normalized_receipt_line_text,
+                    raw_receipt_line_text,
+                    candidate_source_name,
+                    candidate_source_product_code,
+                    candidate_name,
+                    candidate_brand,
+                    category,
+                    product_type,
+                    quantity_label,
+                    source_url,
+                    confidence,
+                    learned_from,
+                    created_at,
+                    updated_at
+                ) VALUES (
+                    :id,
+                    :retailer_code,
+                    :normalized_receipt_line_text,
+                    :raw_receipt_line_text,
+                    :candidate_source_name,
+                    :candidate_source_product_code,
+                    :candidate_name,
+                    :candidate_brand,
+                    :category,
+                    :product_type,
+                    :quantity_label,
+                    :source_url,
+                    :confidence,
+                    :learned_from,
+                    :created_at,
+                    :updated_at
+                )
+                """
+            ),
+            {**params, "id": alias_id, "created_at": timestamp},
+        )
+        return {"ok": True, "id": alias_id, "updated": False, "created": True}
+
+
+def save_alias_from_candidate(
+    retailer_code: str | None,
+    receipt_line_text: str | None,
+    candidate: dict[str, Any],
+    learned_from: str = "matchflow_evidence",
+    min_score: float = MIN_ALIAS_CONFIDENCE,
+) -> dict[str, Any]:
+    score = float(candidate.get("score") or 0.0)
+    if score < min_score:
+        return {"ok": False, "reason": "score_below_threshold", "score": score}
+    return upsert_external_product_alias(
+        retailer_code=retailer_code,
+        receipt_line_text=receipt_line_text,
+        candidate=candidate,
+        learned_from=learned_from,
+        confidence=score,
+    )
+
+
+def _catalog_rules() -> list[dict[str, Any]]:
+    path = Path(CATALOG_SEED_PATH)
+    if not path.exists():
+        return []
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return [dict(rule) for rule in (payload.get("rules") or [])]
+
+
+def ensure_catalog_aliases(retailer_code: str | None = "lidl") -> dict[str, Any]:
+    normalized_retailer = normalize_alias_text(retailer_code)
+    if normalized_retailer != "lidl":
+        return {"ok": True, "created_or_updated": 0, "reason": "unsupported_retailer"}
+
+    changed = 0
+    for rule in _catalog_rules():
+        source_code = str(rule.get("source_product_code") or "").strip()
+        if not _is_usable_source_code(source_code):
+            continue
+        candidate = {
+            "candidate_name": str(rule.get("catalog_product_name") or "").strip(),
+            "candidate_brand": str(rule.get("brand") or "").strip(),
+            "candidate_source_name": "lidl_catalog_enrichment",
+            "candidate_source_product_code": source_code,
+            "source_url": str(rule.get("source_url") or "").strip(),
+            "category": str(rule.get("category") or "").strip(),
+            "product_type": str(rule.get("product_type") or "").strip(),
+            "quantity_label": str(rule.get("quantity_label") or "").strip(),
+            "score": float(rule.get("confidence") or MIN_ALIAS_CONFIDENCE),
+        }
+        for term in rule.get("receipt_terms") or []:
+            result = upsert_external_product_alias(
+                retailer_code=normalized_retailer,
+                receipt_line_text=str(term or ""),
+                candidate=candidate,
+                learned_from="catalog_seed",
+                confidence=float(rule.get("confidence") or MIN_ALIAS_CONFIDENCE),
+            )
+            if result.get("ok"):
+                changed += 1
+    return {"ok": True, "created_or_updated": changed}
+
+
+def _exact_alias_rows(conn, retailer_code: str, normalized_text: str) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        text(
+            """
+            SELECT *
+            FROM external_product_aliases
+            WHERE retailer_code = :retailer_code
+              AND normalized_receipt_line_text = :normalized_text
+            ORDER BY confidence DESC, updated_at DESC
+            LIMIT 10
+            """
+        ),
+        {"retailer_code": retailer_code, "normalized_text": normalized_text},
+    ).mappings().all()
+    return [dict(row) for row in rows]
+
+
+def _fuzzy_alias_rows(conn, retailer_code: str, normalized_text: str) -> list[tuple[dict[str, Any], float]]:
+    rows = conn.execute(
+        text(
+            """
+            SELECT *
+            FROM external_product_aliases
+            WHERE retailer_code = :retailer_code
+              AND confidence >= :min_confidence
+            ORDER BY confidence DESC, updated_at DESC
+            LIMIT 200
+            """
+        ),
+        {"retailer_code": retailer_code, "min_confidence": MIN_ALIAS_CONFIDENCE},
+    ).mappings().all()
+    scored: list[tuple[dict[str, Any], float]] = []
+    for row in rows:
+        item = dict(row)
+        overlap = _stem_overlap(normalized_text, str(item.get("normalized_receipt_line_text") or ""))
+        if overlap >= 0.65:
+            scored.append((item, overlap))
+    scored.sort(key=lambda pair: (-pair[1], -float(pair[0].get("confidence") or 0.0)))
+    return scored[:5]
+
+
+def find_alias_candidates(retailer_code: str | None, receipt_line_text: str | None) -> list[dict[str, Any]]:
+    ensure_external_product_aliases_schema()
+    normalized_retailer = normalize_alias_text(retailer_code)
+    normalized_text = normalize_alias_text(receipt_line_text)
+    if not normalized_retailer or not normalized_text:
+        return []
+
+    ensure_catalog_aliases(normalized_retailer)
+
+    with engine.begin() as conn:
+        exact_rows = _exact_alias_rows(conn, normalized_retailer, normalized_text)
+        if exact_rows:
+            return [_alias_candidate(row, receipt_line_text) for row in exact_rows]
+
+        fuzzy_rows = _fuzzy_alias_rows(conn, normalized_retailer, normalized_text)
+        return [_alias_candidate(row, receipt_line_text, fuzzy_score=score) for row, score in fuzzy_rows]

--- a/backend/app/services/lidl_local_catalog_index.py
+++ b/backend/app/services/lidl_local_catalog_index.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import difflib
+import json
+import re
+import uuid
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db import engine
+from app.services.product_taxonomy_store import normalize_taxonomy_text
+
+LIDL_CATALOG_INDEX_SOURCE = "lidl_catalog_index"
+LIDL_CATALOG_INDEX_SEED_PATH = Path(__file__).resolve().parents[1] / "data" / "lidl_catalog_enrichment_seed.json"
+
+CREATE_EXTERNAL_PRODUCT_INDEX_SQL = """
+CREATE TABLE IF NOT EXISTS external_product_index (
+    id TEXT PRIMARY KEY,
+    source_name TEXT NOT NULL,
+    source_product_code TEXT NOT NULL,
+    retailer_code TEXT,
+    gtin TEXT,
+    product_name TEXT NOT NULL,
+    brand TEXT,
+    category TEXT,
+    product_type TEXT,
+    quantity_label TEXT,
+    search_terms TEXT,
+    source_url TEXT,
+    confidence_base REAL,
+    raw_payload_json TEXT,
+    created_at TEXT,
+    updated_at TEXT
+)
+"""
+
+EXTERNAL_PRODUCT_INDEX_COLUMNS: dict[str, str] = {
+    "id": "TEXT PRIMARY KEY",
+    "source_name": "TEXT NOT NULL DEFAULT ''",
+    "source_product_code": "TEXT NOT NULL DEFAULT ''",
+    "retailer_code": "TEXT",
+    "gtin": "TEXT",
+    "product_name": "TEXT NOT NULL DEFAULT ''",
+    "brand": "TEXT",
+    "category": "TEXT",
+    "product_type": "TEXT",
+    "quantity_label": "TEXT",
+    "search_terms": "TEXT",
+    "source_url": "TEXT",
+    "confidence_base": "REAL",
+    "raw_payload_json": "TEXT",
+    "created_at": "TEXT",
+    "updated_at": "TEXT",
+}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _sqlite_columns(conn) -> set[str]:
+    rows = conn.execute(text("PRAGMA table_info(external_product_index)")).mappings().all()
+    return {str(row.get("name") or "") for row in rows}
+
+
+def _postgres_columns(conn) -> set[str]:
+    rows = conn.execute(
+        text(
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_name = 'external_product_index'
+            """
+        )
+    ).mappings().all()
+    return {str(row.get("column_name") or "") for row in rows}
+
+
+def _ensure_columns(conn) -> None:
+    dialect_name = str(conn.engine.dialect.name or "").lower()
+    existing_columns = _sqlite_columns(conn) if dialect_name == "sqlite" else _postgres_columns(conn)
+    for column_name, column_definition in EXTERNAL_PRODUCT_INDEX_COLUMNS.items():
+        if column_name in existing_columns or column_name == "id":
+            continue
+        conn.execute(text(f"ALTER TABLE external_product_index ADD COLUMN {column_name} {column_definition}"))
+
+
+def ensure_external_product_index_schema() -> None:
+    with engine.begin() as conn:
+        conn.execute(text(CREATE_EXTERNAL_PRODUCT_INDEX_SQL))
+        _ensure_columns(conn)
+        conn.execute(
+            text(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_external_product_index_source_code
+                ON external_product_index (source_name, source_product_code)
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE INDEX IF NOT EXISTS idx_external_product_index_retailer_source
+                ON external_product_index (retailer_code, source_name)
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE INDEX IF NOT EXISTS idx_external_product_index_product_name
+                ON external_product_index (product_name)
+                """
+            )
+        )
+
+
+@lru_cache(maxsize=1)
+def _load_lidl_catalog_seed_rules() -> tuple[dict[str, Any], ...]:
+    if not LIDL_CATALOG_INDEX_SEED_PATH.exists():
+        return tuple()
+    payload = json.loads(LIDL_CATALOG_INDEX_SEED_PATH.read_text(encoding="utf-8"))
+    return tuple(dict(rule) for rule in (payload.get("rules") or []))
+
+
+def _dedupe_terms(values: list[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = normalize_taxonomy_text(value)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
+def _catalog_index_record(rule: dict[str, Any]) -> dict[str, Any]:
+    source_product_code = str(rule.get("source_product_code") or "").strip()
+    product_name = str(rule.get("catalog_product_name") or "").strip()
+    record_id = f"{LIDL_CATALOG_INDEX_SOURCE}:{source_product_code or uuid.uuid4()}"
+    search_terms = _dedupe_terms([
+        product_name,
+        str(rule.get("brand") or ""),
+        str(rule.get("category") or ""),
+        str(rule.get("product_type") or ""),
+        str(rule.get("quantity_label") or ""),
+        *(rule.get("receipt_terms") or []),
+        *(rule.get("search_terms") or []),
+    ])
+    return {
+        "id": record_id,
+        "source_name": LIDL_CATALOG_INDEX_SOURCE,
+        "source_product_code": source_product_code,
+        "retailer_code": "lidl",
+        "gtin": "",
+        "product_name": product_name,
+        "brand": str(rule.get("brand") or "").strip(),
+        "category": str(rule.get("category") or "").strip(),
+        "product_type": str(rule.get("product_type") or "").strip(),
+        "quantity_label": str(rule.get("quantity_label") or "").strip(),
+        "search_terms": " ".join(search_terms),
+        "source_url": str(rule.get("source_url") or "").strip(),
+        "confidence_base": float(rule.get("confidence") or 0.0),
+        "raw_payload_json": json.dumps(rule, ensure_ascii=False, sort_keys=True),
+    }
+
+
+def ensure_lidl_local_catalog_index() -> dict[str, Any]:
+    """Load the local Lidl catalog seed into external_product_index.
+
+    This keeps product knowledge in data/import form. It does not create global products,
+    household articles, or inventory events.
+    """
+    ensure_external_product_index_schema()
+    rules = _load_lidl_catalog_seed_rules()
+    timestamp = _now_iso()
+    written = 0
+
+    with engine.begin() as conn:
+        for rule in rules:
+            record = _catalog_index_record(rule)
+            if not record["source_product_code"] or not record["product_name"]:
+                continue
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO external_product_index (
+                        id, source_name, source_product_code, retailer_code, gtin,
+                        product_name, brand, category, product_type, quantity_label,
+                        search_terms, source_url, confidence_base, raw_payload_json,
+                        created_at, updated_at
+                    ) VALUES (
+                        :id, :source_name, :source_product_code, :retailer_code, :gtin,
+                        :product_name, :brand, :category, :product_type, :quantity_label,
+                        :search_terms, :source_url, :confidence_base, :raw_payload_json,
+                        :created_at, :updated_at
+                    )
+                    ON CONFLICT(source_name, source_product_code)
+                    DO UPDATE SET
+                        retailer_code = excluded.retailer_code,
+                        gtin = excluded.gtin,
+                        product_name = excluded.product_name,
+                        brand = excluded.brand,
+                        category = excluded.category,
+                        product_type = excluded.product_type,
+                        quantity_label = excluded.quantity_label,
+                        search_terms = excluded.search_terms,
+                        source_url = excluded.source_url,
+                        confidence_base = excluded.confidence_base,
+                        raw_payload_json = excluded.raw_payload_json,
+                        updated_at = excluded.updated_at
+                    """
+                ),
+                {**record, "created_at": timestamp, "updated_at": timestamp},
+            )
+            written += 1
+
+    return {
+        "ok": True,
+        "source_name": LIDL_CATALOG_INDEX_SOURCE,
+        "loaded_count": written,
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+    }
+
+
+def _normalize(value: str | None) -> str:
+    normalized = normalize_taxonomy_text(value)
+    normalized = re.sub(r"[^a-z0-9áéíóúàèìòùäëïöüçñ\s-]+", " ", normalized, flags=re.IGNORECASE)
+    return " ".join(normalized.split())
+
+
+def _text_similarity(left: str, right: str) -> float:
+    left_normalized = _normalize(left)
+    right_normalized = _normalize(right)
+    if not left_normalized or not right_normalized:
+        return 0.0
+    if left_normalized == right_normalized:
+        return 1.0
+    if left_normalized in right_normalized or right_normalized in left_normalized:
+        return 0.92
+    return difflib.SequenceMatcher(None, left_normalized, right_normalized).ratio()
+
+
+def _token_overlap(left: str, right: str) -> float:
+    left_tokens = {token for token in _normalize(left).split() if len(token) >= 3}
+    right_tokens = {token for token in _normalize(right).split() if len(token) >= 3}
+    if not left_tokens or not right_tokens:
+        return 0.0
+    return len(left_tokens & right_tokens) / max(1, len(left_tokens | right_tokens))
+
+
+def _score_catalog_row(receipt_line_text: str, row: dict[str, Any]) -> dict[str, Any]:
+    product_name = str(row.get("product_name") or "").strip()
+    brand = str(row.get("brand") or "").strip()
+    category = str(row.get("category") or "").strip()
+    product_type = str(row.get("product_type") or "").strip()
+    quantity_label = str(row.get("quantity_label") or "").strip()
+    search_terms = str(row.get("search_terms") or "").strip()
+    source_product_code = str(row.get("source_product_code") or "").strip()
+    confidence_base = float(row.get("confidence_base") or 0.0)
+
+    text_score = max(
+        _text_similarity(receipt_line_text, product_name),
+        _token_overlap(receipt_line_text, product_name),
+        _token_overlap(receipt_line_text, search_terms),
+    )
+    brand_score = 1.0 if brand and _normalize(brand) in _normalize(receipt_line_text) else (0.70 if brand else 0.45)
+    product_type_score = max(_text_similarity(receipt_line_text, product_type), _token_overlap(receipt_line_text, category))
+    quantity_score = 0.80 if quantity_label else 0.50
+    source_score = max(0.80, min(confidence_base, 0.96))
+    variant_score = max(0.70, _token_overlap(receipt_line_text, category))
+
+    breakdown = {
+        "text_score": round(text_score, 3),
+        "brand_score": round(brand_score, 3),
+        "product_type_score": round(product_type_score, 3),
+        "quantity_score": round(quantity_score, 3),
+        "variant_score": round(variant_score, 3),
+        "source_score": round(source_score, 3),
+    }
+    score = round(
+        breakdown["text_score"] * 0.30
+        + breakdown["brand_score"] * 0.20
+        + breakdown["product_type_score"] * 0.20
+        + breakdown["quantity_score"] * 0.10
+        + breakdown["variant_score"] * 0.10
+        + breakdown["source_score"] * 0.10,
+        3,
+    )
+    candidate_status = "probable_candidate" if score >= 0.85 else "possible_candidate" if score >= 0.70 else "weak_candidate"
+    return {
+        "candidate_name": product_name or source_product_code or "Onbekend Lidl-catalogusproduct",
+        "candidate_brand": brand,
+        "candidate_source_name": LIDL_CATALOG_INDEX_SOURCE,
+        "candidate_source_product_code": source_product_code or "unknown",
+        "source_name": LIDL_CATALOG_INDEX_SOURCE,
+        "source_product_code": source_product_code or "unknown",
+        "retailer_article_number": source_product_code or "",
+        "quantity_label": quantity_label,
+        "variant": product_type or category,
+        "source_url": str(row.get("source_url") or "").strip(),
+        "score": score,
+        "score_breakdown": breakdown,
+        "candidate_status": candidate_status,
+        "is_probable": score >= 0.85,
+        "is_user_confirmed": False,
+        "is_external_database_override": False,
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+        "created_by": "m2c2i21_lidl_local_catalog_index",
+    }
+
+
+def search_lidl_local_catalog_candidates(receipt_line_text: str, limit: int = 5) -> list[dict[str, Any]]:
+    ensure_lidl_local_catalog_index()
+    normalized = _normalize(receipt_line_text)
+    tokens = [token for token in normalized.split() if len(token) >= 3]
+    if not tokens:
+        return []
+
+    params: dict[str, Any] = {"source_name": LIDL_CATALOG_INDEX_SOURCE, "retailer_code": "lidl", "limit": 80}
+    where_parts: list[str] = []
+    search_expr = """
+        lower(COALESCE(product_name, '') || ' ' ||
+              COALESCE(brand, '') || ' ' ||
+              COALESCE(category, '') || ' ' ||
+              COALESCE(product_type, '') || ' ' ||
+              COALESCE(quantity_label, '') || ' ' ||
+              COALESCE(search_terms, '') || ' ' ||
+              COALESCE(source_product_code, ''))
+    """
+    for index, token in enumerate(tokens[:8]):
+        key = f"token_{index}"
+        where_parts.append(f"{search_expr} LIKE :{key}")
+        params[key] = f"%{token}%"
+
+    with engine.begin() as conn:
+        rows = conn.execute(
+            text(
+                f"""
+                SELECT *
+                FROM external_product_index
+                WHERE source_name = :source_name
+                  AND retailer_code = :retailer_code
+                  AND ({' OR '.join(where_parts)})
+                LIMIT :limit
+                """
+            ),
+            params,
+        ).mappings().all()
+
+    scored = [_score_catalog_row(receipt_line_text, dict(row)) for row in rows]
+    scored.sort(key=lambda item: (-float(item.get("score") or 0.0), str(item.get("candidate_name") or "")))
+    return scored[: max(1, min(int(limit or 5), 5))]

--- a/backend/tests/test_m2c2i17_retailer_alias_learning.py
+++ b/backend/tests/test_m2c2i17_retailer_alias_learning.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+import uuid
+
+from app.services.external_database_matchflow_evidence import match_retailer_receipt_line
+from app.services.external_product_alias_store import find_alias_candidates, save_alias_from_candidate
+from app.services.product_evidence_packet import build_product_evidence_packet_dict
+from app.services.retailer_catalog_enrichment import CATALOG_SEED_PATH
+
+
+def _first_catalog_rule() -> dict:
+    payload = json.loads(CATALOG_SEED_PATH.read_text(encoding="utf-8"))
+    return dict((payload.get("rules") or [])[0])
+
+
+def test_m2c2i17_catalog_seed_is_packaged_and_matchable() -> None:
+    rule = _first_catalog_rule()
+    receipt_term = str((rule.get("receipt_terms") or [])[0])
+    expected_code = str(rule.get("source_product_code") or "")
+
+    evidence = build_product_evidence_packet_dict(receipt_term, "lidl")
+
+    assert evidence["matched"] is True
+    assert evidence["retailer_article_code"] == expected_code
+    assert evidence["creates_global_product"] is False
+    assert evidence["creates_household_article"] is False
+    assert evidence["creates_inventory_event"] is False
+
+
+def test_m2c2i17_alias_is_learned_and_reused_for_new_receipt_text() -> None:
+    rule = _first_catalog_rule()
+    receipt_term = str((rule.get("receipt_terms") or [])[0])
+    expected_code = str(rule.get("source_product_code") or "")
+
+    initial_result = match_retailer_receipt_line("lidl", receipt_term, True)
+    initial_candidate = initial_result["candidates"][0]
+    alias_text = f"alias-probe-{uuid.uuid4().hex[:12]}"
+
+    saved = save_alias_from_candidate("lidl", alias_text, initial_candidate, learned_from="test_alias_learning")
+    assert saved["ok"] is True
+
+    alias_candidates = find_alias_candidates("lidl", alias_text)
+    assert alias_candidates
+    assert alias_candidates[0]["candidate_source_product_code"] == expected_code
+    assert alias_candidates[0]["creates_global_product"] is False
+    assert alias_candidates[0]["creates_household_article"] is False
+    assert alias_candidates[0]["creates_inventory_event"] is False
+
+    learned_result = match_retailer_receipt_line("lidl", alias_text, True)
+    learned_candidate = learned_result["candidates"][0]
+
+    assert learned_candidate["candidate_source_product_code"] == expected_code
+    assert learned_candidate["score"] >= 0.90
+    assert learned_result["creates_global_product"] is False
+    assert learned_result["creates_household_article"] is False
+    assert learned_result["creates_inventory_event"] is False

--- a/backend/tests/test_m2c2i20_external_resolved_state.py
+++ b/backend/tests/test_m2c2i20_external_resolved_state.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from app.services import external_database_matchflow_evidence as matchflow
+
+
+def test_m2c2i20_item_with_external_product_code_is_resolved() -> None:
+    item = {
+        "is_receipt_item_placeholder": True,
+        "purchase_import_line_id": "pil-1",
+        "receipt_line_text": "Veldsla",
+        "retailer_code": "lidl",
+        "retailer_article_number": "lidl:groente.veldsla",
+    }
+
+    assert matchflow.is_m2c2i20_external_resolved_item(item) is True
+    assert matchflow.m2c2i20_external_product_code(item) == "lidl:groente.veldsla"
+
+
+def test_m2c2i20_item_without_external_product_code_is_not_resolved() -> None:
+    item = {
+        "is_receipt_item_placeholder": True,
+        "purchase_import_line_id": "pil-2",
+        "receipt_line_text": "Onbekend artikel",
+        "retailer_code": "lidl",
+        "candidate_status": "no_candidate",
+    }
+
+    assert matchflow.is_m2c2i20_external_resolved_item(item) is False
+    assert matchflow.m2c2i20_external_product_code(item) == ""
+
+
+def test_m2c2i20_ensure_skips_resolved_items(monkeypatch) -> None:
+    captured = {}
+
+    def fake_ensure_external_receipt_item_candidates(*args, **kwargs):
+        items = kwargs.get("items") if "items" in kwargs else (args[0] if args else [])
+        captured["items"] = list(items or [])
+        return {
+            "ok": True,
+            "total": len(items or []),
+            "processed": len(items or []),
+            "saved_count": 0,
+            "updated_count": 0,
+            "skipped_count": 0,
+            "errors": [],
+            "creates_global_product": False,
+            "creates_household_article": False,
+            "creates_inventory_event": False,
+        }
+
+    monkeypatch.setattr(
+        matchflow.candidate_store,
+        "ensure_external_receipt_item_candidates",
+        fake_ensure_external_receipt_item_candidates,
+    )
+
+    resolved_item = {
+        "is_receipt_item_placeholder": True,
+        "purchase_import_line_id": "pil-1",
+        "receipt_line_text": "Veldsla",
+        "retailer_code": "lidl",
+        "retailer_article_number": "lidl:groente.veldsla",
+    }
+    unresolved_item = {
+        "is_receipt_item_placeholder": True,
+        "purchase_import_line_id": "pil-2",
+        "receipt_line_text": "Nieuw onbekend artikel",
+        "retailer_code": "lidl",
+    }
+
+    result = matchflow.ensure_external_receipt_item_candidates(
+        items=[resolved_item, unresolved_item],
+        include_below_threshold=True,
+    )
+
+    assert captured["items"] == [unresolved_item]
+    assert result["total"] == 2
+    assert result["processed"] == 1
+    assert result["external_resolved_skipped_count"] == 1
+    assert result["external_resolved_skipped"][0]["external_product_code"] == "lidl:groente.veldsla"
+    assert result["m2c2i20_resolved_state_gate"] is True
+    assert result["creates_global_product"] is False
+    assert result["creates_household_article"] is False
+    assert result["creates_inventory_event"] is False

--- a/docs/architecture/M2C2i17_retailer_alias_learning.md
+++ b/docs/architecture/M2C2i17_retailer_alias_learning.md
@@ -1,0 +1,28 @@
+# M2C2i-17 — Dynamische retailer-aliaslearning
+
+## Doel
+
+Nieuwe bontekstvarianten moeten dezelfde externe productkandidaat kunnen krijgen als een eerder betrouwbaar herkende bonregel, zonder dat productkennis in Python-code wordt vastgelegd.
+
+## Besluit
+
+Rezzerv leert alleen externe kandidaat-herkenning:
+
+- geen `global_products` aanmaken
+- geen huishoudartikel aanmaken
+- geen voorraadmutatie aanmaken
+
+## Implementatie
+
+- Nieuwe tabel: `external_product_aliases`
+- Nieuwe service: `backend/app/services/external_product_alias_store.py`
+- Matchflow gebruikt aliaskandidaten naast de bestaande index-, catalogus- en taxonomy-kandidaten.
+- Bij score >= 0.90 en een bruikbare externe code wordt de bontekst als alias opgeslagen.
+- Canonieke seedregels worden als aliasbasis ingelezen vanuit `lidl_catalog_enrichment_seed.json`.
+
+## Acceptatie
+
+- Een betrouwbare match wordt als alias opgeslagen.
+- Een latere bontekstvariant kan via de aliaslaag opnieuw dezelfde kandidaat tonen.
+- Safety flags blijven false.
+- Productkennis blijft in JSON/data of database, niet in Python-code.

--- a/docs/architecture/M2C2i20_external_resolved_state.md
+++ b/docs/architecture/M2C2i20_external_resolved_state.md
@@ -1,0 +1,67 @@
+# M2C2i-20 — Externe artikelcode als resolved-state op bonregels
+
+## Doel
+
+Een bonregel die al een externe artikelcode heeft, is voor de externe-databaseflow klaar. Rezzerv zoekt dan niet opnieuw op bontekst naar externe productkandidaten.
+
+```text
+bonregel met externe artikelcode
+→ external_match_status = resolved / external_resolved
+→ geen kandidaatzoekactie
+→ productinformatie komt voortaan via externe artikelcode
+```
+
+## Functionele regel
+
+Als een bonartikel een bruikbare externe artikelcode heeft, dan wordt het artikel beschouwd als resolved voor externe productherkenning.
+
+Voorbeelden van velden die als externe code kunnen tellen:
+
+- `external_product_code`
+- `external_source_product_code`
+- `external_product_index_id`
+- `external_article_code`
+- `retailer_article_number`
+- `gtin`
+- `ean`
+
+## Gedrag
+
+### Niet-resolved bonregel
+
+```text
+bonregel zonder externe code
+→ zoek kandidaten via seed / alias / matchflow
+→ bewaar kandidaatregels
+```
+
+### Resolved bonregel
+
+```text
+bonregel met externe code
+→ sla kandidaatzoekactie over
+→ geef expliciet terug dat deze regel is overgeslagen wegens resolved-state
+```
+
+## Veiligheidsgrenzen
+
+M2C2i-20 maakt nog steeds geen definitieve gebruikersartikelen of voorraadmutaties.
+
+```text
+creates_global_product = false
+creates_household_article = false
+creates_inventory_event = false
+```
+
+## Relatie met PR #95 en PR #96
+
+- PR #95 aliaslearning helpt om onbekende bontekst naar een externe code te brengen.
+- PR #96 Lidl-catalogusdekking geeft bekende Lidl-artikelen meer externe codes.
+- M2C2i-20 borgt dat een artikel na het verkrijgen van die externe code niet opnieuw door de zoekflow gaat.
+
+## Buiten scope
+
+- Geen bonregeltypes zoals verzendkosten, statiegeld of zegels.
+- Geen brede Lidl-catalogusimport.
+- Geen automatische Mijn-artikel-aanmaak.
+- Geen voorraadmutatie.

--- a/docs/architecture/M2C2i21_lidl_local_catalog_index.md
+++ b/docs/architecture/M2C2i21_lidl_local_catalog_index.md
@@ -1,0 +1,58 @@
+# M2C2i-21 — Lokale Lidl-catalogusindex voor onbekende bonartikelen
+
+## Doel
+
+Rezzerv kan bij een onbekende Lidl-bonregel zoeken in een lokale catalogusindex en maximaal 5 externe productkandidaten tonen, zonder codewijziging per nieuw artikel.
+
+```text
+onbekende Lidl-bonregel
+→ lokale Lidl-catalogusindex
+→ externe productkandidaten
+→ gebruiker bevestigt eventueel later
+→ pas daarna resolved / aliaslearning
+```
+
+## Architectuurgrens
+
+```text
+external_product_index ≠ global_products ≠ Mijn artikel
+```
+
+De catalogusindex is een externe kennisbron. M2C2i-21 maakt geen huishoudartikelen en doet geen voorraadmutaties.
+
+```text
+creates_global_product = false
+creates_household_article = false
+creates_inventory_event = false
+```
+
+## Datalaag
+
+M2C2i-21 introduceert een loader voor `external_product_index` op basis van bestaande Lidl-catalogusdata:
+
+- bronbestand: `backend/app/data/lidl_catalog_enrichment_seed.json`
+- indexbron: `source_name = lidl_catalog_index`
+- sleutel: `source_product_code`
+- velden: productnaam, merk, categorie, producttype, hoeveelheid, zoektermen en bron-url
+
+Productkennis blijft daarmee in data/importvorm en niet in productie-Python.
+
+## Matchflow
+
+De bestaande flow blijft leidend:
+
+1. resolved bonregels worden overgeslagen;
+2. alias candidates worden opgehaald;
+3. Lidl-catalogusindex levert lokale kandidaten;
+4. bestaande base/fallback candidates blijven beschikbaar;
+5. kandidaten worden genormaliseerd, gescoord en gededuped;
+6. maximaal 5 kandidaten worden teruggegeven.
+
+## Buiten scope
+
+- Geen live Lidl-scraping.
+- Geen Open Food Facts-live afhankelijkheid.
+- Geen bonregeltypeclassificatie.
+- Geen Mijn-artikel-aanmaak.
+- Geen voorraadmutatie.
+- Geen definitieve productkoppeling zonder vervolgactie.

--- a/docs/architecture/M2C2i22_confirm_external_candidate.md
+++ b/docs/architecture/M2C2i22_confirm_external_candidate.md
@@ -1,0 +1,45 @@
+# M2C2i-22 — Externe kandidaat bevestigen op bonregel
+
+## Doel
+
+Een gebruiker kan een externe kandidaat bevestigen op een bonregel/importregel. Rezzerv legt dan alleen de externe bron en artikelcode vast op de bonregel. Daarna is de bonregel extern resolved en voorkomt M2C2i-20 dat dezelfde regel opnieuw door de kandidaatzoekflow gaat.
+
+```text
+kandidaat gevonden
+→ gebruiker bevestigt kandidaat
+→ externe artikelcode wordt op bonregel/importregel vastgelegd
+→ bonregel is external_resolved
+→ kandidaatzoeken wordt bij volgende refresh overgeslagen
+```
+
+## Domeingrens
+
+```text
+external_product_index ≠ global_products ≠ Mijn artikel
+```
+
+M2C2i-22 maakt bewust geen catalogusproduct, geen huishoudartikel en geen voorraadmutatie.
+
+```text
+creates_global_product = false
+creates_household_article = false
+creates_inventory_event = false
+```
+
+## Mutaties
+
+De bevestiging mag alleen deze mutaties uitvoeren:
+
+1. geselecteerde candidate markeren als `user_confirmed` / `external_resolved`;
+2. andere candidates binnen dezelfde context terugzetten naar gewone candidate-status;
+3. externe artikelcode en bron vastleggen op `purchase_import_lines` of `receipt_lines`, voor zover de kolommen bestaan;
+4. safety flags expliciet `false` teruggeven.
+
+## Buiten scope
+
+- Geen `global_products` aanmaken.
+- Geen `product_identities` aanmaken.
+- Geen Mijn-artikel aanmaken.
+- Geen voorraadmutatie.
+- Geen bonregeltypeclassificatie.
+- Geen automatische productkoppeling buiten de externe artikelcode.

--- a/docs/architecture/M2C2i23_confirmed_external_candidate_ui.md
+++ b/docs/architecture/M2C2i23_confirmed_external_candidate_ui.md
@@ -1,16 +1,22 @@
-# M2C2i-23 — Bevestigde externe kandidaat zichtbaar maken in UI-flow
+# M2C2i-23 — Bevestigde herkenning zichtbaar maken in UI-flow
 
 ## Doel
 
-De Externe databases-UI laat zichtbaar zien wanneer een bonartikel extern is bevestigd, zonder dat dit wordt gepresenteerd als cataloguskoppeling of Mijn artikel.
+De Externe databases-UI laat zichtbaar zien wanneer een bonartikel is herkend aan de hand van een winkel-/broncode, zonder dat dit wordt gepresenteerd als cataloguskoppeling of Mijn artikel.
 
 ```text
-candidate gevonden
-→ gebruiker bevestigt externe kandidaat
-→ bonregel krijgt externe artikelcode
-→ status wordt Extern bevestigd
-→ refresh/ensure slaat resolved regels over
+herkenningskandidaat gevonden
+→ gebruiker bevestigt herkenning
+→ bonregel krijgt winkel-/broncode
+→ status wordt Herkenning bevestigd
+→ refresh/ensure slaat bevestigde herkenningen over
 ```
+
+## Begrippen
+
+- `Winkel-/broncode`: de externe code van de winkelketen of externe bron, bijvoorbeeld `lidl:groente.veldsla` of `LIDL-00008`.
+- `Herkenning bevestigd`: de gebruiker zegt dat de bonregel overeenkomt met die winkel-/broncode.
+- Dit is nog geen Rezzerv-artikel, geen Mijn artikel en geen voorraadmutatie.
 
 ## Domeingrens
 
@@ -18,7 +24,7 @@ candidate gevonden
 external_product_index ≠ global_products ≠ Mijn artikel
 ```
 
-M2C2i-23 gebruikt de M2C2i-22 confirm-flow. Die legt alleen externe bron en artikelcode vast.
+M2C2i-23 gebruikt de M2C2i-22 confirm-flow. Die legt alleen bron en winkel-/broncode vast.
 
 ```text
 creates_global_product = false
@@ -29,12 +35,12 @@ creates_inventory_event = false
 ## UI-aanpassingen
 
 - Nieuwe overzichtscomponent `ReceiptItemsOverviewResolved.jsx`.
-- Bonartikelen tonen nu expliciet status `Extern bevestigd`.
-- Externe artikelcode blijft zichtbaar in de tabel.
-- Detailkandidaten tonen bron, externe code en status.
-- Actieknop heet `Bevestig externe kandidaat`.
+- Bonartikelen tonen status `Herkenning bevestigd`.
+- Winkel-/broncode blijft zichtbaar in de tabel.
+- Detailkandidaten tonen bron, winkel-/broncode en status.
+- Actieknop heet `Bevestig herkenning`.
 - Bevestigen gebruikt endpoint `/api/external-databases/candidates/confirm-external`.
-- Bij kandidaten bijlezen stuurt de UI bestaande externe artikelcode/status mee, zodat M2C2i-20 resolved regels kan overslaan.
+- Bij kandidaten bijlezen stuurt de UI bestaande winkel-/broncode/status mee, zodat M2C2i-20 bevestigde herkenningen kan overslaan.
 
 ## Backend-aanpassing
 

--- a/docs/architecture/M2C2i23_confirmed_external_candidate_ui.md
+++ b/docs/architecture/M2C2i23_confirmed_external_candidate_ui.md
@@ -1,0 +1,60 @@
+# M2C2i-23 — Bevestigde externe kandidaat zichtbaar maken in UI-flow
+
+## Doel
+
+De Externe databases-UI laat zichtbaar zien wanneer een bonartikel extern is bevestigd, zonder dat dit wordt gepresenteerd als cataloguskoppeling of Mijn artikel.
+
+```text
+candidate gevonden
+→ gebruiker bevestigt externe kandidaat
+→ bonregel krijgt externe artikelcode
+→ status wordt Extern bevestigd
+→ refresh/ensure slaat resolved regels over
+```
+
+## Domeingrens
+
+```text
+external_product_index ≠ global_products ≠ Mijn artikel
+```
+
+M2C2i-23 gebruikt de M2C2i-22 confirm-flow. Die legt alleen externe bron en artikelcode vast.
+
+```text
+creates_global_product = false
+creates_household_article = false
+creates_inventory_event = false
+```
+
+## UI-aanpassingen
+
+- Nieuwe overzichtscomponent `ReceiptItemsOverviewResolved.jsx`.
+- Bonartikelen tonen nu expliciet status `Extern bevestigd`.
+- Externe artikelcode blijft zichtbaar in de tabel.
+- Detailkandidaten tonen bron, externe code en status.
+- Actieknop heet `Bevestig externe kandidaat`.
+- Bevestigen gebruikt endpoint `/api/external-databases/candidates/confirm-external`.
+- Bij kandidaten bijlezen stuurt de UI bestaande externe artikelcode/status mee, zodat M2C2i-20 resolved regels kan overslaan.
+
+## Backend-aanpassing
+
+Nieuw endpoint in `system_routes.py`:
+
+```text
+POST /api/external-databases/candidates/confirm-external
+```
+
+Dit endpoint gebruikt:
+
+```text
+confirm_external_candidate_for_receipt_item(candidate_id, force_overwrite=False)
+```
+
+## Buiten scope
+
+- Geen automatische cataloguskoppeling.
+- Geen `global_products`-aanmaak.
+- Geen `product_identities`-aanmaak.
+- Geen Mijn-artikel-aanmaak.
+- Geen voorraadmutatie.
+- Geen bonregeltypeclassificatie.

--- a/docs/release/M2C2i17_change_summary.md
+++ b/docs/release/M2C2i17_change_summary.md
@@ -1,0 +1,19 @@
+# M2C2i-17 change summary
+
+## Gewijzigd
+
+- Nieuwe aliasstore voor externe productkandidaten.
+- Matchflow voegt aliaskandidaten toe aan bestaande kandidaatset.
+- Betrouwbare topkandidaat kan bontekst als alias opslaan.
+- Aliasbron krijgt prioriteit onder catalogusbron en boven generieke bronnen.
+- Tests toegevoegd voor seedcontract en aliashergebruik.
+
+## Niet gewijzigd
+
+- Geen voorraadverwerking.
+- Geen definitieve productkoppeling.
+- Geen UI-layout.
+
+## QA-status
+
+Nog niet lokaal gevalideerd in Docker. PR mag pas worden gemerged na lokale backend-smoke en UI-check.

--- a/docs/release/M2C2i17_known_limitations.md
+++ b/docs/release/M2C2i17_known_limitations.md
@@ -1,0 +1,6 @@
+# M2C2i-17 bekende beperkingen
+
+- De PR is via GitHub voorbereid en niet lokaal in Docker gevalideerd.
+- De aliaslaag gebruikt een nieuwe runtime-tabel; databasevalidatie is verplicht.
+- Fuzzy aliasherkenning is conservatief en bedoeld als hulpmiddel, niet als definitieve productkoppeling.
+- Kandidaten blijven externe kandidaten; de gebruiker moet nog steeds expliciet bevestigen.

--- a/docs/release/M2C2i17_merge_policy.md
+++ b/docs/release/M2C2i17_merge_policy.md
@@ -1,0 +1,11 @@
+# M2C2i-17 mergebeleid
+
+Deze PR mag pas worden gemerged nadat lokaal is bevestigd:
+
+1. Docker backend build slaagt.
+2. `/api/health` is ok.
+3. Seedcontract werkt.
+4. Aliaslearning werkt.
+5. UI-route `Externe databases` toont geen regressie.
+
+Geen lokale validatie betekent: niet mergen.

--- a/docs/release/M2C2i17_no_product_names_note.md
+++ b/docs/release/M2C2i17_no_product_names_note.md
@@ -1,0 +1,7 @@
+# M2C2i-17 no product names in Python
+
+Deze PR houdt productkennis buiten Python-code.
+
+De test leest de benodigde receipt terms en productcodes dynamisch uit `lidl_catalog_enrichment_seed.json`.
+
+Daarmee wordt getest op gedrag en configuratiecontract, zonder productnamen als Python-literals toe te voegen.

--- a/docs/release/M2C2i17_po_test.md
+++ b/docs/release/M2C2i17_po_test.md
@@ -1,0 +1,18 @@
+# M2C2i-17 PO-test
+
+## Doel
+
+Controleren dat Rezzerv geleerde Lidl-bonvarianten opnieuw als externe kandidaat toont.
+
+## Teststappen
+
+1. Start de app lokaal.
+2. Open `Externe databases`.
+3. Controleer bestaande Lidl-kandidaten.
+4. Controleer dat kandidaatregels geen automatische voorraad- of artikelmutatie veroorzaken.
+
+## Verwacht gedrag
+
+- Bekende Lidl-regels tonen een kandidaat met externe code.
+- Nieuwe of afwijkende bontekstvarianten kunnen via de aliaslaag opnieuw dezelfde kandidaat tonen.
+- De gebruiker moet nog steeds expliciet bevestigen voordat iets definitief wordt.

--- a/docs/release/M2C2i17_ready_for_local_validation.md
+++ b/docs/release/M2C2i17_ready_for_local_validation.md
@@ -1,0 +1,9 @@
+# M2C2i-17 klaar voor lokale validatie
+
+Deze branch is klaar om lokaal te valideren.
+
+Status:
+
+- Implementatie aanwezig.
+- PR mag worden geopend.
+- Nog geen merge zonder lokale validatie.

--- a/docs/release/M2C2i17_release_gate.md
+++ b/docs/release/M2C2i17_release_gate.md
@@ -1,0 +1,37 @@
+# M2C2i-17 Release Gate
+
+## Release Gate v1.10 – Compliance Check
+
+Basisversie: `main` na PR #94 (`9524eca627ff264e4d859309c2685015b5fd733c`)
+
+Nieuwe versie: nog niet vastgesteld; dit is een PR, geen release.
+
+Releasecategorie: backend feature.
+
+Wijzigingsdoel: dynamische retailer-aliaslearning voor externe productkandidaten.
+
+Niet gewijzigd:
+- UI-layout
+- voorraadmutaties
+- definitive productkoppelingen
+- huishoudartikelen
+
+Getest:
+- Nog niet lokaal uitgevoerd in Docker.
+
+Niet getest:
+- Docker build
+- backend runtime smoke
+- UI bovenste tabel
+
+Risiconiveau: middel. Nieuwe runtime-tabel en matchflowwijziging.
+
+Database locatie: moet lokaal bevestigd worden via `/api/health`.
+
+Database validatie: verplicht vóór merge.
+
+Scope Gate: groen op afbakening.
+
+QA/QC Gate: nog niet groen.
+
+Packaging Gate: niet van toepassing voor PR; wel verplicht bij release.

--- a/docs/release/M2C2i17_scope_gate.md
+++ b/docs/release/M2C2i17_scope_gate.md
@@ -1,0 +1,25 @@
+# M2C2i-17 Scope Gate
+
+## Basis
+
+- Basiscommit: `9524eca627ff264e4d859309c2685015b5fd733c`
+- Basis: `main` na M2C2i-16 / PR #94
+
+## Releasecategorie
+
+Backend feature.
+
+## Hoofddoel
+
+Dynamische retailer-aliaslearning voor externe productkandidaten.
+
+## Niet wijzigen
+
+- Geen UI-componenten.
+- Geen voorraadmutaties.
+- Geen definitieve product- of huishoudartikelkoppeling.
+- Geen productnamen in Python-code.
+
+## Risico
+
+Nieuwe tabel wordt runtime via service aangemaakt. Lokale databasevalidatie is verplicht vóór merge.

--- a/docs/release/M2C2i17_test_result_placeholder.md
+++ b/docs/release/M2C2i17_test_result_placeholder.md
@@ -1,0 +1,10 @@
+# M2C2i-17 testresultaat
+
+Nog in te vullen na lokale validatie.
+
+Te bevestigen:
+
+- Backend build: open
+- Health check: open
+- Aliaslearning smoke: open
+- UI-check: open

--- a/docs/release/M2C2i17_validation.md
+++ b/docs/release/M2C2i17_validation.md
@@ -1,0 +1,33 @@
+# M2C2i-17 validatie
+
+## Scope
+
+Backend feature: dynamische retailer-aliaslearning voor externe productkandidaten.
+
+## Niet gewijzigd
+
+- Geen UI-componenten aangepast.
+- Geen voorraadlogica aangepast.
+- Geen `global_products` of huishoudartikelen aangemaakt.
+
+## Testen
+
+Aanbevolen lokale checks:
+
+```powershell
+docker compose up -d --build backend
+```
+
+```powershell
+docker compose exec backend python -c "from app.services.external_database_matchflow_evidence import match_retailer_receipt_line; r=match_retailer_receipt_line('lidl','Mexicaanse kruiden',True); c=r['candidates'][0]; print(c.get('candidate_name'), c.get('score'), c.get('candidate_source_product_code'), r.get('creates_global_product'), r.get('creates_household_article'), r.get('creates_inventory_event'))"
+```
+
+```powershell
+docker compose exec backend python -c "from app.services.external_database_matchflow_evidence import match_retailer_receipt_line; r=match_retailer_receipt_line('lidl','MEXICAANSE KRUIDENM',True); c=r['candidates'][0]; print(c.get('candidate_name'), c.get('score'), c.get('candidate_source_name'), c.get('candidate_source_product_code'))"
+```
+
+## Verwachting
+
+- Herkende kandidaat heeft een externe code.
+- Score is hoog genoeg voor een betrouwbare alias.
+- Safety flags blijven false.

--- a/docs/release/M2C2i20_validation.md
+++ b/docs/release/M2C2i20_validation.md
@@ -1,0 +1,103 @@
+# M2C2i-20 — Validatie
+
+## Doelvalidatie
+
+Aantonen dat bonartikelen met een externe artikelcode niet opnieuw door de kandidaatzoekflow gaan.
+
+## Technische smoke zonder pytest
+
+De backend-container bevat geen pytest. Gebruik daarom een gewone Python-smoke via stdin.
+
+```powershell
+@'
+from app.services import external_database_matchflow_evidence as m
+
+resolved = {
+    "is_receipt_item_placeholder": True,
+    "purchase_import_line_id": "pil-1",
+    "receipt_line_text": "Veldsla",
+    "retailer_code": "lidl",
+    "retailer_article_number": "lidl:groente.veldsla",
+}
+
+unresolved = {
+    "is_receipt_item_placeholder": True,
+    "purchase_import_line_id": "pil-2",
+    "receipt_line_text": "Nieuw onbekend artikel",
+    "retailer_code": "lidl",
+}
+
+assert m.is_m2c2i20_external_resolved_item(resolved) is True
+assert m.m2c2i20_external_product_code(resolved) == "lidl:groente.veldsla"
+assert m.is_m2c2i20_external_resolved_item(unresolved) is False
+
+unresolved_items, resolved_items = m._m2c2i20_split_resolved_items([resolved, unresolved])
+
+assert unresolved_items == [unresolved]
+assert resolved_items == [resolved]
+
+result = m._m2c2i20_enrich_ensure_result(
+    {
+        "ok": True,
+        "total": 1,
+        "processed": 1,
+        "saved_count": 0,
+        "updated_count": 0,
+        "skipped_count": 0,
+        "errors": [],
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+    },
+    original_total=2,
+    resolved_items=resolved_items,
+)
+
+assert result["total"] == 2
+assert result["external_resolved_skipped_count"] == 1
+assert result["external_resolved_skipped"][0]["external_product_code"] == "lidl:groente.veldsla"
+assert result["m2c2i20_resolved_state_gate"] is True
+assert result["creates_global_product"] is False
+assert result["creates_household_article"] is False
+assert result["creates_inventory_event"] is False
+
+print("M2C2i-20 smoke OK: resolved bonartikelen worden niet opnieuw gezocht.")
+'@ | docker compose exec -T backend python
+```
+
+Verwacht:
+
+```text
+M2C2i-20 smoke OK: resolved bonartikelen worden niet opnieuw gezocht.
+```
+
+## Functionele test in Externe databases
+
+1. Open `http://localhost:5174/externe-databases`.
+2. Controleer een bonartikel dat al een artikelnummer/externe code heeft.
+3. Klik op vernieuwen/kandidaten ophalen.
+4. Controleer dat dit artikel niet opnieuw als onbekend kandidaatzoekitem wordt behandeld.
+5. Controleer dat artikelen zonder externe code nog wel kandidaatzoekacties kunnen krijgen.
+
+## Verwachte technische output
+
+De ensure-flow geeft expliciet terug:
+
+```json
+{
+  "m2c2i20_resolved_state_gate": true,
+  "external_resolved_skipped_count": 1,
+  "creates_global_product": false,
+  "creates_household_article": false,
+  "creates_inventory_event": false
+}
+```
+
+## Releasebesluit
+
+GO als:
+
+- resolved bonregels worden overgeslagen;
+- unresolved bonregels nog kandidaten kunnen ophalen;
+- safety flags false blijven;
+- bestaande Lidl-catalogus- en aliaslearningflow niet regressief wijzigt.

--- a/docs/release/M2C2i20a_validation.md
+++ b/docs/release/M2C2i20a_validation.md
@@ -1,0 +1,82 @@
+# M2C2i-20a — Performancevalidatie Externe databases
+
+## Doel
+
+De Externe databases-tabel moet bij het bijlezen van een nieuwe pagina merkbaar sneller reageren, zonder functionele wijziging in kandidaatlogica.
+
+## Wijziging
+
+M2C2i-20a voegt lichte database-indexen toe rond de bestaande resolved-state flow:
+
+- `external_product_candidates(context_key, updated_at)`
+- `external_product_candidates(purchase_import_line_id, updated_at)`
+- `external_product_candidates(receipt_line_id, updated_at)`
+- `external_product_candidates(candidate_status, status, context_key)`
+
+Daarnaast stopt de ensure-flow direct als de aangeleverde zichtbare items allemaal al resolved zijn. Dan wordt geen lege kandidaatzoekronde meer doorgezet.
+
+## Opstartroutine
+
+Gebruik bij lokale validatie altijd een wachttijd van 90 seconden na het starten of rebuilden van containers. Daarmee krijgen backend, frontend en database genoeg tijd om stabiel op te komen voordat de UI of smoke wordt getest.
+
+```powershell
+cd C:\Users\Gebruiker\Rezzerv_Github
+git fetch origin
+git switch m2c2i20a-external-db-pagination-performance
+git pull --ff-only origin m2c2i20a-external-db-pagination-performance
+docker compose up -d --build backend frontend
+Start-Sleep -Seconds 90
+```
+
+## PO-test
+
+1. Start lokaal volgens de opstartroutine hierboven.
+2. Open `http://localhost:5174/externe-databases`.
+3. Ga naar een volgende pagina in de tabel.
+4. Herhaal dit een paar keer.
+5. Controleer of het bijlezen merkbaar sneller en stabieler is.
+6. Controleer dat bekende artikelen met externe artikelcode resolved blijven.
+7. Controleer dat onbekende artikelen zonder externe artikelcode nog kandidaatzoekbaar blijven.
+
+## Smoke zonder pytest
+
+```powershell
+@'
+from app.services import external_database_matchflow_evidence as m
+
+m._m2c2i20a_ensure_performance_indexes()
+
+resolved = {
+    "is_receipt_item_placeholder": True,
+    "purchase_import_line_id": "pil-1",
+    "receipt_line_text": "Veldsla",
+    "retailer_code": "lidl",
+    "retailer_article_number": "lidl:groente.veldsla",
+}
+
+result = m.ensure_external_receipt_item_candidates(items=[resolved], include_below_threshold=True)
+
+assert result["processed"] == 0
+assert result["external_resolved_skipped_count"] == 1
+assert result["m2c2i20a_performance_indexes"] is True
+assert result["creates_global_product"] is False
+assert result["creates_household_article"] is False
+assert result["creates_inventory_event"] is False
+
+print("M2C2i-20a smoke OK: resolved-only refresh stopt direct en indexen zijn aanwezig.")
+'@ | docker compose exec -T backend python
+```
+
+Verwacht:
+
+```text
+M2C2i-20a smoke OK: resolved-only refresh stopt direct en indexen zijn aanwezig.
+```
+
+## GO-criteria
+
+- Nieuwe pagina in Externe databases laadt merkbaar sneller of in ieder geval niet trager.
+- Artikelen met externe artikelcode blijven resolved.
+- Onbekende artikelen blijven kandidaatzoekbaar.
+- Geen Mijn-artikel-aanmaak.
+- Geen voorraadmutatie.

--- a/docs/release/M2C2i21_validation.md
+++ b/docs/release/M2C2i21_validation.md
@@ -1,0 +1,75 @@
+# M2C2i-21 — Validatie
+
+## Doelvalidatie
+
+Aantonen dat onbekende Lidl-bonregels lokale cataloguskandidaten kunnen krijgen uit `external_product_index`, zonder live externe bron en zonder product-/voorraadmutaties.
+
+## Opstartroutine
+
+```powershell
+cd C:\Users\Gebruiker\Rezzerv_Github
+git fetch origin
+git switch m2c2i21-lidl-local-catalog-index
+git pull --ff-only origin m2c2i21-lidl-local-catalog-index
+docker compose up -d --build backend frontend
+Start-Sleep -Seconds 90
+```
+
+## Smoke zonder pytest
+
+```powershell
+@'
+from app.services.lidl_local_catalog_index import ensure_lidl_local_catalog_index, search_lidl_local_catalog_candidates
+from app.services import external_database_matchflow_evidence as m
+
+loaded = ensure_lidl_local_catalog_index()
+assert loaded["loaded_count"] > 0
+assert loaded["creates_global_product"] is False
+assert loaded["creates_household_article"] is False
+assert loaded["creates_inventory_event"] is False
+
+catalog_candidates = search_lidl_local_catalog_candidates("Veldsla", limit=5)
+assert catalog_candidates
+assert len(catalog_candidates) <= 5
+assert catalog_candidates[0]["candidate_source_name"] == "lidl_catalog_index"
+assert catalog_candidates[0]["creates_global_product"] is False
+assert catalog_candidates[0]["creates_household_article"] is False
+assert catalog_candidates[0]["creates_inventory_event"] is False
+
+match = m.match_retailer_receipt_line("lidl", "Veldsla", include_below_threshold=True)
+assert match["uses_lidl_local_catalog_index"] is True
+assert match["lidl_local_catalog_candidate_count"] >= 1
+assert len(match["candidates"]) <= 5
+assert any("lidl_catalog_index" in (c.get("merged_source_names") or [c.get("candidate_source_name")]) for c in match["candidates"])
+assert any(c.get("has_lidl_local_catalog_index_source") is True for c in match["candidates"])
+assert match["creates_global_product"] is False
+assert match["creates_household_article"] is False
+assert match["creates_inventory_event"] is False
+
+print("M2C2i-21 smoke OK: lokale Lidl-catalogusindex levert kandidaten zonder mutaties.")
+'@ | docker compose exec -T backend python
+```
+
+Verwacht:
+
+```text
+M2C2i-21 smoke OK: lokale Lidl-catalogusindex levert kandidaten zonder mutaties.
+```
+
+## PO-test in de UI
+
+1. Open `http://localhost:5174/externe-databases`.
+2. Gebruik een Lidl-bonregel die nog geen externe artikelcode heeft maar wel als product in de Lidl-catalogusdata voorkomt.
+3. Ververs/haal kandidaten op.
+4. Controleer dat maximaal 5 kandidaten worden getoond.
+5. Controleer dat de kandidaatbron direct of via samengevoegde bronnen herleidbaar is naar `lidl_catalog_index`.
+6. Controleer dat er geen Mijn-artikel wordt aangemaakt.
+7. Controleer dat er geen voorraadmutatie ontstaat.
+
+## GO-criteria
+
+- Onbekende Lidl-bonregel krijgt cataloguskandidaat uit lokale index.
+- Kandidaten zijn maximaal 5.
+- Bron is direct of via samengevoegde bronnen herkenbaar als `lidl_catalog_index`.
+- Geen live externe afhankelijkheid.
+- Geen global product, household article of inventory event.

--- a/docs/release/M2C2i22_validation.md
+++ b/docs/release/M2C2i22_validation.md
@@ -1,0 +1,84 @@
+# M2C2i-22 — Validatie
+
+## Doelvalidatie
+
+Aantonen dat een externe kandidaat kan worden bevestigd op een bonregel/importregel, zonder `global_products`, Mijn artikel of voorraadmutaties aan te maken.
+
+## Opstartroutine
+
+```powershell
+cd C:\Users\Gebruiker\Rezzerv_Github
+git fetch origin
+git switch m2c2i22-confirm-external-candidate
+git pull --ff-only origin m2c2i22-confirm-external-candidate
+docker compose up -d --build backend frontend
+Start-Sleep -Seconds 90
+```
+
+## Smoke zonder pytest
+
+Deze smoke maakt tijdelijk alleen een candidate aan en bevestigt die. Daarmee testen we de kernregel: de candidate wordt external resolved, zonder `global_product_id` of andere product-/voorraadmutaties. In de echte UI-flow wordt dezelfde functie gebruikt met een bestaande `purchase_import_line_id`, waardoor ook de externe artikelcode op de importregel wordt vastgelegd als de kolom bestaat.
+
+```powershell
+@'
+from app.db import engine
+from sqlalchemy import text
+from app.services.external_product_candidate_store import ensure_external_product_candidates_schema
+from app.services.external_candidate_confirmation import confirm_external_candidate_for_receipt_item
+
+ensure_external_product_candidates_schema()
+line_id = "m2c2i22-smoke-line"
+candidate_id = "m2c2i22-smoke-candidate"
+context_key = "purchase-import-line:" + line_id
+
+with engine.begin() as conn:
+    conn.execute(text("DELETE FROM external_product_candidates WHERE id = :id OR purchase_import_line_id = :line_id"), {"id": candidate_id, "line_id": line_id})
+    conn.execute(text("""
+        INSERT INTO external_product_candidates (
+            id, purchase_import_line_id, context_key, retailer_code, receipt_line_text,
+            candidate_name, candidate_brand, candidate_source_name, candidate_source_product_code,
+            source_name, source_product_code, retailer_article_number, score,
+            candidate_status, is_probable, is_user_confirmed, is_external_database_override,
+            created_by, created_at, updated_at
+        ) VALUES (
+            :id, :purchase_import_line_id, :context_key, 'lidl', 'Veldsla',
+            'Lidl Veldsla', 'Lidl Groente', 'lidl_catalog_index', 'lidl:groente.veldsla',
+            'lidl_catalog_index', 'lidl:groente.veldsla', 'lidl:groente.veldsla', 0.95,
+            'possible_candidate', 1, 0, 0,
+            'm2c2i22_smoke', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+        )
+    """), {"id": candidate_id, "purchase_import_line_id": line_id, "context_key": context_key})
+
+result = confirm_external_candidate_for_receipt_item(candidate_id)
+assert result["ok"] is True
+assert result["confirmed"] is True
+assert result["external_product_code"] == "lidl:groente.veldsla"
+assert result["creates_global_product"] is False
+assert result["creates_household_article"] is False
+assert result["creates_inventory_event"] is False
+
+with engine.begin() as conn:
+    candidate = conn.execute(text("SELECT candidate_status, status, global_product_id, is_user_confirmed FROM external_product_candidates WHERE id = :id"), {"id": candidate_id}).mappings().first()
+    assert candidate["candidate_status"] == "user_confirmed"
+    assert candidate["status"] == "external_resolved"
+    assert not candidate["global_product_id"]
+    assert int(candidate["is_user_confirmed"] or 0) == 1
+
+print("M2C2i-22 smoke OK: externe kandidaat bevestigd zonder product- of voorraadmutaties.")
+'@ | docker compose exec -T backend python
+```
+
+Verwacht:
+
+```text
+M2C2i-22 smoke OK: externe kandidaat bevestigd zonder product- of voorraadmutaties.
+```
+
+## GO-criteria
+
+- Geselecteerde candidate wordt `user_confirmed` / `external_resolved`.
+- Externe artikelcode is vastgelegd op de bonregel/importregel als de kolom bestaat.
+- `global_product_id` blijft leeg.
+- Geen `global_products`-aanmaak.
+- Geen Mijn-artikel-aanmaak.
+- Geen voorraadmutatie.

--- a/docs/release/M2C2i23_validation.md
+++ b/docs/release/M2C2i23_validation.md
@@ -1,0 +1,95 @@
+# M2C2i-23 — Validatie
+
+## Doelvalidatie
+
+Aantonen dat de Externe databases-UI bevestigde externe kandidaten zichtbaar maakt als `Extern bevestigd`, en dat bevestigen geen product-/voorraadmutaties veroorzaakt.
+
+## Opstartroutine
+
+```powershell
+cd C:\Users\Gebruiker\Rezzerv_Github
+git fetch origin
+git switch m2c2i23-confirmed-external-candidate-ui
+git pull --ff-only origin m2c2i23-confirmed-external-candidate-ui
+docker compose up -d --build backend frontend
+Start-Sleep -Seconds 90
+```
+
+## Smoke zonder pytest
+
+```powershell
+@'
+from app.db import engine
+from sqlalchemy import text
+from app.services.external_product_candidate_store import ensure_external_product_candidates_schema
+from app.services.external_candidate_confirmation import confirm_external_candidate_for_receipt_item
+
+ensure_external_product_candidates_schema()
+line_id = "m2c2i23-smoke-line"
+candidate_id = "m2c2i23-smoke-candidate"
+context_key = "purchase-import-line:" + line_id
+
+with engine.begin() as conn:
+    conn.execute(text("DELETE FROM external_product_candidates WHERE id = :id OR purchase_import_line_id = :line_id"), {"id": candidate_id, "line_id": line_id})
+    conn.execute(text("""
+        INSERT INTO external_product_candidates (
+            id, purchase_import_line_id, context_key, retailer_code, receipt_line_text,
+            candidate_name, candidate_brand, candidate_source_name, candidate_source_product_code,
+            source_name, source_product_code, retailer_article_number, score,
+            candidate_status, status, is_probable, is_user_confirmed, is_external_database_override,
+            created_by, created_at, updated_at
+        ) VALUES (
+            :id, :purchase_import_line_id, :context_key, 'lidl', 'Veldsla',
+            'Lidl Veldsla', 'Lidl Groente', 'lidl_catalog_index', 'lidl:groente.veldsla',
+            'lidl_catalog_index', 'lidl:groente.veldsla', 'lidl:groente.veldsla', 0.95,
+            'possible_candidate', 'candidate', 1, 0, 0,
+            'm2c2i23_smoke', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+        )
+    """), {"id": candidate_id, "purchase_import_line_id": line_id, "context_key": context_key})
+
+result = confirm_external_candidate_for_receipt_item(candidate_id)
+assert result["ok"] is True
+assert result["confirmed"] is True
+assert result["external_product_code"] == "lidl:groente.veldsla"
+assert result["creates_global_product"] is False
+assert result["creates_household_article"] is False
+assert result["creates_inventory_event"] is False
+
+with engine.begin() as conn:
+    row = conn.execute(text("SELECT candidate_status, status, retailer_article_number, global_product_id, is_user_confirmed FROM external_product_candidates WHERE id = :id"), {"id": candidate_id}).mappings().first()
+    assert row["candidate_status"] == "user_confirmed"
+    assert row["status"] == "external_resolved"
+    assert row["retailer_article_number"] == "lidl:groente.veldsla"
+    assert not row["global_product_id"]
+    assert int(row["is_user_confirmed"] or 0) == 1
+
+print("M2C2i-23 smoke OK: bevestigde externe kandidaat is external_resolved zonder mutaties.")
+'@ | docker compose exec -T backend python
+```
+
+Verwacht:
+
+```text
+M2C2i-23 smoke OK: bevestigde externe kandidaat is external_resolved zonder mutaties.
+```
+
+## PO-test in de UI
+
+1. Open `http://localhost:5174/externe-databases`.
+2. Dubbelklik een bonartikel met externe kandidaten.
+3. Selecteer een externe kandidaat.
+4. Klik `Bevestig externe kandidaat`.
+5. Controleer dat de status in de tabel `Extern bevestigd` wordt.
+6. Controleer dat de externe artikelcode zichtbaar blijft.
+7. Klik `Kandidaten bijlezen` of `Vernieuwen`.
+8. Controleer dat de status `Extern bevestigd` behouden blijft.
+
+## GO-criteria
+
+- Bevestigde kandidaat is zichtbaar als `Extern bevestigd`.
+- Externe artikelcode is zichtbaar in de hoofdregel.
+- Detailkandidaat toont bron en externe code.
+- Refresh veroorzaakt geen nieuwe kandidaatzoeking voor resolved regels.
+- Geen `global_products`-aanmaak.
+- Geen Mijn-artikel-aanmaak.
+- Geen voorraadmutatie.

--- a/docs/release/M2C2i23_validation.md
+++ b/docs/release/M2C2i23_validation.md
@@ -2,7 +2,7 @@
 
 ## Doelvalidatie
 
-Aantonen dat de Externe databases-UI bevestigde externe kandidaten zichtbaar maakt als `Extern bevestigd`, en dat bevestigen geen product-/voorraadmutaties veroorzaakt.
+Aantonen dat de Externe databases-UI bevestigde herkenningen zichtbaar maakt als `Herkenning bevestigd`, en dat bevestigen geen product-/voorraadmutaties veroorzaakt.
 
 ## Opstartroutine
 
@@ -63,33 +63,34 @@ with engine.begin() as conn:
     assert not row["global_product_id"]
     assert int(row["is_user_confirmed"] or 0) == 1
 
-print("M2C2i-23 smoke OK: bevestigde externe kandidaat is external_resolved zonder mutaties.")
+print("M2C2i-23 smoke OK: herkenning bevestigd zonder product- of voorraadmutaties.")
 '@ | docker compose exec -T backend python
 ```
 
 Verwacht:
 
 ```text
-M2C2i-23 smoke OK: bevestigde externe kandidaat is external_resolved zonder mutaties.
+M2C2i-23 smoke OK: herkenning bevestigd zonder product- of voorraadmutaties.
 ```
 
 ## PO-test in de UI
 
 1. Open `http://localhost:5174/externe-databases`.
-2. Dubbelklik een bonartikel met externe kandidaten.
-3. Selecteer een externe kandidaat.
-4. Klik `Bevestig externe kandidaat`.
-5. Controleer dat de status in de tabel `Extern bevestigd` wordt.
-6. Controleer dat de externe artikelcode zichtbaar blijft.
-7. Klik `Kandidaten bijlezen` of `Vernieuwen`.
-8. Controleer dat de status `Extern bevestigd` behouden blijft.
+2. De sectie heet `Bonartikelen herkennen`.
+3. Dubbelklik een bonartikel met herkenningskandidaten.
+4. Selecteer een herkenningskandidaat.
+5. Klik `Bevestig herkenning`.
+6. Controleer dat de status in de tabel `Herkenning bevestigd` wordt.
+7. Controleer dat de `Winkel-/broncode` zichtbaar blijft.
+8. Klik `Herkenningskandidaten bijlezen` of `Vernieuwen`.
+9. Controleer dat de status `Herkenning bevestigd` behouden blijft.
 
 ## GO-criteria
 
-- Bevestigde kandidaat is zichtbaar als `Extern bevestigd`.
-- Externe artikelcode is zichtbaar in de hoofdregel.
-- Detailkandidaat toont bron en externe code.
-- Refresh veroorzaakt geen nieuwe kandidaatzoeking voor resolved regels.
+- Bevestigde kandidaat is zichtbaar als `Herkenning bevestigd`.
+- Winkel-/broncode is zichtbaar in de hoofdregel.
+- Detailkandidaat toont bron en winkel-/broncode.
+- Refresh veroorzaakt geen nieuwe kandidaatzoeking voor bevestigde herkenningen.
 - Geen `global_products`-aanmaak.
 - Geen Mijn-artikel-aanmaak.
 - Geen voorraadmutatie.

--- a/docs/technical/M2C2i17_local_commands.md
+++ b/docs/technical/M2C2i17_local_commands.md
@@ -1,0 +1,21 @@
+# M2C2i-17 lokale validatiecommando's
+
+```powershell
+cd C:\Users\Gebruiker\Rezzerv_Github
+git switch main
+git pull --ff-only
+git switch m2c2i17-retailer-alias-learning
+git pull --ff-only
+```
+
+```powershell
+docker compose up -d --build backend
+```
+
+```powershell
+docker compose exec backend python -c "from app.services.external_database_matchflow_evidence import match_retailer_receipt_line; r=match_retailer_receipt_line('lidl','Mexicaanse kruiden',True); c=r['candidates'][0]; print(c.get('candidate_name'), c.get('score'), c.get('candidate_source_product_code'), r.get('creates_global_product'), r.get('creates_household_article'), r.get('creates_inventory_event'))"
+```
+
+```powershell
+docker compose exec backend python -c "from app.services.external_database_matchflow_evidence import match_retailer_receipt_line; r=match_retailer_receipt_line('lidl','MEXICAANSE KRUIDENM',True); c=r['candidates'][0]; print(c.get('candidate_name'), c.get('score'), c.get('candidate_source_name'), c.get('candidate_source_product_code'))"
+```

--- a/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
+++ b/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
@@ -5,7 +5,7 @@ import ScreenCard from '../../ui/ScreenCard'
 import Table from '../../ui/Table'
 import Input from '../../ui/Input'
 import Button from '../../ui/Button'
-import ReceiptItemsOverview from './ReceiptItemsOverview'
+import ReceiptItemsOverview from './ReceiptItemsOverviewResolved'
 import { fetchJsonWithAuth } from '../../lib/authSession'
 import './externalDatabases.css'
 
@@ -253,5 +253,3 @@ export default function ExternalDatabasesPage() {
     </AppShell>
   )
 }
-
-

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverviewResolved.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverviewResolved.jsx
@@ -24,12 +24,6 @@ function scoreText(value) {
   return number.toLocaleString('nl-NL', { minimumFractionDigits: 3, maximumFractionDigits: 3 })
 }
 
-function numberText(value) {
-  const number = Number(value)
-  if (!Number.isFinite(number)) return '-'
-  return number.toLocaleString('nl-NL', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
-}
-
 function retailerLabel(value) {
   const normalized = String(value || '').trim()
   const key = normalized.toLowerCase()
@@ -80,15 +74,15 @@ function isFallback(row) {
 }
 
 function statusLabel(row) {
-  if (isCatalogLinked(row)) return 'Catalogus gekoppeld'
-  if (isExternalResolved(row)) return 'Extern bevestigd'
-  if (isFallback(row)) return 'Geen externe match'
+  if (isCatalogLinked(row)) return 'Artikel gekoppeld'
+  if (isExternalResolved(row)) return 'Herkenning bevestigd'
+  if (isFallback(row)) return 'Geen herkenning'
   const raw = statusKey(row?.candidate_status || row?.status)
   const labels = {
-    probable_candidate: 'Waarschijnlijke kandidaat',
-    possible_candidate: 'Kandidaat',
+    probable_candidate: 'Waarschijnlijke herkenning',
+    possible_candidate: 'Herkenningskandidaat',
     weak_candidate: 'Lage zekerheid',
-    candidate: 'Kandidaat',
+    candidate: 'Herkenningskandidaat',
     no_candidate: 'Nog niet verwerkt',
   }
   return labels[raw] || valueText(row?.candidate_status || row?.status || 'Nog niet verwerkt')
@@ -134,8 +128,7 @@ function buildRows(payloadItems) {
       receiptLineText: valueText(row.receipt_line_text),
       retailerCode: retailerLabel(row.retailer_code),
       retailerCodeRaw: valueText(row.retailer_code, ''),
-      articleNumber: valueText(externalCode(row)),
-      gtin: valueText(row.gtin || row.ean),
+      externalReference: valueText(externalCode(row)),
       quantity: valueText(row.quantity_label),
       price: row.price ?? '-',
       candidateCount: 0,
@@ -145,14 +138,14 @@ function buildRows(payloadItems) {
       candidates: [],
     }
 
-    if (!current.articleNumber || current.articleNumber === '-') current.articleNumber = valueText(externalCode(row))
+    if (!current.externalReference || current.externalReference === '-') current.externalReference = valueText(externalCode(row))
     if (isExternalResolved(row)) {
       current.externalResolved = true
-      current.status = 'Extern bevestigd'
+      current.status = 'Herkenning bevestigd'
     }
     if (isCatalogLinked(row)) {
       current.catalogLinked = true
-      current.status = 'Catalogus gekoppeld'
+      current.status = 'Artikel gekoppeld'
     }
 
     if (!placeholder && row.candidate_name) {
@@ -161,8 +154,8 @@ function buildRows(payloadItems) {
       if (!candidate.fallback) current.candidateCount += 1
       if (candidate.externalResolved && !current.catalogLinked) {
         current.externalResolved = true
-        current.status = 'Extern bevestigd'
-        current.articleNumber = candidate.code
+        current.status = 'Herkenning bevestigd'
+        current.externalReference = candidate.code
       }
     }
 
@@ -173,19 +166,19 @@ function buildRows(payloadItems) {
         if (!candidate.fallback) current.candidateCount += 1
         if (candidate.externalResolved && !current.catalogLinked) {
           current.externalResolved = true
-          current.status = 'Extern bevestigd'
-          current.articleNumber = candidate.code
+          current.status = 'Herkenning bevestigd'
+          current.externalReference = candidate.code
         }
         if (candidate.catalogLinked) {
           current.catalogLinked = true
-          current.status = 'Catalogus gekoppeld'
-          current.articleNumber = candidate.code
+          current.status = 'Artikel gekoppeld'
+          current.externalReference = candidate.code
         }
       })
     }
 
     if (current.candidateCount > 0 && !current.externalResolved && !current.catalogLinked) {
-      current.status = 'Kandidaten gevonden'
+      current.status = 'Herkenningskandidaten gevonden'
     }
 
     grouped.set(key, current)
@@ -251,7 +244,7 @@ export default function ReceiptItemsOverviewResolved({ onError, onMessage }) {
   const filteredItems = useMemo(() => {
     const normalized = filter.toLowerCase().trim()
     if (!normalized) return items
-    return items.filter((item) => [item.receiptLineText, item.retailerCode, item.articleNumber, item.status, item.bestCandidateName].join(' ').toLowerCase().includes(normalized))
+    return items.filter((item) => [item.receiptLineText, item.retailerCode, item.externalReference, item.status, item.bestCandidateName].join(' ').toLowerCase().includes(normalized))
   }, [items, filter])
 
   const pageCount = Math.max(1, Math.ceil(filteredItems.length / PAGE_SIZE))
@@ -274,17 +267,17 @@ export default function ReceiptItemsOverviewResolved({ onError, onMessage }) {
             retailer_code: item.retailerCodeRaw || item.retailerCode,
             purchase_import_line_id: item.purchaseImportLineId,
             receipt_line_id: item.receiptLineId,
-            retailer_article_number: item.externalResolved ? item.articleNumber : '',
+            retailer_article_number: item.externalResolved ? item.externalReference : '',
             external_match_status: item.externalResolved ? 'external_resolved' : '',
           })),
         }),
       })
       const data = await response.json().catch(() => ({}))
-      if (!response.ok) throw new Error(data?.detail || 'Kandidaten bijlezen is mislukt')
+      if (!response.ok) throw new Error(data?.detail || 'Herkenningskandidaten bijlezen is mislukt')
       await loadItems()
-      onMessage?.(`Bijlezen afgerond. Resolved overgeslagen: ${data?.external_resolved_skipped_count ?? 0}.`)
+      onMessage?.(`Bijlezen afgerond. Bevestigde herkenningen overgeslagen: ${data?.external_resolved_skipped_count ?? 0}.`)
     } catch (err) {
-      onError?.(err?.message || 'Kandidaten bijlezen is mislukt')
+      onError?.(err?.message || 'Herkenningskandidaten bijlezen is mislukt')
     } finally {
       setIsEnsuring(false)
     }
@@ -300,13 +293,13 @@ export default function ReceiptItemsOverviewResolved({ onError, onMessage }) {
         body: JSON.stringify({ candidate_id: selectedCandidate.raw?.id || selectedCandidate.id }),
       })
       const data = await response.json().catch(() => ({}))
-      if (!response.ok) throw new Error(data?.detail || 'Externe kandidaat bevestigen is mislukt')
-      if (!data?.confirmed) throw new Error(data?.reason || 'Externe kandidaat is niet bevestigd')
-      onMessage?.(`Externe kandidaat bevestigd: ${data.external_product_code || selectedCandidate.code}`)
+      if (!response.ok) throw new Error(data?.detail || 'Herkenning bevestigen is mislukt')
+      if (!data?.confirmed) throw new Error(data?.reason || 'Herkenning is niet bevestigd')
+      onMessage?.(`Herkenning bevestigd met code: ${data.external_product_code || selectedCandidate.code}`)
       setSelectedCandidateId('')
       await loadItems()
     } catch (err) {
-      onError?.(err?.message || 'Externe kandidaat bevestigen is mislukt')
+      onError?.(err?.message || 'Herkenning bevestigen is mislukt')
     } finally {
       setIsConfirming(false)
     }
@@ -320,16 +313,16 @@ export default function ReceiptItemsOverviewResolved({ onError, onMessage }) {
   return (
     <div className="rz-external-receipt-overview">
       <div className="rz-external-databases-section-header">
-        <h3>Bonartikelen voor externe herkenning</h3>
+        <h3>Bonartikelen herkennen</h3>
         <div className="rz-external-databases-actions">
           <Button type="button" variant="secondary" disabled={isLoading} onClick={loadItems}>{isLoading ? 'Laden...' : 'Vernieuwen'}</Button>
-          <Button type="button" variant="secondary" disabled={isEnsuring || !visibleItems.length} onClick={ensureVisibleCandidates}>{isEnsuring ? 'Bijlezen...' : 'Kandidaten bijlezen'}</Button>
+          <Button type="button" variant="secondary" disabled={isEnsuring || !visibleItems.length} onClick={ensureVisibleCandidates}>{isEnsuring ? 'Bijlezen...' : 'Herkenningskandidaten bijlezen'}</Button>
         </div>
       </div>
 
-      <div className="rz-external-databases-muted">Bevestigen legt alleen externe artikelcode vast. Geen Mijn artikel, global product of voorraadmutatie.</div>
+      <div className="rz-external-databases-muted">Bevestigen betekent alleen: deze bonregel is herkend als deze winkel-/broncode. Er ontstaat geen Mijn artikel, product of voorraadmutatie.</div>
       <div className="rz-external-databases-actions">
-        <input className="rz-table-filter" value={filter} onChange={(event) => { setFilter(event.target.value); setPage(1) }} placeholder="Zoek bonartikel, status of artikelcode" />
+        <input className="rz-table-filter" value={filter} onChange={(event) => { setFilter(event.target.value); setPage(1) }} placeholder="Zoek bonartikel, status of winkel-/broncode" />
       </div>
 
       <div className="rz-table-scroll rz-table-scroll--wide">
@@ -338,9 +331,9 @@ export default function ReceiptItemsOverviewResolved({ onError, onMessage }) {
             <tr className="rz-table-header">
               <th>Bonartikel</th>
               <th>Winkelketen</th>
-              <th>Status</th>
-              <th>Externe artikelcode</th>
-              <th>Kandidaat</th>
+              <th>Status herkenning</th>
+              <th>Winkel-/broncode</th>
+              <th>Beste herkenning</th>
               <th className="rz-num">Score</th>
               <th className="rz-num">Kandidaten</th>
             </tr>
@@ -351,7 +344,7 @@ export default function ReceiptItemsOverviewResolved({ onError, onMessage }) {
                 <td>{item.receiptLineText}</td>
                 <td>{item.retailerCode}</td>
                 <td>{item.status}</td>
-                <td>{item.articleNumber || '-'}</td>
+                <td>{item.externalReference || '-'}</td>
                 <td>{item.bestCandidateName || '-'}</td>
                 <td className="rz-num">{scoreText(item.bestCandidateScore)}</td>
                 <td className="rz-num">{item.candidateCount}</td>
@@ -370,17 +363,17 @@ export default function ReceiptItemsOverviewResolved({ onError, onMessage }) {
       <div className="rz-external-receipt-detail">
         {selectedItem ? (
           <>
-            <h3>Externe kandidaten voor: {selectedItem.receiptLineText}</h3>
+            <h3>Herkenningskandidaten voor: {selectedItem.receiptLineText}</h3>
             <div className="rz-table-scroll">
               <Table dataTestId="external-receipt-item-candidates-table" tableClassName="rz-external-candidate-detail-table">
                 <thead>
                   <tr className="rz-table-header">
                     <th>Keuze</th>
-                    <th>Kandidaat</th>
+                    <th>Herkenning</th>
                     <th>Score</th>
                     <th>Merk</th>
                     <th>Bron</th>
-                    <th>Externe code</th>
+                    <th>Winkel-/broncode</th>
                     <th>Status</th>
                   </tr>
                 </thead>
@@ -397,18 +390,18 @@ export default function ReceiptItemsOverviewResolved({ onError, onMessage }) {
                       <td>{candidate.code}</td>
                       <td>{candidate.status}</td>
                     </tr>
-                  )) : <tr><td colSpan="7">Geen externe kandidaten gevonden voor dit bonartikel.</td></tr>}
+                  )) : <tr><td colSpan="7">Geen herkenningskandidaten gevonden voor dit bonartikel.</td></tr>}
                 </tbody>
               </Table>
             </div>
             <div className="rz-external-databases-actions rz-external-detail-actions">
               <Button type="button" disabled={!canConfirmSelectedCandidate || isConfirming} onClick={confirmSelectedCandidate}>
-                {isConfirming ? 'Bevestigen...' : 'Bevestig externe kandidaat'}
+                {isConfirming ? 'Bevestigen...' : 'Bevestig herkenning'}
               </Button>
-              <span className="rz-external-databases-muted">Status na bevestigen: Extern bevestigd.</span>
+              <span className="rz-external-databases-muted">Na bevestigen blijft alleen de winkel-/broncode aan de bonregel hangen.</span>
             </div>
           </>
-        ) : <p className="rz-external-databases-muted">Dubbelklik op een bonartikel om externe kandidaten te bekijken.</p>}
+        ) : <p className="rz-external-databases-muted">Dubbelklik op een bonartikel om herkenningskandidaten te bekijken.</p>}
       </div>
     </div>
   )

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverviewResolved.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverviewResolved.jsx
@@ -1,0 +1,415 @@
+import { useEffect, useMemo, useState } from 'react'
+import Table from '../../ui/Table'
+import Button from '../../ui/Button'
+import { fetchJsonWithAuth } from '../../lib/authSession'
+
+const PAGE_SIZE = 10
+const RESOLVED_STATUSES = new Set(['external_resolved', 'user_confirmed'])
+const LINKED_STATUSES = new Set(['linked_to_catalog'])
+const FALLBACK_STATUSES = new Set(['fallback_candidate', 'receipt_fallback_candidate', 'receipt_unresolved_fallback', 'unresolved_fallback', 'unresolved', 'no_external_match'])
+
+function valueText(value, fallback = '-') {
+  const normalized = String(value ?? '').trim()
+  return normalized || fallback
+}
+
+function statusKey(value) {
+  return String(value || '').trim().toLowerCase()
+}
+
+function scoreText(value) {
+  if (value === null || value === undefined || value === '') return '-'
+  const number = Number(value)
+  if (!Number.isFinite(number)) return '-'
+  return number.toLocaleString('nl-NL', { minimumFractionDigits: 3, maximumFractionDigits: 3 })
+}
+
+function numberText(value) {
+  const number = Number(value)
+  if (!Number.isFinite(number)) return '-'
+  return number.toLocaleString('nl-NL', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+function retailerLabel(value) {
+  const normalized = String(value || '').trim()
+  const key = normalized.toLowerCase()
+  const labels = {
+    ah: 'Albert Heijn',
+    albert_heijn: 'Albert Heijn',
+    'albert heijn': 'Albert Heijn',
+    jumbo: 'Jumbo',
+    lidl: 'Lidl',
+    aldi: 'Aldi',
+    plus: 'PLUS',
+    picnic: 'Picnic',
+  }
+  if (!key || key === '-' || key === 'import' || key === 'onbekend') return 'Onbekend'
+  return labels[key] || normalized
+}
+
+function externalCode(row) {
+  return valueText(
+    row?.external_source_product_code ||
+    row?.candidate_source_product_code ||
+    row?.source_product_code ||
+    row?.retailer_article_number ||
+    row?.external_article_code ||
+    row?.gtin ||
+    row?.ean,
+    ''
+  )
+}
+
+function sourceName(row) {
+  return valueText(row?.external_source_name || row?.candidate_source_name || row?.source_name, '')
+}
+
+function isExternalResolved(row) {
+  const statuses = [row?.status, row?.candidate_status, row?.external_match_status].map(statusKey)
+  return Boolean(externalCode(row)) && statuses.some((status) => RESOLVED_STATUSES.has(status))
+}
+
+function isCatalogLinked(row) {
+  const statuses = [row?.status, row?.candidate_status].map(statusKey)
+  return Boolean(row?.is_linked_to_catalog || row?.global_product_id || row?.matched_global_product_id || statuses.some((status) => LINKED_STATUSES.has(status)))
+}
+
+function isFallback(row) {
+  const statuses = [row?.status, row?.candidate_status, row?.source_name, row?.candidate_source_name].map(statusKey)
+  return statuses.some((status) => FALLBACK_STATUSES.has(status) || status.includes('fallback') || status.includes('unresolved'))
+}
+
+function statusLabel(row) {
+  if (isCatalogLinked(row)) return 'Catalogus gekoppeld'
+  if (isExternalResolved(row)) return 'Extern bevestigd'
+  if (isFallback(row)) return 'Geen externe match'
+  const raw = statusKey(row?.candidate_status || row?.status)
+  const labels = {
+    probable_candidate: 'Waarschijnlijke kandidaat',
+    possible_candidate: 'Kandidaat',
+    weak_candidate: 'Lage zekerheid',
+    candidate: 'Kandidaat',
+    no_candidate: 'Nog niet verwerkt',
+  }
+  return labels[raw] || valueText(row?.candidate_status || row?.status || 'Nog niet verwerkt')
+}
+
+function rowId(row) {
+  return valueText(row.context_key || row.purchase_import_line_id || row.receipt_line_id || row.receipt_line_text, 'receipt-item')
+}
+
+function candidateId(row) {
+  return valueText(row.candidate_id || row.id || `${row.candidate_name}-${externalCode(row)}-${row.variant}`, 'candidate')
+}
+
+function mapCandidate(row) {
+  return {
+    id: candidateId(row),
+    raw: row,
+    name: valueText(row.candidate_name || row.receipt_line_text),
+    brand: valueText(row.candidate_brand),
+    source: valueText(sourceName(row)),
+    code: valueText(externalCode(row)),
+    variant: valueText(row.variant),
+    score: row.score,
+    status: statusLabel(row),
+    externalResolved: isExternalResolved(row),
+    catalogLinked: isCatalogLinked(row),
+    fallback: isFallback(row),
+    linkable: Boolean(row.is_linkable_to_catalog) && !isFallback(row),
+  }
+}
+
+function buildRows(payloadItems) {
+  const grouped = new Map()
+
+  payloadItems.forEach((row) => {
+    const key = rowId(row)
+    const placeholder = Boolean(row.is_receipt_item_placeholder)
+    const current = grouped.get(key) || {
+      id: key,
+      contextKey: valueText(row.context_key, ''),
+      receiptLineId: valueText(row.receipt_line_id, ''),
+      purchaseImportLineId: valueText(row.purchase_import_line_id, ''),
+      receiptLineText: valueText(row.receipt_line_text),
+      retailerCode: retailerLabel(row.retailer_code),
+      retailerCodeRaw: valueText(row.retailer_code, ''),
+      articleNumber: valueText(externalCode(row)),
+      gtin: valueText(row.gtin || row.ean),
+      quantity: valueText(row.quantity_label),
+      price: row.price ?? '-',
+      candidateCount: 0,
+      status: statusLabel(row),
+      externalResolved: isExternalResolved(row),
+      catalogLinked: isCatalogLinked(row),
+      candidates: [],
+    }
+
+    if (!current.articleNumber || current.articleNumber === '-') current.articleNumber = valueText(externalCode(row))
+    if (isExternalResolved(row)) {
+      current.externalResolved = true
+      current.status = 'Extern bevestigd'
+    }
+    if (isCatalogLinked(row)) {
+      current.catalogLinked = true
+      current.status = 'Catalogus gekoppeld'
+    }
+
+    if (!placeholder && row.candidate_name) {
+      const candidate = mapCandidate(row)
+      current.candidates.push(candidate)
+      if (!candidate.fallback) current.candidateCount += 1
+      if (candidate.externalResolved && !current.catalogLinked) {
+        current.externalResolved = true
+        current.status = 'Extern bevestigd'
+        current.articleNumber = candidate.code
+      }
+    }
+
+    if (placeholder && Array.isArray(row.candidates)) {
+      row.candidates.forEach((candidateRow) => {
+        const candidate = mapCandidate(candidateRow)
+        current.candidates.push(candidate)
+        if (!candidate.fallback) current.candidateCount += 1
+        if (candidate.externalResolved && !current.catalogLinked) {
+          current.externalResolved = true
+          current.status = 'Extern bevestigd'
+          current.articleNumber = candidate.code
+        }
+        if (candidate.catalogLinked) {
+          current.catalogLinked = true
+          current.status = 'Catalogus gekoppeld'
+          current.articleNumber = candidate.code
+        }
+      })
+    }
+
+    if (current.candidateCount > 0 && !current.externalResolved && !current.catalogLinked) {
+      current.status = 'Kandidaten gevonden'
+    }
+
+    grouped.set(key, current)
+  })
+
+  return Array.from(grouped.values()).map((row) => {
+    const unique = new Map()
+    row.candidates.forEach((candidate) => {
+      const key = `${candidate.source}|${candidate.code}|${candidate.name}`.toLowerCase()
+      const existing = unique.get(key)
+      if (!existing || Number(candidate.score || 0) > Number(existing.score || 0)) unique.set(key, candidate)
+    })
+    const candidates = Array.from(unique.values()).sort((a, b) => {
+      if (a.externalResolved !== b.externalResolved) return a.externalResolved ? -1 : 1
+      if (a.catalogLinked !== b.catalogLinked) return a.catalogLinked ? -1 : 1
+      return Number(b.score || 0) - Number(a.score || 0)
+    })
+    const best = candidates.find((candidate) => !candidate.fallback) || null
+    return {
+      ...row,
+      candidates,
+      bestCandidateName: valueText(best?.name, ''),
+      bestCandidateScore: best?.score ?? null,
+      candidateCount: candidates.filter((candidate) => !candidate.fallback).length,
+    }
+  })
+}
+
+export default function ReceiptItemsOverviewResolved({ onError, onMessage }) {
+  const [items, setItems] = useState([])
+  const [selectedItem, setSelectedItem] = useState(null)
+  const [selectedCandidateId, setSelectedCandidateId] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [isEnsuring, setIsEnsuring] = useState(false)
+  const [isConfirming, setIsConfirming] = useState(false)
+  const [page, setPage] = useState(1)
+  const [filter, setFilter] = useState('')
+
+  async function fetchItems() {
+    const response = await fetchJsonWithAuth('/api/external-databases/receipt-items?limit=500', { method: 'GET' })
+    const data = await response.json().catch(() => ({}))
+    if (!response.ok) throw new Error(data?.detail || 'Bonartikelen konden niet worden geladen')
+    return buildRows(Array.isArray(data?.items) ? data.items : [])
+  }
+
+  async function loadItems() {
+    setIsLoading(true)
+    try {
+      const rows = await fetchItems()
+      setItems(rows)
+      if (selectedItem) setSelectedItem(rows.find((row) => row.id === selectedItem.id) || null)
+    } catch (err) {
+      onError?.(err?.message || 'Bonartikelen konden niet worden geladen')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadItems()
+  }, [])
+
+  const filteredItems = useMemo(() => {
+    const normalized = filter.toLowerCase().trim()
+    if (!normalized) return items
+    return items.filter((item) => [item.receiptLineText, item.retailerCode, item.articleNumber, item.status, item.bestCandidateName].join(' ').toLowerCase().includes(normalized))
+  }, [items, filter])
+
+  const pageCount = Math.max(1, Math.ceil(filteredItems.length / PAGE_SIZE))
+  const currentPage = Math.min(page, pageCount)
+  const visibleItems = filteredItems.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
+  const selectedCandidate = selectedItem?.candidates?.find((candidate) => candidate.id === selectedCandidateId) || null
+  const canConfirmSelectedCandidate = Boolean(selectedCandidate && !selectedCandidate.externalResolved && !selectedCandidate.catalogLinked && !selectedCandidate.fallback && selectedCandidate.code && selectedCandidate.code !== '-')
+
+  async function ensureVisibleCandidates() {
+    if (!visibleItems.length) return
+    setIsEnsuring(true)
+    try {
+      const response = await fetchJsonWithAuth('/api/external-databases/receipt-items/ensure-candidates', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          include_below_threshold: true,
+          items: visibleItems.map((item) => ({
+            receipt_line_text: item.receiptLineText,
+            retailer_code: item.retailerCodeRaw || item.retailerCode,
+            purchase_import_line_id: item.purchaseImportLineId,
+            receipt_line_id: item.receiptLineId,
+            retailer_article_number: item.externalResolved ? item.articleNumber : '',
+            external_match_status: item.externalResolved ? 'external_resolved' : '',
+          })),
+        }),
+      })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data?.detail || 'Kandidaten bijlezen is mislukt')
+      await loadItems()
+      onMessage?.(`Bijlezen afgerond. Resolved overgeslagen: ${data?.external_resolved_skipped_count ?? 0}.`)
+    } catch (err) {
+      onError?.(err?.message || 'Kandidaten bijlezen is mislukt')
+    } finally {
+      setIsEnsuring(false)
+    }
+  }
+
+  async function confirmSelectedCandidate() {
+    if (!selectedCandidate) return
+    setIsConfirming(true)
+    try {
+      const response = await fetchJsonWithAuth('/api/external-databases/candidates/confirm-external', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ candidate_id: selectedCandidate.raw?.id || selectedCandidate.id }),
+      })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data?.detail || 'Externe kandidaat bevestigen is mislukt')
+      if (!data?.confirmed) throw new Error(data?.reason || 'Externe kandidaat is niet bevestigd')
+      onMessage?.(`Externe kandidaat bevestigd: ${data.external_product_code || selectedCandidate.code}`)
+      setSelectedCandidateId('')
+      await loadItems()
+    } catch (err) {
+      onError?.(err?.message || 'Externe kandidaat bevestigen is mislukt')
+    } finally {
+      setIsConfirming(false)
+    }
+  }
+
+  function openItem(item) {
+    setSelectedItem(item)
+    setSelectedCandidateId('')
+  }
+
+  return (
+    <div className="rz-external-receipt-overview">
+      <div className="rz-external-databases-section-header">
+        <h3>Bonartikelen voor externe herkenning</h3>
+        <div className="rz-external-databases-actions">
+          <Button type="button" variant="secondary" disabled={isLoading} onClick={loadItems}>{isLoading ? 'Laden...' : 'Vernieuwen'}</Button>
+          <Button type="button" variant="secondary" disabled={isEnsuring || !visibleItems.length} onClick={ensureVisibleCandidates}>{isEnsuring ? 'Bijlezen...' : 'Kandidaten bijlezen'}</Button>
+        </div>
+      </div>
+
+      <div className="rz-external-databases-muted">Bevestigen legt alleen externe artikelcode vast. Geen Mijn artikel, global product of voorraadmutatie.</div>
+      <div className="rz-external-databases-actions">
+        <input className="rz-table-filter" value={filter} onChange={(event) => { setFilter(event.target.value); setPage(1) }} placeholder="Zoek bonartikel, status of artikelcode" />
+      </div>
+
+      <div className="rz-table-scroll rz-table-scroll--wide">
+        <Table dataTestId="external-receipt-items-table" tableClassName="rz-external-receipt-table">
+          <thead>
+            <tr className="rz-table-header">
+              <th>Bonartikel</th>
+              <th>Winkelketen</th>
+              <th>Status</th>
+              <th>Externe artikelcode</th>
+              <th>Kandidaat</th>
+              <th className="rz-num">Score</th>
+              <th className="rz-num">Kandidaten</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visibleItems.length ? visibleItems.map((item) => (
+              <tr key={item.id} className={selectedItem?.id === item.id ? 'rz-row-active' : ''} onDoubleClick={() => openItem(item)}>
+                <td>{item.receiptLineText}</td>
+                <td>{item.retailerCode}</td>
+                <td>{item.status}</td>
+                <td>{item.articleNumber || '-'}</td>
+                <td>{item.bestCandidateName || '-'}</td>
+                <td className="rz-num">{scoreText(item.bestCandidateScore)}</td>
+                <td className="rz-num">{item.candidateCount}</td>
+              </tr>
+            )) : <tr><td colSpan="7">Geen bonartikelen beschikbaar voor externe herkenning.</td></tr>}
+          </tbody>
+        </Table>
+      </div>
+
+      <div className="rz-external-databases-pagination">
+        <Button type="button" variant="secondary" disabled={currentPage <= 1 || isEnsuring} onClick={() => setPage((value) => Math.max(1, value - 1))}>Vorige</Button>
+        <span className="rz-external-databases-page-indicator">Pagina {currentPage} van {pageCount}</span>
+        <Button type="button" variant="secondary" disabled={currentPage >= pageCount || isEnsuring} onClick={() => setPage((value) => Math.min(pageCount, value + 1))}>Volgende</Button>
+      </div>
+
+      <div className="rz-external-receipt-detail">
+        {selectedItem ? (
+          <>
+            <h3>Externe kandidaten voor: {selectedItem.receiptLineText}</h3>
+            <div className="rz-table-scroll">
+              <Table dataTestId="external-receipt-item-candidates-table" tableClassName="rz-external-candidate-detail-table">
+                <thead>
+                  <tr className="rz-table-header">
+                    <th>Keuze</th>
+                    <th>Kandidaat</th>
+                    <th>Score</th>
+                    <th>Merk</th>
+                    <th>Bron</th>
+                    <th>Externe code</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {selectedItem.candidates.length ? selectedItem.candidates.map((candidate) => (
+                    <tr key={candidate.id}>
+                      <td className="rz-check">
+                        <input type="radio" name="external-candidate-choice" checked={selectedCandidateId === candidate.id} onChange={() => setSelectedCandidateId(candidate.id)} />
+                      </td>
+                      <td>{candidate.name}</td>
+                      <td className="rz-num">{scoreText(candidate.score)}</td>
+                      <td>{candidate.brand}</td>
+                      <td>{candidate.source}</td>
+                      <td>{candidate.code}</td>
+                      <td>{candidate.status}</td>
+                    </tr>
+                  )) : <tr><td colSpan="7">Geen externe kandidaten gevonden voor dit bonartikel.</td></tr>}
+                </tbody>
+              </Table>
+            </div>
+            <div className="rz-external-databases-actions rz-external-detail-actions">
+              <Button type="button" disabled={!canConfirmSelectedCandidate || isConfirming} onClick={confirmSelectedCandidate}>
+                {isConfirming ? 'Bevestigen...' : 'Bevestig externe kandidaat'}
+              </Button>
+              <span className="rz-external-databases-muted">Status na bevestigen: Extern bevestigd.</span>
+            </div>
+          </>
+        ) : <p className="rz-external-databases-muted">Dubbelklik op een bonartikel om externe kandidaten te bekijken.</p>}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
M2C2i-23 — Bevestigde herkenning zichtbaar maken in UI-flow.

Doel:
- De Externe databases-UI gebruikt PO-taal: herkennen/bevestigen in plaats van koppelen/catalogus.
- Een bevestigde herkenning wordt zichtbaar als `Herkenning bevestigd`.
- De winkel-/broncode blijft zichtbaar in de hoofdregel en in detailkandidaten.
- Bevestigen gebruikt de M2C2i-22 confirm-flow en maakt geen catalogusproduct of Mijn artikel.
- Bij kandidaten bijlezen stuurt de UI bestaande winkel-/broncode/status mee, zodat M2C2i-20 bevestigde herkenningen kan overslaan.

Wijzigingen:
- Nieuw endpoint `POST /api/external-databases/candidates/confirm-external`.
- Nieuwe UI-component `ReceiptItemsOverviewResolved.jsx`.
- `ExternalDatabasesPage.jsx` gebruikt de resolved-aware overzichtscomponent.
- Hoofdregel toont `Herkenning bevestigd`.
- Detailkandidaten tonen bron, winkel-/broncode en status.
- Actieknop: `Bevestig herkenning`.
- Architectuur- en validatiedocumentatie bijgewerkt op PO-taal.

Niet gewijzigd:
- Geen automatische cataloguskoppeling.
- Geen `global_products`-aanmaak.
- Geen `product_identities`-aanmaak.
- Geen Mijn-artikel-aanmaak.
- Geen voorraadmutatie.
- Geen bonregeltypeclassificatie.

Safety:
- `creates_global_product = False`
- `creates_household_article = False`
- `creates_inventory_event = False`

Validatie:
- Pytest-vrije smoke opgenomen in `docs/release/M2C2i23_validation.md`.
- Opstartroutine bevat `Start-Sleep -Seconds 90`.