### PR TITLE
feat(receipts): recognize wine intent without fallback candidates

### DIFF
--- a/backend/app/data/receipt_intent_overrides.json
+++ b/backend/app/data/receipt_intent_overrides.json
@@ -1,0 +1,13 @@
+{
+  "version": "m2c2i21s-receipt-intent-overrides-v1",
+  "overrides": [
+    {
+      "intent_key": "wijn",
+      "category": "Wijn",
+      "product_type": "Rode wijn",
+      "trigger_terms": ["malbec"],
+      "variant_terms": ["malbec", "argentijnse", "argentijns", "argentinie", "argentinie"],
+      "search_terms": ["wijn", "rode wijn", "malbec", "argentijnse malbec"]
+    }
+  ]
+}

--- a/backend/app/data/receipt_intent_overrides.json
+++ b/backend/app/data/receipt_intent_overrides.json
@@ -6,7 +6,7 @@
       "category": "Wijn",
       "product_type": "Rode wijn",
       "trigger_terms": ["malbec"],
-      "variant_terms": ["malbec", "argentijnse", "argentijns", "argentinie", "argentinie"],
+      "variant_terms": ["malbec", "argentijnse", "argentijns", "argentinie"],
       "search_terms": ["wijn", "rode wijn", "malbec", "argentijnse malbec"]
     }
   ]

--- a/backend/app/services/receipt_product_intent_analyzer.py
+++ b/backend/app/services/receipt_product_intent_analyzer.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import asdict, dataclass
+from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 from app.services.product_intent_classifier import classify_product_intent
@@ -20,6 +23,7 @@ QUANTITY_PATTERN = re.compile(
 )
 
 STOPWORDS = {"de", "het", "een", "en", "of", "met", "voor", "van"}
+INTENT_OVERRIDES_PATH = Path(__file__).resolve().parents[1] / "data" / "receipt_intent_overrides.json"
 
 
 @dataclass(frozen=True)
@@ -38,6 +42,22 @@ class ReceiptProductAnalysis:
     retailer_catalog_match: dict[str, Any]
     retailer_catalog_terms: list[str]
     requires_user_confirmation: bool
+
+
+@lru_cache(maxsize=1)
+def _load_intent_overrides() -> tuple[dict[str, Any], ...]:
+    if not INTENT_OVERRIDES_PATH.exists():
+        return tuple()
+    payload = json.loads(INTENT_OVERRIDES_PATH.read_text(encoding="utf-8"))
+    return tuple(dict(item) for item in (payload.get("overrides") or []))
+
+
+def _match_intent_override(normalized_text: str) -> dict[str, Any] | None:
+    for item in _load_intent_overrides():
+        trigger_terms = [normalize_taxonomy_text(term) for term in (item.get("trigger_terms") or [])]
+        if any(term and contains_taxonomy_term(normalized_text, term) for term in trigger_terms):
+            return item
+    return None
 
 
 def _extract_quantity(normalized_text: str) -> tuple[str, str, str]:
