### PR TITLE
data(external-db): add real Lidl Malbec source row

### DIFF
--- a/backend/app/data/lidl_catalog_enrichment_seed.json
+++ b/backend/app/data/lidl_catalog_enrichment_seed.json
@@ -1,5 +1,5 @@
 {
-  "version": "m2c2i18-lidl-catalog-enrichment-v2",
+  "version": "m2c2i22s-lidl-catalog-enrichment-v3",
   "rules": [
     {
       "receipt_terms": ["mexicaanse kruiden", "mexicaanse kruidenm", "mexicaanse kruidenmix", "mexicaanse kruidenm", "taco kruidenmix", "burrito kruidenmix", "fajita kruidenmix"],
@@ -384,6 +384,18 @@
       "source_url": "",
       "confidence": 0.9,
       "search_terms": ["winterpeen", "carrot"]
+    },
+    {
+      "receipt_terms": ["argentijnse malbec", "malbec", "rode wijn malbec"],
+      "source_product_code": "lidl:wijn.argentijnse-malbec",
+      "catalog_product_name": "Lidl Argentijnse Malbec",
+      "brand": "Lidl Wijn",
+      "category": "Wijn",
+      "product_type": "Rode wijn",
+      "quantity_label": "1 fles",
+      "source_url": "",
+      "confidence": 0.9,
+      "search_terms": ["argentijnse malbec", "malbec", "argentijnse", "rode wijn", "wijn"]
     }
   ]
 }


### PR DESCRIPTION
M2C2i-22S — Echte bronkandidaat voor wijn/Malbec zonder fallback.

Base:
- Gestapeld op `m2c2i21s-wine-intent-no-fallback`.

Doel:
- `Argentijnse Malbec` krijgt nu een echte bronregel in de Lidl-catalogusverrijking.
- Daarmee mag de diagnose een echte kandidaat teruggeven.
- Dit blijft strikt gescheiden van Mijn artikel, voorraad en globale productcreatie.

Wijziging:
- `backend/app/data/lidl_catalog_enrichment_seed.json`
  - versie naar `m2c2i22s-lidl-catalog-enrichment-v3`
  - één bronregel toegevoegd:
    - `source_product_code = lidl:wijn.argentijnse-malbec`
    - `catalog_product_name = Lidl Argentijnse Malbec`
    - `category = Wijn`
    - `product_type = Rode wijn`
    - search terms: `argentijnse malbec`, `malbec`, `argentijnse`, `rode wijn`, `wijn`

Niet gewijzigd:
- Geen fallback.
- Geen self-learning.
- Geen `concept_candidate`.
- Geen `learned_receipt_line`.
- Geen `global_products`-aanmaak.
- Geen `product_identities`-aanmaak.
- Geen Mijn-artikel-aanmaak.
- Geen voorraadmutatie.
- Geen frontendwijziging.

Verwachte validatie:
```text
Argentijnse Malbec
→ product_intent = wijn
→ product_type = rode wijn
→ retailer_catalog_matched = true
→ candidate_count >= 1
→ real_candidate_count >= 1
→ candidate_source_name = lidl_catalog_enrichment
→ candidate_source_product_code = lidl:wijn.argentijnse-malbec
→ uses_coverage_fallback = false
→ writes_database = false
```

Lokale PO-validatie door gebruiker:
- JSON-validatie OK via `python -m json.tool backend/app/data/lidl_catalog_enrichment_seed.json > $null`.
- Diff is schoon: `1 file changed, 13 insertions(+), 1 deletion(-)`.