### PR TITLE
feat(external-db): surface learned concept candidates in existing flow

### DIFF
--- a/backend/app/services/external_candidate_normalization.py
+++ b/backend/app/services/external_candidate_normalization.py
@@ -9,6 +9,7 @@ SOURCE_PRIORITY = {
     "lidl_product_group": 90,
     "product_taxonomy_seed": 80,
     "OFF-index": 70,
+    "learned_receipt_line": 60,
     "receipt_product_intent_fallback": 10,
     "receipt_unresolved_fallback": 0,
 }
@@ -61,12 +62,22 @@ def _identity_key(candidate: dict[str, Any], evidence_packet: dict[str, Any] | N
     return f"name:{source_name}:{candidate_name}"
 
 
+def _candidate_status_for_result(result: dict[str, Any], primary: dict[str, Any]) -> str:
+    source_name = _source_name(result)
+    existing_status = str(primary.get("candidate_status") or result.get("candidate_status") or "").strip()
+    if source_name == "learned_receipt_line":
+        return "concept_candidate"
+    if float(result.get("score") or 0.0) >= 0.85:
+        return "probable_candidate"
+    return existing_status or "possible_candidate"
+
+
 def _merge_candidates(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
     primary, secondary = (incoming, existing) if _priority(incoming) > _priority(existing) else (existing, incoming)
     result = dict(primary)
 
     result["score"] = round(max(float(existing.get("score") or 0.0), float(incoming.get("score") or 0.0)), 3)
-    result["candidate_status"] = "probable_candidate" if result["score"] >= 0.85 else primary.get("candidate_status", "possible_candidate")
+    result["candidate_status"] = _candidate_status_for_result(result, primary)
     result["is_probable"] = result["score"] >= 0.85
 
     evidence_packet = primary.get("product_evidence_packet") or secondary.get("product_evidence_packet")
@@ -103,6 +114,10 @@ def normalize_external_candidates(candidates: list[dict[str, Any]], evidence_pac
         item.setdefault("source_name", item.get("candidate_source_name"))
         item.setdefault("source_product_code", item.get("candidate_source_product_code"))
         item.setdefault("retailer_article_number", item.get("candidate_source_product_code"))
+        if _source_name(item) == "learned_receipt_line":
+            item["candidate_status"] = "concept_candidate"
+            item["is_probable"] = False
+            item.setdefault("score_breakdown", {})["concept_candidate"] = True
         for flag in ["creates_global_product", "creates_household_article", "creates_inventory_event"]:
             item[flag] = False
 

--- a/backend/app/services/external_database_matchflow_evidence.py
+++ b/backend/app/services/external_database_matchflow_evidence.py
@@ -8,6 +8,72 @@ from app.services.external_database_matchers import match_retailer_receipt_line 
 from app.services.external_product_index_store import ensure_learned_external_product_candidate
 from app.services.product_evidence_packet import apply_product_evidence_to_candidates, build_product_evidence_packet_dict
 
+MIN_USEFUL_CANDIDATE_SCORE = 0.70
+NON_USEFUL_SOURCES = {
+    "receipt_unresolved_fallback",
+    "receipt_product_intent_fallback",
+}
+
+
+def _candidate_source(candidate: dict[str, Any]) -> str:
+    return str(candidate.get("candidate_source_name") or candidate.get("source_name") or "").strip()
+
+
+def _is_useful_candidate(candidate: dict[str, Any]) -> bool:
+    source_name = _candidate_source(candidate)
+    if source_name in NON_USEFUL_SOURCES:
+        return False
+    if source_name == "learned_receipt_line":
+        return True
+    status = str(candidate.get("candidate_status") or candidate.get("status") or "").strip().lower()
+    if status in {"probable_candidate", "user_confirmed", "external_database_override", "linked_to_catalog"}:
+        return True
+    return float(candidate.get("score") or 0.0) >= MIN_USEFUL_CANDIDATE_SCORE
+
+
+def _has_useful_candidate(candidates: list[dict[str, Any]]) -> bool:
+    return any(_is_useful_candidate(candidate) for candidate in candidates)
+
+
+def _append_learned_candidate(result: dict[str, Any], learned: dict[str, Any]) -> dict[str, Any]:
+    item = learned.get("item") or {}
+    if not item:
+        return result
+
+    candidate = {
+        "candidate_name": item.get("product_name") or result.get("receipt_line_text") or "Onbekend bonartikel",
+        "candidate_brand": item.get("brand") or result.get("retailer_code") or "",
+        "candidate_source_name": item.get("source_name") or "learned_receipt_line",
+        "candidate_source_product_code": item.get("source_product_code") or item.get("code") or "",
+        "source_name": item.get("source_name") or "learned_receipt_line",
+        "source_product_code": item.get("source_product_code") or item.get("code") or "",
+        "retailer_article_number": item.get("source_product_code") or item.get("code") or "",
+        "quantity_label": item.get("quantity") or item.get("net_content") or "",
+        "variant": "",
+        "source_url": item.get("source_url") or "",
+        "score": 0.71,
+        "score_breakdown": {"self_learning_concept_candidate": True},
+        "candidate_status": "concept_candidate",
+        "is_probable": False,
+        "is_user_confirmed": False,
+        "is_external_database_override": False,
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+        "created_by": "m2c2i20r_self_learning_candidate",
+    }
+
+    enriched = dict(result)
+    existing_candidates = list(enriched.get("candidates") or [])
+    source_code = str(candidate.get("candidate_source_product_code") or "").strip()
+    if source_code and not any(
+        str(existing.get("candidate_source_product_code") or existing.get("source_product_code") or existing.get("retailer_article_number") or "").strip() == source_code
+        for existing in existing_candidates
+    ):
+        existing_candidates.append(candidate)
+    enriched["candidates"] = existing_candidates
+    return enriched
+
 
 def _with_evidence_scoring(result: dict[str, Any], receipt_line_text: str, retailer_code: str) -> dict[str, Any]:
     candidates = list(result.get("candidates") or [])
@@ -41,8 +107,10 @@ def _match_with_self_learning(retailer_code: str, receipt_line_text: str, includ
         receipt_line_text=receipt_line_text,
         include_below_threshold=include_below_threshold,
     )
-    if result.get("candidates"):
+    initial_candidates = list(result.get("candidates") or [])
+    if _has_useful_candidate(initial_candidates):
         result["uses_self_learning_external_index"] = False
+        result["self_learning_reason"] = "useful_candidate_already_available"
         return result
 
     learned = ensure_learned_external_product_candidate(
@@ -54,13 +122,15 @@ def _match_with_self_learning(retailer_code: str, receipt_line_text: str, includ
         receipt_line_text=receipt_line_text,
         include_below_threshold=True,
     )
-    enriched = dict(learned_result)
+    enriched = _append_learned_candidate(dict(learned_result), learned)
     enriched["uses_self_learning_external_index"] = bool(learned.get("ok"))
     enriched["self_learning_external_index"] = {
         "learned": bool(learned.get("learned")),
         "reason": learned.get("reason"),
         "source_name": (learned.get("item") or {}).get("source_name"),
         "source_product_code": (learned.get("item") or {}).get("source_product_code"),
+        "trigger": "no_useful_candidate",
+        "initial_candidate_count": len(initial_candidates),
     }
     enriched["creates_global_product"] = False
     enriched["creates_household_article"] = False

--- a/docs/architecture/M2C2i20R_concept_candidates_ui_flow.md
+++ b/docs/architecture/M2C2i20R_concept_candidates_ui_flow.md
@@ -1,0 +1,55 @@
+# M2C2i-20R — Conceptkandidaat in bestaande UI-flow
+
+## Doel
+
+Een on the fly geleerde bonregel moet niet alleen in `external_product_index` staan, maar ook als kandidaat zichtbaar worden in de bestaande Externe databases-flow.
+
+```text
+onbekend bonartikel
+-> self-learning conceptkandidaat in external_product_index
+-> ensure-candidates slaat kandidaat op in external_product_candidates
+-> bestaande UI toont kandidaat onder het bonartikel
+-> geen frontendwijziging
+```
+
+## Uitgangspunt
+
+M2C2i-20R bouwt voort op M2C2i-19R.
+
+Er komt geen nieuwe frontend. De bestaande Externe databases-UI blijft leidend.
+
+## Conceptkandidaat
+
+Een geleerde kandidaat krijgt bron:
+
+```text
+source_name = learned_receipt_line
+candidate_status = concept_candidate
+```
+
+Deze status betekent:
+
+```text
+Rezzerv heeft deze kandidaat zelf afgeleid uit de bonregel.
+De gebruiker heeft hem nog niet bevestigd.
+Het is geen Rezzerv-artikel.
+```
+
+## Safety
+
+M2C2i-20R maakt niets aan in het Rezzerv-artikeldomein.
+
+```text
+creates_global_product = false
+creates_household_article = false
+creates_inventory_event = false
+```
+
+## Buiten scope
+
+- Geen nieuwe frontend.
+- Geen bevestigingsflow.
+- Geen Mijn-artikel-aanmaak.
+- Geen voorraadmutatie.
+- Geen cataloguskoppeling.
+- Geen resolved-state gate.

--- a/docs/release/M2C2i20R_validation.md
+++ b/docs/release/M2C2i20R_validation.md
@@ -2,7 +2,7 @@
 
 ## Doelvalidatie
 
-Aantonen dat een onbekende bonregel als conceptkandidaat wordt geleerd en via de bestaande candidate-save/ensure-flow in `external_product_candidates` terechtkomt.
+Aantonen dat een onbekende Lidl-bonregel als conceptkandidaat wordt geleerd en via de bestaande candidate-save/ensure-flow in `external_product_candidates` terechtkomt, ook wanneer de oude matcher alleen zwakke of niet-bruikbare kandidaten teruggeeft.
 
 ## Opstartroutine
 
@@ -22,9 +22,9 @@ Start-Sleep -Seconds 90
 from app.db import engine
 from sqlalchemy import text
 from app.services.external_product_candidate_store import build_candidate_context_key, list_saved_external_product_candidates
-from app.services.external_database_matchflow_evidence import ensure_external_receipt_item_candidates
+from app.services.external_database_matchflow_evidence import ensure_external_receipt_item_candidates, match_retailer_receipt_line
 
-receipt_text = "M2C2i20R onbekende UI flow testregel"
+receipt_text = "M2C2i20R onbekende Lidl bonregel zonder zinvolle match"
 retailer_code = "lidl"
 line_id = "m2c2i20r-smoke-line"
 context_key = build_candidate_context_key(retailer_code, receipt_text, purchase_import_line_id=line_id)
@@ -32,6 +32,12 @@ context_key = build_candidate_context_key(retailer_code, receipt_text, purchase_
 with engine.begin() as conn:
     conn.execute(text("DELETE FROM external_product_candidates WHERE context_key = :context_key"), {"context_key": context_key})
     conn.execute(text("DELETE FROM external_product_index WHERE source_name = 'learned_receipt_line' AND product_name = :name"), {"name": receipt_text})
+
+preview = match_retailer_receipt_line(retailer_code, receipt_text, include_below_threshold=True)
+assert preview["candidates"]
+assert preview["uses_self_learning_external_index"] is True
+assert preview["self_learning_external_index"]["trigger"] == "no_useful_candidate"
+assert any(candidate.get("candidate_source_name") == "learned_receipt_line" for candidate in preview["candidates"])
 
 result = ensure_external_receipt_item_candidates(
     items=[{
@@ -84,7 +90,7 @@ M2C2i-20R smoke OK: conceptkandidaat komt in bestaande candidate-flow zonder pro
 
 1. Open `http://localhost:5174/externe-databases`.
 2. Gebruik de bestaande UI.
-3. Kies een onbekend bonartikel.
+3. Kies een onbekend Lidl-bonartikel.
 4. Klik de bestaande actie om kandidaten bij te lezen.
 5. Controleer dat er een kandidaat verschijnt.
 6. Controleer dat er geen Mijn artikel en geen voorraadmutatie ontstaat.
@@ -92,6 +98,7 @@ M2C2i-20R smoke OK: conceptkandidaat komt in bestaande candidate-flow zonder pro
 ## GO-criteria
 
 - Onbekende bonregel levert een `concept_candidate` op.
+- Ook bij zwakke oude Lidl-kandidaten wordt alsnog een self-learning kandidaat toegevoegd.
 - De kandidaat staat in `external_product_candidates`.
 - De kandidaat gebruikt bron `learned_receipt_line`.
 - De tweede run maakt geen dubbele nieuwe kandidaat.

--- a/docs/release/M2C2i20R_validation.md
+++ b/docs/release/M2C2i20R_validation.md
@@ -1,0 +1,101 @@
+# M2C2i-20R — Validatie
+
+## Doelvalidatie
+
+Aantonen dat een onbekende bonregel als conceptkandidaat wordt geleerd en via de bestaande candidate-save/ensure-flow in `external_product_candidates` terechtkomt.
+
+## Opstartroutine
+
+```powershell
+cd C:\Users\Gebruiker\Rezzerv_Github
+git fetch origin
+git switch m2c2i20r-concept-candidates-ui-flow
+git pull --ff-only origin m2c2i20r-concept-candidates-ui-flow
+docker compose up -d --build backend frontend
+Start-Sleep -Seconds 90
+```
+
+## Smoke zonder pytest
+
+```powershell
+@'
+from app.db import engine
+from sqlalchemy import text
+from app.services.external_product_candidate_store import build_candidate_context_key, list_saved_external_product_candidates
+from app.services.external_database_matchflow_evidence import ensure_external_receipt_item_candidates
+
+receipt_text = "M2C2i20R onbekende UI flow testregel"
+retailer_code = "lidl"
+line_id = "m2c2i20r-smoke-line"
+context_key = build_candidate_context_key(retailer_code, receipt_text, purchase_import_line_id=line_id)
+
+with engine.begin() as conn:
+    conn.execute(text("DELETE FROM external_product_candidates WHERE context_key = :context_key"), {"context_key": context_key})
+    conn.execute(text("DELETE FROM external_product_index WHERE source_name = 'learned_receipt_line' AND product_name = :name"), {"name": receipt_text})
+
+result = ensure_external_receipt_item_candidates(
+    items=[{
+        "retailer_code": retailer_code,
+        "receipt_line_text": receipt_text,
+        "purchase_import_line_id": line_id,
+    }],
+    include_below_threshold=True,
+)
+
+assert result["ok"] is True
+assert result["processed"] == 1
+assert result["saved_count"] >= 1 or result["updated_count"] >= 1
+assert result["creates_global_product"] is False
+assert result["creates_household_article"] is False
+assert result["creates_inventory_event"] is False
+
+saved = list_saved_external_product_candidates(context_key=context_key, limit=10)
+items = saved["items"]
+assert items
+assert any(item.get("candidate_source_name") == "learned_receipt_line" for item in items)
+assert any(item.get("candidate_status") == "concept_candidate" for item in items)
+assert all(not item.get("global_product_id") for item in items)
+
+second = ensure_external_receipt_item_candidates(
+    items=[{
+        "retailer_code": retailer_code,
+        "receipt_line_text": receipt_text,
+        "purchase_import_line_id": line_id,
+    }],
+    include_below_threshold=True,
+)
+assert second["ok"] is True
+assert second["saved_count"] == 0
+assert second["creates_global_product"] is False
+assert second["creates_household_article"] is False
+assert second["creates_inventory_event"] is False
+
+print("M2C2i-20R smoke OK: conceptkandidaat komt in bestaande candidate-flow zonder productmutaties.")
+'@ | docker compose exec -T backend python
+```
+
+Verwacht:
+
+```text
+M2C2i-20R smoke OK: conceptkandidaat komt in bestaande candidate-flow zonder productmutaties.
+```
+
+## PO-test
+
+1. Open `http://localhost:5174/externe-databases`.
+2. Gebruik de bestaande UI.
+3. Kies een onbekend bonartikel.
+4. Klik de bestaande actie om kandidaten bij te lezen.
+5. Controleer dat er een kandidaat verschijnt.
+6. Controleer dat er geen Mijn artikel en geen voorraadmutatie ontstaat.
+
+## GO-criteria
+
+- Onbekende bonregel levert een `concept_candidate` op.
+- De kandidaat staat in `external_product_candidates`.
+- De kandidaat gebruikt bron `learned_receipt_line`.
+- De tweede run maakt geen dubbele nieuwe kandidaat.
+- Geen nieuwe frontend.
+- Geen `global_products`-aanmaak.
+- Geen Mijn-artikel-aanmaak.
+- Geen voorraadmutatie.


### PR DESCRIPTION
GESLOTEN OP PO-BESLUIT.

Reden:
- Het principe `learned_receipt_line` / `concept_candidate` / self-learning fallback wordt verworpen.
- Een fallback-artikel dat feitelijk alleen de bonregel zelf teruggeeft heeft geen functionele waarde.
- Geen fallback-artikel, geen concept_candidate en geen self-learning pseudo-artikel.

Actie:
- Deze PR wordt niet gemerged.
- Lokale database moet worden opgeschoond op `learned_receipt_line` en `concept_candidate` records.
- Ontwikkeling gaat terug naar rollbackbasis `63cd33ef` / branch `rollback-m2c2i18`.