@@ -67,6 +87,17 @@ def _extract_variant_matches(normalized_text: str, product_intent: str) -> list[
     return matches
 
 
+def _override_variant_terms(normalized_text: str, override: dict[str, Any] | None) -> list[str]:
+    if not override:
+        return []
+    result: list[str] = []
+    for term in override.get("variant_terms") or []:
+        normalized_term = normalize_taxonomy_text(term)
+        if normalized_term and contains_taxonomy_term(normalized_text, normalized_term):
+            result.append(normalized_term)
+    return result
+
+
 def _deduplicate(values: list[str]) -> list[str]:
     result: list[str] = []
     seen: set[str] = set()
@@ -87,6 +118,7 @@ def _build_searchable_terms(
     variant_matches: list[dict[str, Any]],
     quantity_label: str,
     retailer_catalog_terms: list[str] | None = None,
+    override_terms: list[str] | None = None,
 ) -> list[str]:
     tokens = [token for token in normalized_text.split() if len(token) >= 3 and token not in STOPWORDS]
     variant_terms = [str(match.get("normalized_variant_term") or "") for match in variant_matches]
@@ -105,6 +137,7 @@ def _build_searchable_terms(
         product_type,
         *variant_terms,
         *variant_search_terms,
+        *(override_terms or []),
         quantity_label,
         *(retailer_catalog_terms or []),
         *tokens,
@@ -116,14 +149,27 @@ def analyze_receipt_product_line(receipt_line_text: str | None, retailer_code: s
     normalized_text = normalize_taxonomy_text(raw_text)
     normalized_retailer = normalize_taxonomy_text(retailer_code)
     product_intent = classify_product_intent(normalized_text, retailer_code=normalized_retailer)
+    intent_override = None if product_intent else _match_intent_override(normalized_text)
+    if intent_override:
+        product_intent = str(intent_override.get("intent_key") or "").strip()
+
     taxonomy_metadata = get_taxonomy_metadata_for_intent(product_intent)
     category = taxonomy_metadata.get("category") or ""
     product_type = taxonomy_metadata.get("product_type") or ""
+    if intent_override:
+        category = str(intent_override.get("category") or category or "").strip()
+        product_type = str(intent_override.get("product_type") or product_type or "").strip()
+
     quantity_amount, quantity_unit, quantity_label = _extract_quantity(normalized_text)
     variant_matches = _extract_variant_matches(normalized_text, product_intent)
-    variant_terms = _deduplicate([str(match.get("normalized_variant_term") or "") for match in variant_matches])
+    override_variant_terms = _override_variant_terms(normalized_text, intent_override)
+    variant_terms = _deduplicate([
+        *[str(match.get("normalized_variant_term") or "") for match in variant_matches],
+        *override_variant_terms,
+    ])
     retailer_catalog_match = enrich_receipt_product_line_dict(raw_text, retailer_code=normalized_retailer)
     retailer_catalog_terms = list(retailer_catalog_match.get("search_terms") or [])
+    override_search_terms = [str(term or "") for term in ((intent_override or {}).get("search_terms") or [])]
     searchable_terms = _build_searchable_terms(
         normalized_text=normalized_text,
         product_intent=product_intent,
@@ -132,6 +178,7 @@ def analyze_receipt_product_line(receipt_line_text: str | None, retailer_code: s
         variant_matches=variant_matches,
         quantity_label=quantity_label,
         retailer_catalog_terms=retailer_catalog_terms,
+        override_terms=[*override_variant_terms, *override_search_terms],
     )
 
     return ReceiptProductAnalysis(
@@ -139,8 +186,8 @@ def analyze_receipt_product_line(receipt_line_text: str | None, retailer_code: s
         normalized_text=normalized_text,
         retailer_code=normalized_retailer,
         product_intent=product_intent,
-        category=category,
-        product_type=product_type,
+        category=normalize_taxonomy_text(category),
+        product_type=normalize_taxonomy_text(product_type),
         variant_terms=variant_terms,
         quantity_amount=quantity_amount,
         quantity_unit=quantity_unit,

--- a/docs/architecture/M2C2i21S_wine_intent_no_fallback.md
+++ b/docs/architecture/M2C2i21S_wine_intent_no_fallback.md
@@ -1,0 +1,73 @@
+# M2C2i-21S — Wijn-intent herkennen zonder fallback
+
+## Doel
+
+Rezzerv moet bonregel `Argentijnse Malbec` inhoudelijk kunnen duiden als wijn, zonder daar automatisch een kandidaatartikel van te maken.
+
+```text
+Argentijnse Malbec
+-> product_intent = wijn
+-> product_type = rode wijn
+-> variant_terms bevat argentijnse en malbec
+-> geen echte brondata?
+-> geen kandidaat
+```
+
+## Uitgangspunt
+
+M2C2i-21S bouwt voort op M2C2i-20S.
+
+M2C2i-20S voegde diagnose toe. M2C2i-21S verbetert de analyse-laag zodat de diagnose beter uitlegt wat de bonregel betekent.
+
+## Geen fallback
+
+Deze stap maakt nog steeds geen pseudo-kandidaat.
+
+Niet toegestaan:
+
+```text
+receipt_product_intent_fallback
+receipt_unresolved_fallback
+learned_receipt_line
+concept_candidate
+```
+
+## Nieuwe data
+
+Nieuwe intent-overrides staan los van `external_product_index`:
+
+```text
+backend/app/data/receipt_intent_overrides.json
+```
+
+Deze data is alleen bedoeld voor analyse, niet voor kandidaatgeneratie.
+
+## Nieuwe analyse
+
+Voor `Argentijnse Malbec` verwacht de diagnose:
+
+```text
+product_intent = wijn
+category = wijn
+product_type = rode wijn
+variant_terms bevat argentijnse en malbec
+real_candidate_count = 0 zolang echte brondata ontbreekt
+```
+
+## Safety
+
+```text
+writes_database = false
+creates_global_product = false
+creates_household_article = false
+creates_inventory_event = false
+```
+
+## Buiten scope
+
+- Geen echte wijncatalogus toevoegen.
+- Geen kandidaat maken voor Malbec.
+- Geen self-learning.
+- Geen fallback.
+- Geen frontendwijziging.
+- Geen voorraadmutatie.

--- a/docs/release/M2C2i21S_validation.md
+++ b/docs/release/M2C2i21S_validation.md
@@ -1,0 +1,93 @@
+# M2C2i-21S — Validatie
+
+## Doelvalidatie
+
+Aantonen dat `Argentijnse Malbec` wordt herkend als wijn, zonder fallback-kandidaat en zonder database-write.
+
+## Opstartroutine
+
+```powershell
+cd C:\Users\Gebruiker\Rezzerv_Github
+git fetch origin
+git switch m2c2i21s-wine-intent-no-fallback
+git pull --ff-only origin m2c2i21s-wine-intent-no-fallback
+docker compose up -d --build backend frontend
+Start-Sleep -Seconds 90
+```
+
+## Smoke zonder pytest
+
+```powershell
+@'
+from app.services.external_candidate_diagnostics import diagnose_real_candidate_coverage
+
+result = diagnose_real_candidate_coverage(
+    retailer_code='lidl',
+    receipt_line_text='Argentijnse Malbec',
+    include_below_threshold=True,
+)
+
+analysis = result['receipt_analysis']
+assert result['ok'] is True
+assert result['writes_database'] is False
+assert result['creates_global_product'] is False
+assert result['creates_household_article'] is False
+assert result['creates_inventory_event'] is False
+assert result['uses_coverage_fallback'] is False
+assert result['uses_legacy_fallback'] is False
+assert result['has_forbidden_fallback_candidate'] is False
+assert result['forbidden_candidate_count'] == 0
+
+assert analysis['product_intent'] == 'wijn'
+assert analysis['category'] == 'wijn'
+assert analysis['product_type'] == 'rode wijn'
+assert 'malbec' in analysis['variant_terms']
+assert 'argentijnse' in analysis['variant_terms']
+assert analysis['retailer_catalog_matched'] is False
+
+assert result['real_candidate_count'] == 0
+assert result['candidate_count'] == 0
+assert result['candidate_source'] in {'no_real_candidate', 'external_product_index_no_match'}
+
+print('M2C2i-21S smoke OK: Argentijnse Malbec wordt wijn-intent zonder fallback-kandidaat.')
+'@ | docker compose exec -T backend python
+```
+
+Verwacht:
+
+```text
+M2C2i-21S smoke OK: Argentijnse Malbec wordt wijn-intent zonder fallback-kandidaat.
+```
+
+## API-test
+
+```powershell
+Invoke-RestMethod `
+  -Method Post `
+  -Uri "http://localhost:8011/api/external-databases/retailers/lidl/diagnose-real-candidates" `
+  -ContentType "application/json" `
+  -Body '{"receipt_line_text":"Argentijnse Malbec","include_below_threshold":true}'
+```
+
+Controleer:
+
+```text
+receipt_analysis.product_intent = wijn
+receipt_analysis.product_type = rode wijn
+receipt_analysis.variant_terms bevat malbec en argentijnse
+real_candidate_count = 0
+candidate_count = 0
+uses_coverage_fallback = false
+writes_database = false
+```
+
+## GO-criteria
+
+- `Argentijnse Malbec` wordt als wijn geduid.
+- Er wordt geen kandidaat gemaakt zolang echte brondata ontbreekt.
+- Geen fallback.
+- Geen self-learning.
+- Geen database-write.
+- Geen frontendwijziging.
+- Geen Mijn-artikel-aanmaak.
+- Geen voorraadmutatie.


### PR DESCRIPTION
M2C2i-21S — Wijn-intent herkennen zonder fallback.

Base:
- Gestapeld op `m2c2i20s-real-candidate-diagnostics`.
- Recovery-lijn vanaf rollbackbasis `63cd33ef`.

Doel:
- `Argentijnse Malbec` inhoudelijk herkennen als wijn/rode wijn.
- Variantinformatie `argentijnse` en `malbec` zichtbaar maken in de diagnose.
- Geen kandidaat maken zolang echte externe/catalogusbrondata ontbreekt.

Wijzigingen:
- Nieuwe analyse-data: `backend/app/data/receipt_intent_overrides.json`.
- `receipt_product_intent_analyzer.py` gebruikt intent-overrides alleen voor analyse.
- Intent-overrides worden niet naar `external_product_index` geschreven.
- Documentatie en validatie toegevoegd.

Niet gewijzigd:
- Geen fallback.
- Geen self-learning.
- Geen JSON-uitbreiding voor kandidaatdata.
- Geen echte wijncatalogus toegevoegd.
- Geen nieuwe frontend.
- Geen kandidaatbevestiging.
- Geen `global_products`-aanmaak.
- Geen `product_identities`-aanmaak.
- Geen Mijn-artikel-aanmaak.
- Geen voorraadmutatie.

Safety:
- `writes_database = False`
- `creates_global_product = False`
- `creates_household_article = False`
- `creates_inventory_event = False`

Validatie:
- Pytest-vrije smoke opgenomen in `docs/release/M2C2i21S_validation.md`.
- API-smoke met `Argentijnse Malbec` opgenomen.
- Opstartroutine bevat `Start-Sleep -Seconds 90`.