### PR TITLE
M2C2i-26 — Spaarzegels financial-only en generieke normalisatie

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,6 +29,7 @@ RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
 
 COPY app ./app
 COPY receipt_ingestion ./receipt_ingestion
+COPY tests ./tests
 COPY sitecustomize.py ./sitecustomize.py
 COPY VERSION.txt ./VERSION.txt
 

--- a/backend/app/data/receipt_spaarzegels_terms.json
+++ b/backend/app/data/receipt_spaarzegels_terms.json
@@ -1,0 +1,42 @@
+{
+  "metadata_tokens": [
+    "zegel",
+    "zegels",
+    "koopzegel",
+    "koopzegels",
+    "pluspunten",
+    "pluspunt",
+    "spaar",
+    "spaarkaart",
+    "bonuskaart",
+    "klantnummer",
+    "klant:",
+    "digitale zegels",
+    "digitale spaarkaart",
+    "campagne",
+    "punten saldo",
+    "saldo punten",
+    "plus punten",
+    "persoonlijke bonus"
+  ],
+  "priced_tokens": [
+    "zegel",
+    "zegels",
+    "koopzegel",
+    "koopzegels",
+    "pluspunten",
+    "pluspunt"
+  ],
+  "value_label_patterns": [
+    "koopzegels?(?:\\s+premium)?",
+    "pluspunten?"
+  ],
+  "non_product_label_tokens": [
+    "koopzegel",
+    "koopzegels",
+    "zegel",
+    "zegels",
+    "punten",
+    "saldo"
+  ]
+}

--- a/backend/app/receipt_ingestion/line_classifier.py
+++ b/backend/app/receipt_ingestion/line_classifier.py
@@ -6,7 +6,7 @@ Technical Design Reference:
 - Used By: see docs/technical/PYTHON-MODULE-CATALOG.md
 - Depends On: see generated inventory
 - Reads Data: see generated inventory
-- Writes Data: see generated inventory
+- Writes Data: no
 - Status Authority: no
 - Refactor Status: classify
 """
@@ -18,6 +18,12 @@ from collections.abc import Callable
 from typing import Any
 
 from app.receipt_ingestion.profiles.aldi import is_aldi_context, is_aldi_non_product_line
+from app.receipt_ingestion.spaarzegels_terms import (
+    contains_spaarzegels_metadata_token,
+    contains_spaarzegels_priced_token,
+    matches_spaarzegels_value_label,
+    spaarzegels_metadata_tokens,
+)
 
 BLOCKING_CLASSIFICATIONS = {'ignore', 'metadata', 'footer_payment_tax'}
 FOOTER_TOKENS = ('btw', 'vat', 'totaal', 'subtotaal', 'betaal', 'bankpas', 'pin', 'terminal', 'transactie')
@@ -45,11 +51,6 @@ GENERIC_DISCOUNT_TOKENS = (
     'korting', 'bonus', 'actie', 'prijsvoordeel', 'jouw voordeel', 'uw voordeel',
     'lidl plus korting', 'totaal korting', 'coupon', 'voucher', 'gratis',
 )
-GENERIC_LOYALTY_TOKENS = (
-    'zegel', 'zegels', 'koopzegel', 'koopzegels', 'pluspunten', 'pluspunt',
-    'spaar', 'spaarkaart', 'loyalty', 'bonuskaart', 'klantnummer', 'klant:',
-    'digitale zegels', 'digitale spaarkaart', 'campagne', 'punten saldo', 'saldo punten',
-)
 GENERIC_METADATA_TOKENS = (
     'openingstijd', 'openingstijden', 'ma-vr', 'ma tm', 'ma t/m', 'periode',
     'filiaal', 'kassa', 'kassabon', 'bonnr', 'bon nr', 'bonnummer', 'referentie',
@@ -63,8 +64,6 @@ PRICED_DISCOUNT_ARTICLE_TOKENS = (
     'korting', 'bonus', 'actie', 'prijsvoordeel', 'jouw voordeel', 'uw voordeel',
     'lidl plus korting', 'totaal korting',
 )
-PRICED_LOYALTY_ARTICLE_TOKENS = ('zegel', 'zegels', 'koopzegel', 'koopzegels', 'pluspunten', 'pluspunt')
-VALUE_LINE_LABEL_PATTERNS = (r'koopzegels?(?:\s+premium)?', r'pluspunten?')
 
 
 def _default_false(_: str) -> bool:
@@ -80,8 +79,7 @@ def _has_amount(value: str) -> bool:
 
 
 def _is_value_line_label_without_amount(lowered: str) -> bool:
-    normalized = re.sub(r'\s+', ' ', str(lowered or '').strip().lower())
-    return any(re.fullmatch(pattern, normalized) for pattern in VALUE_LINE_LABEL_PATTERNS)
+    return matches_spaarzegels_value_label(lowered)
 
 
 def _token_match(lowered: str, tokens: tuple[str, ...]) -> str | None:
@@ -100,7 +98,7 @@ def _priced_article_value_token(lowered: str) -> str | None:
         return None
     if _token_match(lowered, GENERIC_DEPOSIT_RETURN_TOKENS):
         return None
-    return _token_match(lowered, PRICED_LOYALTY_ARTICLE_TOKENS) or _token_match(lowered, PRICED_DISCOUNT_ARTICLE_TOKENS)
+    return contains_spaarzegels_priced_token(lowered) or _token_match(lowered, PRICED_DISCOUNT_ARTICLE_TOKENS)
 
 
 def _footer_or_metadata(lowered: str) -> str:
@@ -147,11 +145,11 @@ def _generic_non_article_trace(line: str) -> dict[str, Any] | None:
             return _decision(classification, rule, token)
     token = _priced_article_value_token(lowered)
     if token:
-        return _decision('product_candidate', 'GENERIC_PRICED_DISCOUNT_OR_LOYALTY_LINE', token)
+        return _decision('product_candidate', 'GENERIC_PRICED_DISCOUNT_OR_SPAARZEGELS_LINE', token)
     for tokens, classification, rule in (
         (GENERIC_TOTAL_TOKENS, 'footer_payment_tax', 'GENERIC_TOTAL_TOKENS'),
         (GENERIC_DISCOUNT_TOKENS, 'footer_payment_tax', 'GENERIC_DISCOUNT_TOKENS'),
-        (GENERIC_LOYALTY_TOKENS, 'metadata', 'GENERIC_LOYALTY_TOKENS'),
+        (spaarzegels_metadata_tokens(), 'metadata', 'GENERIC_SPAARZEGELS_TERMS'),
     ):
         token = _token_match(lowered, tokens)
         if token:
@@ -202,10 +200,10 @@ def _store_specific_non_article_trace(line: str, store_name: str | None = None, 
     if 'plus' in store_key:
         token = _priced_article_value_token(lowered)
         if token:
-            return _decision('product_candidate', 'PLUS_PRICED_DISCOUNT_OR_LOYALTY_LINE', token, stage='store_specific')
-        token = _token_match(lowered, ('pluspunten', 'plus punten', 'digitale spaarkaart', 'spaarkaart', 'klant:', 'klantnummer', 'koopzegels', 'zegels', 'zegel', 'punten saldo', 'saldo punten', 'persoonlijke bonus'))
+            return _decision('product_candidate', 'PLUS_PRICED_DISCOUNT_OR_SPAARZEGELS_LINE', token, stage='store_specific')
+        token = contains_spaarzegels_metadata_token(lowered)
         if token:
-            return _decision('metadata', 'PLUS_LOYALTY_TOKENS', token, stage='store_specific')
+            return _decision('metadata', 'PLUS_SPAARZEGELS_TERMS', token, stage='store_specific')
         token = _token_match(lowered, ('plus', 'bedankt', 'welkom', 'filiaal', 'kassabon', 'www.', 'kvk', 'iban', 'tel', 'servicebalie', 'klantenservice'))
         if token and not re.search(r'\d+[,.]\d{2}', lowered):
             return _decision('metadata', 'PLUS_METADATA_TOKENS_NO_AMOUNT', token, stage='store_specific')
@@ -239,8 +237,8 @@ def _non_article_reason(classification: str | None, line: str) -> str:
             return 'date_or_time_metadata'
         if any(day in lowered for day in DUTCH_DAY_TOKENS):
             return 'date_or_period_metadata'
-        if any(token in lowered for token in ('pluspunten', 'spaarkaart', 'koopzegel', 'klantnummer', 'zegels', 'bonuskaart')):
-            return 'loyalty_or_savings_metadata'
+        if contains_spaarzegels_metadata_token(lowered):
+            return 'spaarzegels_metadata'
         return 'receipt_metadata'
     if classification == 'ignore':
         return 'noise_or_unclassified_line'

--- a/backend/app/receipt_ingestion/parsing/line_discount_normalization.py
+++ b/backend/app/receipt_ingestion/parsing/line_discount_normalization.py
@@ -6,7 +6,7 @@ Technical Design Reference:
 - Used By: see docs/technical/PYTHON-MODULE-CATALOG.md
 - Depends On: see generated inventory
 - Reads Data: see generated inventory
-- Writes Data: see generated inventory
+- Writes Data: no
 - Status Authority: no
 - Refactor Status: classify
 """
@@ -16,6 +16,8 @@ from __future__ import annotations
 import re
 from decimal import Decimal
 from typing import Any, Callable
+
+from app.receipt_ingestion.spaarzegels_terms import contains_spaarzegels_non_product_token
 
 TRAILING_AMOUNT_RE = re.compile(r"(?<!\d)(?P<amount>-?\d{1,6}(?:[\.,]\d{2}))(?!\d)\s*(?:EUR|[A-Z]{1,3})?\s*$", re.IGNORECASE)
 DISCOUNT_COMPENSATION_RE = re.compile(
@@ -37,12 +39,6 @@ _NON_PRODUCT_LABEL_TOKENS = (
     "terminal",
     "transactie",
     "kaart",
-    "saldo",
-    "punten",
-    "koopzegel",
-    "koopzegels",
-    "zegel",
-    "zegels",
     "openingstijden",
     "medewerker",
     "store",
@@ -91,6 +87,8 @@ def _looks_like_safe_article_label(value: str | None, *, is_invalid_label: Calla
         return False
     if any(token in lowered for token in _NON_PRODUCT_LABEL_TOKENS):
         return False
+    if contains_spaarzegels_non_product_token(lowered):
+        return False
     if is_invalid_label is not None and is_invalid_label(label):
         return False
     return True
@@ -130,11 +128,12 @@ def should_append_generic_article_discount_cluster(
     """Detect a generic article discount/free-product cluster.
 
     Pattern:
-    - product line with positive amount, e.g. "JUMBO STROOPWAFELS 1,65"
-    - next line with negative discount/free compensation, e.g. "Gratis stroopwafels -1,65"
+    - product line with positive amount
+    - next line with negative discount/free compensation
 
     Returns one candidate article line carrying gross line_total and discount_amount.
-    It intentionally excludes savings/value lines such as koopzegels.
+    Value-line knowledge comes from the managed dictionary and is excluded from
+    this generic article-discount path.
     """
     if source_index < 0 or source_index + 1 >= len(lines):
         return None

--- a/backend/app/receipt_ingestion/product_candidate_gateway.py
+++ b/backend/app/receipt_ingestion/product_candidate_gateway.py
@@ -6,7 +6,7 @@ Technical Design Reference:
 - Used By: see docs/technical/PYTHON-MODULE-CATALOG.md
 - Depends On: see generated inventory
 - Reads Data: see generated inventory
-- Writes Data: see generated inventory
+- Writes Data: no
 - Status Authority: no
 - Refactor Status: classify
 """
@@ -18,6 +18,7 @@ from typing import Any
 
 from app.receipt_ingestion.duplicate_lines import is_near_duplicate_of_previous
 from app.receipt_ingestion.line_classifier import classification_allows_append
+from app.receipt_ingestion.spaarzegels_terms import spaarzegels_financial_metadata
 
 
 CleanLabel = Callable[[str | None], str]
@@ -86,7 +87,7 @@ def append_product_candidate(
     is_invalid_label: InvalidLabelCheck | None = None,
     confidence_score: float = 0.85,
 ) -> int | None:
-    """Single guarded gateway for appending receipt product candidates."""
+    """Single guarded gateway for appending receipt financial/product lines."""
     label_value = clean_label(label)
     if not label_value or len(label_value) < 2 or label_value.replace(' ', '').isdigit():
         return None
@@ -131,6 +132,7 @@ def append_product_candidate(
 
     raw_label_value = clean_label(raw_line) if savings_action_path and raw_line else label_value
     line_total_float = amount_to_float(line_total)
+    financial_metadata = spaarzegels_financial_metadata(raw_label_value or label_value)
 
     candidate_line = {
         'raw_label': raw_label_value,
@@ -144,6 +146,9 @@ def append_product_candidate(
         'confidence_score': confidence_score,
         'source_index': source_index,
     }
+    if financial_metadata:
+        candidate_line.update(financial_metadata)
+
     if extracted and is_near_duplicate_of_previous(candidate_line, extracted[-1]):
         _consolidate_with_previous(extracted[-1], candidate_line)
         return len(extracted) - 1
@@ -170,6 +175,15 @@ def append_product_candidate(
         'classification_trace': classification_trace,
         'validated_savings_action_path': savings_action_path,
     }
+    if financial_metadata:
+        producer_trace.update({
+            'line_type': financial_metadata.get('line_type'),
+            'is_spaarzegels': True,
+            'include_in_receipt_total': True,
+            'exclude_from_inventory': True,
+            'external_matching_allowed': False,
+            'matched_spaarzegels_term': financial_metadata.get('matched_spaarzegels_term'),
+        })
 
     candidate_line['producer_trace'] = producer_trace
     extracted.append(candidate_line)

--- a/backend/app/receipt_ingestion/product_candidate_gateway.py
+++ b/backend/app/receipt_ingestion/product_candidate_gateway.py
@@ -132,7 +132,11 @@ def append_product_candidate(
 
     raw_label_value = clean_label(raw_line) if savings_action_path and raw_line else label_value
     line_total_float = amount_to_float(line_total)
-    financial_metadata = spaarzegels_financial_metadata(raw_label_value or label_value)
+    financial_metadata = spaarzegels_financial_metadata(
+        raw_label_value or label_value,
+        label_text=label_value,
+        detail_text=raw_label_value or normalized_line or raw_line,
+    )
 
     candidate_line = {
         'raw_label': raw_label_value,

--- a/backend/app/receipt_ingestion/profiles/jumbo/app_quantity_pairs.py
+++ b/backend/app/receipt_ingestion/profiles/jumbo/app_quantity_pairs.py
@@ -5,8 +5,8 @@ Technical Design Reference:
 - Runtime Type: production
 - Used By: see docs/technical/PYTHON-MODULE-CATALOG.md
 - Depends On: see generated inventory
-- Reads Data: see generated inventory
-- Writes Data: see generated inventory
+- Reads Data: managed dictionary data
+- Writes Data: no
 - Status Authority: no
 - Refactor Status: classify
 """
@@ -17,6 +17,8 @@ import re
 from decimal import Decimal
 from typing import Any, Callable
 
+from app.receipt_ingestion.spaarzegels_terms import contains_spaarzegels_metadata_token, contains_spaarzegels_non_product_token
+
 JUMBO_APP_QUANTITY_DETAIL_RE = re.compile(
     r"^\s*(?P<qty>\d+(?:[\.,]\d+)?)\s*[xX]\s*(?P<amount1>-?\d{1,6}(?:[\.,]\d{2}))"
     r"(?:\s+(?P<amount2>-?\d{1,6}(?:[\.,]\d{2})))?(?:\s+(?:EUR|[A-Z]{1,3}))?\s*$",
@@ -24,22 +26,11 @@ JUMBO_APP_QUANTITY_DETAIL_RE = re.compile(
 )
 
 _JUMBO_NON_PRODUCT_LABEL_TOKENS = (
-    "koopzegel",
-    "koopzegels",
-    "zegel",
-    "zegels",
-    "punten",
-    "saldo",
     "totaal",
     "btw",
     "korting",
     "bankpas",
     "betaling",
-)
-
-_JUMBO_SAVINGS_LABEL_RE = re.compile(
-    r"\b(?:koopzegel|koopzegels|zegel|zegels)\b",
-    re.IGNORECASE,
 )
 
 
@@ -72,6 +63,8 @@ def looks_like_safe_jumbo_app_pair_label(
         return False
     if any(token in lowered for token in _JUMBO_NON_PRODUCT_LABEL_TOKENS):
         return False
+    if contains_spaarzegels_non_product_token(lowered):
+        return False
     if looks_like_non_product_receipt_label and looks_like_non_product_receipt_label(label):
         return False
     return True
@@ -81,7 +74,7 @@ def looks_like_jumbo_app_savings_pair_label(value: str | None) -> bool:
     label = normalize_jumbo_app_label(value)
     if len(label) < 3:
         return False
-    return bool(_JUMBO_SAVINGS_LABEL_RE.search(label))
+    return bool(contains_spaarzegels_metadata_token(label))
 
 
 def _decimal(value: str | None) -> Decimal | None:

--- a/backend/app/receipt_ingestion/spaarzegels_terms.py
+++ b/backend/app/receipt_ingestion/spaarzegels_terms.py
@@ -87,3 +87,33 @@ def contains_spaarzegels_priced_token(value: str) -> str | None:
 
 def contains_spaarzegels_non_product_token(value: str) -> bool:
     return token_match_from_terms(value, spaarzegels_non_product_label_tokens()) is not None
+
+
+def is_spaarzegels_financial_line(value: str | None) -> bool:
+    """Return True for paid Spaarzegels receipt lines.
+
+    The line remains a receipt financial line. Callers must keep the line_total
+    available for receipt total checks, but must not route it into product,
+    household article or inventory matching.
+    """
+    normalized = str(value or "").strip().lower()
+    if not normalized:
+        return False
+    if not re.search(r"(?<!\d)-?\d+[\.,]\d{2}(?!\d)", normalized):
+        return False
+    return contains_spaarzegels_priced_token(normalized) is not None
+
+
+def spaarzegels_financial_metadata(value: str | None) -> dict[str, Any]:
+    """Build generic financial-only metadata for paid Spaarzegels lines."""
+    matched = contains_spaarzegels_priced_token(str(value or ""))
+    if not matched or not is_spaarzegels_financial_line(value):
+        return {}
+    return {
+        "line_type": "spaarzegels",
+        "is_spaarzegels": True,
+        "include_in_receipt_total": True,
+        "exclude_from_inventory": True,
+        "external_matching_allowed": False,
+        "matched_spaarzegels_term": matched,
+    }

--- a/backend/app/receipt_ingestion/spaarzegels_terms.py
+++ b/backend/app/receipt_ingestion/spaarzegels_terms.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 
 TERMS_PATH = Path(__file__).resolve().parents[1] / "data" / "receipt_spaarzegels_terms.json"
+AMOUNT_RE = re.compile(r"(?<!\d)-?\d+[\.,]\d{2}(?!\d)")
 
 
 def _as_tuple(values: Any) -> tuple[str, ...]:
@@ -30,12 +31,6 @@ def _as_tuple(values: Any) -> tuple[str, ...]:
 
 @lru_cache(maxsize=1)
 def load_spaarzegels_terms() -> dict[str, tuple[str, ...]]:
-    """Load managed receipt terms for Spaarzegels.
-
-    Product-/bontermkennis hoort in data, niet in parsercode. Deze loader houdt
-    de parser generiek: code vraagt alleen om termgroepen en beslist daarna op
-    generieke classificatieregels.
-    """
     try:
         payload = json.loads(TERMS_PATH.read_text(encoding="utf-8"))
     except Exception:
@@ -64,6 +59,18 @@ def spaarzegels_non_product_label_tokens() -> tuple[str, ...]:
     return load_spaarzegels_terms()["non_product_label_tokens"]
 
 
+def _normalize_text(value: str | None) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip().lower())
+
+
+def _combined_text(*values: str | None) -> str:
+    return " ".join(_normalize_text(value) for value in values if str(value or "").strip()).strip()
+
+
+def _has_amount(value: str | None) -> bool:
+    return AMOUNT_RE.search(str(value or "")) is not None
+
+
 def token_match_from_terms(value: str, tokens: tuple[str, ...]) -> str | None:
     lowered = str(value or "").lower()
     for token in tokens:
@@ -73,7 +80,7 @@ def token_match_from_terms(value: str, tokens: tuple[str, ...]) -> str | None:
 
 
 def matches_spaarzegels_value_label(value: str) -> bool:
-    normalized = re.sub(r"\s+", " ", str(value or "").strip().lower())
+    normalized = _normalize_text(value)
     return any(re.fullmatch(pattern, normalized) for pattern in spaarzegels_value_label_patterns())
 
 
@@ -90,24 +97,32 @@ def contains_spaarzegels_non_product_token(value: str) -> bool:
 
 
 def is_spaarzegels_financial_line(value: str | None) -> bool:
-    """Return True for paid Spaarzegels receipt lines.
-
-    The line remains a receipt financial line. Callers must keep the line_total
-    available for receipt total checks, but must not route it into product,
-    household article or inventory matching.
-    """
-    normalized = str(value or "").strip().lower()
-    if not normalized:
-        return False
-    if not re.search(r"(?<!\d)-?\d+[\.,]\d{2}(?!\d)", normalized):
+    normalized = _normalize_text(value)
+    if not normalized or not _has_amount(normalized):
         return False
     return contains_spaarzegels_priced_token(normalized) is not None
 
 
-def spaarzegels_financial_metadata(value: str | None) -> dict[str, Any]:
-    """Build generic financial-only metadata for paid Spaarzegels lines."""
-    matched = contains_spaarzegels_priced_token(str(value or ""))
-    if not matched or not is_spaarzegels_financial_line(value):
+def is_spaarzegels_financial_pair(*, label_text: str | None, detail_text: str | None) -> bool:
+    combined = _combined_text(label_text, detail_text)
+    if not combined or not _has_amount(combined):
+        return False
+    return contains_spaarzegels_priced_token(combined) is not None
+
+
+def spaarzegels_financial_metadata(
+    value: str | None = None,
+    *,
+    label_text: str | None = None,
+    detail_text: str | None = None,
+) -> dict[str, Any]:
+    combined = _combined_text(value, label_text, detail_text)
+    matched = contains_spaarzegels_priced_token(combined)
+    if not matched:
+        return {}
+    if value is not None and is_spaarzegels_financial_line(value):
+        pass
+    elif not is_spaarzegels_financial_pair(label_text=label_text, detail_text=detail_text):
         return {}
     return {
         "line_type": "spaarzegels",

--- a/backend/app/receipt_ingestion/spaarzegels_terms.py
+++ b/backend/app/receipt_ingestion/spaarzegels_terms.py
@@ -1,0 +1,89 @@
+"""
+Technical Design Reference:
+- TD Section: TD-03 Receipt ingestion en parsers
+- Module Role: Receipt source parsing and data extraction
+- Runtime Type: production
+- Used By: see docs/technical/PYTHON-MODULE-CATALOG.md
+- Depends On: receipt_spaarzegels_terms.json
+- Reads Data: managed dictionary data
+- Writes Data: no
+- Status Authority: no
+- Refactor Status: classify
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+TERMS_PATH = Path(__file__).resolve().parents[1] / "data" / "receipt_spaarzegels_terms.json"
+
+
+def _as_tuple(values: Any) -> tuple[str, ...]:
+    if not isinstance(values, list):
+        return ()
+    return tuple(str(value).strip().lower() for value in values if str(value).strip())
+
+
+@lru_cache(maxsize=1)
+def load_spaarzegels_terms() -> dict[str, tuple[str, ...]]:
+    """Load managed receipt terms for Spaarzegels.
+
+    Product-/bontermkennis hoort in data, niet in parsercode. Deze loader houdt
+    de parser generiek: code vraagt alleen om termgroepen en beslist daarna op
+    generieke classificatieregels.
+    """
+    try:
+        payload = json.loads(TERMS_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        payload = {}
+    return {
+        "metadata_tokens": _as_tuple(payload.get("metadata_tokens")),
+        "priced_tokens": _as_tuple(payload.get("priced_tokens")),
+        "value_label_patterns": _as_tuple(payload.get("value_label_patterns")),
+        "non_product_label_tokens": _as_tuple(payload.get("non_product_label_tokens")),
+    }
+
+
+def spaarzegels_metadata_tokens() -> tuple[str, ...]:
+    return load_spaarzegels_terms()["metadata_tokens"]
+
+
+def spaarzegels_priced_tokens() -> tuple[str, ...]:
+    return load_spaarzegels_terms()["priced_tokens"]
+
+
+def spaarzegels_value_label_patterns() -> tuple[str, ...]:
+    return load_spaarzegels_terms()["value_label_patterns"]
+
+
+def spaarzegels_non_product_label_tokens() -> tuple[str, ...]:
+    return load_spaarzegels_terms()["non_product_label_tokens"]
+
+
+def token_match_from_terms(value: str, tokens: tuple[str, ...]) -> str | None:
+    lowered = str(value or "").lower()
+    for token in tokens:
+        if token and token in lowered:
+            return token
+    return None
+
+
+def matches_spaarzegels_value_label(value: str) -> bool:
+    normalized = re.sub(r"\s+", " ", str(value or "").strip().lower())
+    return any(re.fullmatch(pattern, normalized) for pattern in spaarzegels_value_label_patterns())
+
+
+def contains_spaarzegels_metadata_token(value: str) -> str | None:
+    return token_match_from_terms(value, spaarzegels_metadata_tokens())
+
+
+def contains_spaarzegels_priced_token(value: str) -> str | None:
+    return token_match_from_terms(value, spaarzegels_priced_tokens())
+
+
+def contains_spaarzegels_non_product_token(value: str) -> bool:
+    return token_match_from_terms(value, spaarzegels_non_product_label_tokens()) is not None

--- a/backend/app/services/external_receipt_auto_coverage.py
+++ b/backend/app/services/external_receipt_auto_coverage.py
@@ -9,6 +9,7 @@ from typing import Any, Callable
 from sqlalchemy import text
 
 from app.db import engine
+from app.receipt_ingestion.spaarzegels_terms import is_spaarzegels_financial_line
 from app.services.external_database_matchflow_evidence import ensure_external_receipt_item_candidates
 
 LOGGER = logging.getLogger(__name__)
@@ -35,6 +36,13 @@ def _receipt_table_exists(conn) -> bool:
             """
         )
     ).first() is not None
+
+
+def _is_external_matching_allowed(row: dict[str, Any]) -> bool:
+    receipt_text = _text(row.get("receipt_line_text")) or _text(row.get("normalized_label"))
+    if is_spaarzegels_financial_line(receipt_text):
+        return False
+    return True
 
 
 def _receipt_table_items(receipt_table_id: str) -> list[dict[str, Any]]:
@@ -68,16 +76,19 @@ def _receipt_table_items(receipt_table_id: str) -> list[dict[str, Any]]:
 
     items: list[dict[str, Any]] = []
     for row in rows:
-        receipt_text = _text(row.get("receipt_line_text")) or _text(row.get("normalized_label"))
+        row_data = dict(row)
+        receipt_text = _text(row_data.get("receipt_line_text")) or _text(row_data.get("normalized_label"))
         if not receipt_text:
             continue
+        if not _is_external_matching_allowed(row_data):
+            continue
         items.append({
-            "receipt_line_id": _text(row.get("receipt_line_id")),
+            "receipt_line_id": _text(row_data.get("receipt_line_id")),
             "receipt_line_text": receipt_text,
-            "retailer_code": _text(row.get("retailer_code")),
-            "retailer_article_number": _text(row.get("retailer_article_number")),
-            "quantity_label": _text(row.get("quantity_label")),
-            "price": row.get("price"),
+            "retailer_code": _text(row_data.get("retailer_code")),
+            "retailer_article_number": _text(row_data.get("retailer_article_number")),
+            "quantity_label": _text(row_data.get("quantity_label")),
+            "price": row_data.get("price"),
         })
 
     return items
@@ -87,11 +98,12 @@ def auto_ensure_external_candidates_for_receipt_table(
     receipt_table_id: str,
     include_below_threshold: bool = True,
 ) -> dict[str, Any]:
-    """Lees echte externe kandidaten bij voor alle regels van een nieuw opgeslagen bon.
+    """Lees echte externe kandidaten bij voor alle productregels van een nieuw opgeslagen bon.
 
     Dit is productgedrag, geen PO-rapport. De functie mag uitsluitend kandidaatcache
     vullen in `external_product_candidates`. Ze maakt geen Mijn artikel, geen
-    global product en geen voorraadmutatie.
+    global product en geen voorraadmutatie. Spaarzegels blijven financiële
+    bonregels voor de kassasom, maar worden niet naar productmatching gestuurd.
     """
     items = _receipt_table_items(receipt_table_id)
     if not items:

--- a/backend/tests/test_spaarzegels_financial_normalization.py
+++ b/backend/tests/test_spaarzegels_financial_normalization.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.receipt_ingestion.product_candidate_gateway import append_product_candidate
+from app.receipt_ingestion.spaarzegels_terms import (
+    is_spaarzegels_financial_pair,
+    spaarzegels_financial_metadata,
+)
+
+
+def _clean(value: str | None) -> str:
+    return str(value or "").strip()
+
+
+def _parse_quantity(value: str | None):
+    if value is None or value == "":
+        return None
+    return Decimal(str(value).replace(",", "."))
+
+
+def _parse_decimal(value: str | None):
+    if value is None or value == "":
+        return None
+    return Decimal(str(value).replace(",", ".")).quantize(Decimal("0.01"))
+
+
+def _amount_to_float(value):
+    if value is None:
+        return None
+    return float(value)
+
+
+def _classify(_value: str) -> str:
+    return "product_candidate"
+
+
+def test_spaarzegels_financial_pair_combines_label_and_detail_line():
+    assert is_spaarzegels_financial_pair(
+        label_text="Koopzegels",
+        detail_text="2 x 0.10 0.20",
+    )
+
+    metadata = spaarzegels_financial_metadata(
+        label_text="Koopzegels",
+        detail_text="2 x 0.10 0.20",
+    )
+
+    assert metadata["line_type"] == "spaarzegels"
+    assert metadata["include_in_receipt_total"] is True
+    assert metadata["exclude_from_inventory"] is True
+    assert metadata["external_matching_allowed"] is False
+
+
+def test_gateway_preserves_quantity_unit_price_total_for_spaarzegels_pair():
+    extracted: list[dict] = []
+
+    appended_index = append_product_candidate(
+        extracted,
+        label="Koopzegels",
+        qty_raw="2",
+        amount1_raw="0.10",
+        amount2_raw="0.20",
+        source_index=12,
+        raw_line="2 x 0.10 0.20",
+        normalized_line="2 x 0.10 0.20",
+        filename="jumbo-app.txt",
+        store_name="Jumbo",
+        function_name="_extract_savings_action_lines",
+        append_branch="savings_action_line",
+        parser_path="test.spaarzegels_pair",
+        caller_line_hint="test spaarzegels detail pair",
+        clean_label=_clean,
+        parse_quantity=_parse_quantity,
+        parse_decimal=_parse_decimal,
+        amount_to_float=_amount_to_float,
+        classify_line=_classify,
+    )
+
+    assert appended_index == 0
+    assert len(extracted) == 1
+
+    line = extracted[0]
+    assert line["quantity"] == 2.0
+    assert line["unit_price"] == 0.10
+    assert line["line_total"] == 0.20
+    assert line["line_type"] == "spaarzegels"
+    assert line["include_in_receipt_total"] is True
+    assert line["exclude_from_inventory"] is True
+    assert line["external_matching_allowed"] is False
+
+    trace = line["producer_trace"]
+    assert trace["line_type"] == "spaarzegels"
+    assert trace["external_matching_allowed"] is False

--- a/backend/tests/test_spaarzegels_financial_normalization.py
+++ b/backend/tests/test_spaarzegels_financial_normalization.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import sys
 from decimal import Decimal
+from pathlib import Path
+
+APP_ROOT = Path(__file__).resolve().parents[1]
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
 
 from app.receipt_ingestion.product_candidate_gateway import append_product_candidate
 from app.receipt_ingestion.spaarzegels_terms import (

--- a/backend/tests/test_spaarzegels_financial_normalization.py
+++ b/backend/tests/test_spaarzegels_financial_normalization.py
@@ -92,3 +92,9 @@ def test_gateway_preserves_quantity_unit_price_total_for_spaarzegels_pair():
     trace = line["producer_trace"]
     assert trace["line_type"] == "spaarzegels"
     assert trace["external_matching_allowed"] is False
+
+
+if __name__ == "__main__":
+    test_spaarzegels_financial_pair_combines_label_and_detail_line()
+    test_gateway_preserves_quantity_unit_price_total_for_spaarzegels_pair()
+    print("SPAARZEGELS_NORMALIZATION_OK")

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import Table from '../../ui/Table'
 import Button from '../../ui/Button'
 import { fetchJsonWithAuth } from '../../lib/authSession'
@@ -25,12 +25,6 @@ function numberText(value) {
   return number.toLocaleString('nl-NL', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
 }
 
-function gtinText(value) {
-  const normalized = String(value || '').trim()
-  if (/^\d{8}$|^\d{12}$|^\d{13}$|^\d{14}$/.test(normalized)) return normalized
-  return '-'
-}
-
 function scoreText(value) {
   if (value === null || value === undefined || value === '') return '-'
   const number = Number(value)
@@ -38,24 +32,10 @@ function scoreText(value) {
   return number.toLocaleString('nl-NL', { minimumFractionDigits: 3, maximumFractionDigits: 3 })
 }
 
-function retailerLabel(value) {
+function gtinText(value) {
   const normalized = String(value || '').trim()
-  const key = normalized.toLowerCase()
-
-  if (!key || key === '-' || key === 'import' || key === 'onbekend') return 'Onbekend'
-
-  const labels = {
-    ah: 'Albert Heijn',
-    albert_heijn: 'Albert Heijn',
-    'albert heijn': 'Albert Heijn',
-    jumbo: 'Jumbo',
-    lidl: 'Lidl',
-    aldi: 'Aldi',
-    plus: 'PLUS',
-    picnic: 'Picnic',
-  }
-
-  return labels[key] || normalized
+  if (/^\d{8}$|^\d{12}$|^\d{13}$|^\d{14}$/.test(normalized)) return normalized
+  return '-'
 }
 
 function normalizeCandidateStatus(value) {
@@ -90,26 +70,31 @@ function detectFallbackCandidate(candidate) {
   ].some((value) => isFallbackCandidateStatus(value) || isFallbackSignal(value))
 }
 
-function candidateStatusLabel(value) {
-  const normalized = normalizeCandidateStatus(value)
-  const labels = {
-    linked_to_catalog: 'Gekoppeld',
-    user_confirmed: 'Bevestigd',
-    probable_candidate: 'Waarschijnlijke kandidaat',
-    weak_candidate: 'Lage zekerheid',
-    candidate: 'Kandidaat',
-    fallback_candidate: 'Geen externe match',
-    receipt_fallback_candidate: 'Geen externe match',
-    receipt_unresolved_fallback: 'Geen externe match',
-    unresolved_fallback: 'Geen externe match',
-    unresolved: 'Geen externe match',
-    no_external_match: 'Geen externe match',
-  }
-  return labels[normalized] || text(value)
+function candidateStatusLabel(candidate, linked) {
+  if (linked) return 'Gekoppeld'
+  if (detectFallbackCandidate(candidate)) return 'Geen externe match'
+  const normalized = normalizeCandidateStatus(candidate?.candidate_status || candidate?.status)
+  if (normalized === 'linked_to_catalog') return 'Gekoppeld'
+  if (normalized === 'user_confirmed') return 'Bevestigd'
+  if (normalized === 'probable_candidate') return 'Waarschijnlijke kandidaat'
+  if (normalized === 'weak_candidate') return 'Lage zekerheid'
+  return text(candidate?.status_label || candidate?.candidate_status || candidate?.status || 'Kandidaat')
 }
 
-function candidateRawStatus(candidate) {
-  return normalizeCandidateStatus(candidate?.candidate_status || candidate?.status)
+function retailerLabel(value) {
+  const normalized = String(value || '').trim()
+  const key = normalized.toLowerCase()
+  const labels = {
+    ah: 'Albert Heijn',
+    albert_heijn: 'Albert Heijn',
+    'albert heijn': 'Albert Heijn',
+    jumbo: 'Jumbo',
+    lidl: 'Lidl',
+    aldi: 'Aldi',
+    plus: 'PLUS',
+    picnic: 'Picnic',
+  }
+  return labels[key] || normalized || 'Onbekend'
 }
 
 function rowKey(item) {
@@ -134,40 +119,58 @@ function candidateDedupKey(candidate) {
   const source = candidateDedupValue(candidate.source || raw.external_source_name || raw.candidate_source_name || raw.source_name)
   const externalCode = candidateDedupValue(candidate.externalCode || raw.external_source_product_code || raw.candidate_source_product_code || raw.source_product_code || raw.retailer_article_number)
   const gtin = candidateDedupValue(raw.gtin || raw.ean)
-
   if (source && externalCode) return `source:${source}|code:${externalCode}`
   if (gtin) return `gtin:${gtin}`
-
   const name = candidateDedupValue(candidate.candidateName || raw.candidate_name)
   const brand = candidateDedupValue(candidate.brand || raw.candidate_brand)
   const variant = candidateDedupValue(candidate.variant || raw.variant)
-
   return `fallback:${name}|brand:${brand}|variant:${variant}`
 }
 
 function preferCandidate(current, next) {
   if (!current) return next
-
   if (next.isLinkedToCatalog && !current.isLinkedToCatalog) return next
   if (current.isLinkedToCatalog && !next.isLinkedToCatalog) return current
-
-  const currentScore = Number(current.score || 0)
-  const nextScore = Number(next.score || 0)
-
-  if (nextScore > currentScore) return next
-
-  return current
+  return Number(next.score || 0) > Number(current.score || 0) ? next : current
 }
 
 function dedupeCandidates(candidates) {
   const deduped = new Map()
-
   candidates.forEach((candidate) => {
     const key = candidateDedupKey(candidate)
     deduped.set(key, preferCandidate(deduped.get(key), candidate))
   })
-
   return Array.from(deduped.values())
+}
+
+function hasCatalogLink(candidate) {
+  return Boolean(
+    candidate?.is_linked_to_catalog === true ||
+    text(candidate?.global_product_id, '') ||
+    text(candidate?.product_identity_id, '') ||
+    text(candidate?.matched_global_product_id, '') ||
+    text(candidate?.matched_global_article_id, '')
+  )
+}
+
+function buildCandidate(candidate) {
+  const linked = candidate?.is_linked_to_catalog === true
+  const isFallbackCandidate = detectFallbackCandidate(candidate)
+  return {
+    id: candidateKey(candidate),
+    candidateName: text(candidate.candidate_name),
+    brand: text(candidate.candidate_brand),
+    source: text(candidate.external_source_name || candidate.candidate_source_name || candidate.source_name),
+    externalCode: text(candidate.external_source_product_code || candidate.candidate_source_product_code || candidate.source_product_code || candidate.retailer_article_number),
+    variant: text(candidate.variant),
+    score: candidate.score,
+    status: candidateStatusLabel(candidate, linked),
+    isLinkedToCatalog: linked,
+    catalogLinked: hasCatalogLink(candidate),
+    isFallbackCandidate,
+    isLinkableToCatalog: Boolean(candidate.is_linkable_to_catalog) && !linked && !isFallbackCandidate,
+    raw: candidate,
+  }
 }
 
 function bestCandidateForItem(candidates) {
@@ -176,190 +179,58 @@ function bestCandidateForItem(candidates) {
   return candidates.find((candidate) => !candidate.isFallbackCandidate) || null
 }
 
-function candidateExternalCode(candidate) {
-  if (!candidate) return ''
-  const raw = candidate.raw || {}
-  return text(
-    candidate.externalCode ||
-    raw.external_source_product_code ||
-    raw.candidate_source_product_code ||
-    raw.source_product_code,
-    ''
-  )
-}
-
-function candidateExternalGtin(candidate) {
-  if (!candidate) return '-'
-  const raw = candidate.raw || {}
-  return gtinText(
-    raw.gtin ||
-    raw.ean ||
-    candidate.externalCode ||
-    raw.external_source_product_code ||
-    raw.candidate_source_product_code ||
-    raw.source_product_code
-  )
-}
-
-function isBackendLinkedCandidate(candidate) {
-  return candidate?.is_linked_to_catalog === true
-}
-
-function hasCatalogLink(candidate) {
-  if (!candidate) return false
-  return (
-    candidate.is_linked_to_catalog === true ||
-    Boolean(text(candidate.global_product_id, '')) ||
-    Boolean(text(candidate.product_identity_id, '')) ||
-    Boolean(text(candidate.matched_global_product_id, '')) ||
-    Boolean(text(candidate.matched_global_article_id, ''))
-  )
-}
-
-function candidateStatusFromBackend(candidate, linked) {
-  if (linked) return 'Gekoppeld'
-  if (detectFallbackCandidate(candidate)) return 'Geen externe match'
-
-  const rawLabel = text(candidate.status_label, '')
-  if (rawLabel && rawLabel.toLowerCase() !== 'gekoppeld') return rawLabel
-
-  const rawStatus = candidateRawStatus(candidate)
-  if (isFallbackCandidateStatus(rawStatus)) return candidateStatusLabel(rawStatus)
-  if (rawStatus === 'linked_to_catalog' || rawStatus === 'user_confirmed') return 'Kandidaat'
-
-  return candidateStatusLabel(candidate.candidate_status || candidate.status)
-}
-
-function buildReceiptItems(candidates) {
+function buildReceiptItems(rawItems) {
   const grouped = new Map()
 
-  candidates.forEach((candidate) => {
-    const key = rowKey(candidate)
-    const isPlaceholder = Boolean(candidate.is_receipt_item_placeholder)
-    const linked = isBackendLinkedCandidate(candidate)
-    const catalogLinked = hasCatalogLink(candidate)
-    const rawStatus = candidateRawStatus(candidate)
-    const isFallbackCandidate = detectFallbackCandidate(candidate)
-
-    const candidateItem = {
-      id: candidateKey(candidate),
-      candidateName: text(candidate.candidate_name),
-      brand: text(candidate.candidate_brand),
-      source: text(candidate.external_source_name || candidate.candidate_source_name || candidate.source_name),
-      externalCode: text(candidate.external_source_product_code || candidate.candidate_source_product_code || candidate.source_product_code || candidate.retailer_article_number),
-      variant: text(candidate.variant),
-      score: candidate.score,
-      status: candidateStatusFromBackend(candidate, linked),
-      rawStatus,
-      catalogLinked,
-      isLinkedToCatalog: linked,
-      isFallbackCandidate,
-      isLinkableToCatalog: Boolean(candidate.is_linkable_to_catalog) && !linked && !isFallbackCandidate,
-      isExistingLinkForReceiptItem: linked,
-      canonicalCatalogProductId: text(candidate.canonical_catalog_product_id, ''),
-      raw: candidate,
-    }
-
+  rawItems.forEach((rawItem) => {
+    const key = rowKey(rawItem)
     const current = grouped.get(key) || {
       id: key,
-      contextKey: text(candidate.context_key, ''),
-      receiptLineId: text(candidate.receipt_line_id, ''),
-      purchaseImportLineId: text(candidate.purchase_import_line_id, ''),
-      receiptLineText: text(candidate.receipt_line_text),
-      retailerCode: retailerLabel(candidate.retailer_code),
-      retailerCodeRaw: text(candidate.retailer_code, ''),
-      articleNumber: text(candidate.retailer_article_number || candidate.source_product_code || candidate.candidate_source_product_code),
-      gtin: gtinText(candidate.gtin || candidate.ean),
-      quantity: text(candidate.quantity_label),
-      price: candidate.price ?? '-',
+      contextKey: text(rawItem.context_key, ''),
+      receiptLineId: text(rawItem.receipt_line_id, ''),
+      purchaseImportLineId: text(rawItem.purchase_import_line_id, ''),
+      receiptLineText: text(rawItem.receipt_line_text),
+      retailerCode: retailerLabel(rawItem.retailer_code),
+      retailerCodeRaw: text(rawItem.retailer_code, ''),
+      articleNumber: text(rawItem.retailer_article_number || rawItem.source_product_code || rawItem.candidate_source_product_code),
+      gtin: gtinText(rawItem.gtin || rawItem.ean),
+      quantity: text(rawItem.quantity_label),
+      price: rawItem.price ?? '-',
       amount: '-',
-      candidateCount: 0,
-      hasFallbackCandidate: false,
       catalogLinked: false,
-      linkedGlobalProductId: '',
-      linkedProductIdentityId: '',
-      linkedMatchedGlobalProductId: '',
-      linkedMatchedGlobalArticleId: '',
       status: 'Nog niet verwerkt',
       candidates: [],
     }
 
-    if (!isPlaceholder) {
-      if (!candidateItem.isFallbackCandidate) current.candidateCount += 1
-      if (candidateItem.isFallbackCandidate) current.hasFallbackCandidate = true
-      current.candidates.push(candidateItem)
-    }
-
-    if (isPlaceholder && Array.isArray(candidate.candidates)) {
-      candidate.candidates.forEach((nestedCandidate) => {
-        const nestedLinked = isBackendLinkedCandidate(nestedCandidate)
-        const nestedCatalogLinked = hasCatalogLink(nestedCandidate)
-        const nestedRawStatus = candidateRawStatus(nestedCandidate)
-        const nestedIsFallbackCandidate = detectFallbackCandidate(nestedCandidate)
-        const nestedItem = {
-          id: candidateKey(nestedCandidate),
-          candidateName: text(nestedCandidate.candidate_name),
-          brand: text(nestedCandidate.candidate_brand),
-          source: text(nestedCandidate.external_source_name || nestedCandidate.candidate_source_name || nestedCandidate.source_name),
-          externalCode: text(nestedCandidate.external_source_product_code || nestedCandidate.candidate_source_product_code || nestedCandidate.source_product_code || nestedCandidate.retailer_article_number),
-          variant: text(nestedCandidate.variant),
-          score: nestedCandidate.score,
-          status: candidateStatusFromBackend(nestedCandidate, nestedLinked),
-          rawStatus: nestedRawStatus,
-          catalogLinked: nestedCatalogLinked,
-          isLinkedToCatalog: nestedLinked,
-          isFallbackCandidate: nestedIsFallbackCandidate,
-          isLinkableToCatalog: Boolean(nestedCandidate.is_linkable_to_catalog) && !nestedLinked && !nestedIsFallbackCandidate,
-          isExistingLinkForReceiptItem: nestedLinked,
-          canonicalCatalogProductId: text(nestedCandidate.canonical_catalog_product_id, ''),
-          raw: nestedCandidate,
-        }
-
-        if (!nestedItem.isFallbackCandidate) current.candidateCount += 1
-        if (nestedItem.isFallbackCandidate) current.hasFallbackCandidate = true
-        current.candidates.push(nestedItem)
-
-        if (nestedCatalogLinked) {
+    const nestedCandidates = rawItem.is_receipt_item_placeholder && Array.isArray(rawItem.candidates) ? rawItem.candidates : [rawItem]
+    nestedCandidates.forEach((candidate) => {
+      if (rawItem.is_receipt_item_placeholder && !candidate) return
+      if (rawItem.is_receipt_item_placeholder === true || !rawItem.is_receipt_item_placeholder) {
+        const candidateItem = buildCandidate(candidate)
+        current.candidates.push(candidateItem)
+        if (candidateItem.catalogLinked) {
           current.catalogLinked = true
           current.status = 'Gekoppeld'
-          current.linkedGlobalProductId = text(nestedCandidate.global_product_id, current.linkedGlobalProductId || '')
-          current.linkedProductIdentityId = text(nestedCandidate.product_identity_id, current.linkedProductIdentityId || '')
-          current.linkedMatchedGlobalProductId = text(nestedCandidate.matched_global_product_id, current.linkedMatchedGlobalProductId || '')
-          current.linkedMatchedGlobalArticleId = text(nestedCandidate.matched_global_article_id, current.linkedMatchedGlobalArticleId || '')
         }
-      })
-    }
+      }
+    })
 
-    if (catalogLinked) {
-      current.catalogLinked = true
-      current.status = 'Gekoppeld'
-      current.linkedGlobalProductId = text(candidate.global_product_id, current.linkedGlobalProductId || '')
-      current.linkedProductIdentityId = text(candidate.product_identity_id, current.linkedProductIdentityId || '')
-      current.linkedMatchedGlobalProductId = text(candidate.matched_global_product_id, current.linkedMatchedGlobalProductId || '')
-      current.linkedMatchedGlobalArticleId = text(candidate.matched_global_article_id, current.linkedMatchedGlobalArticleId || '')
-    } else if (current.candidateCount > 0) current.status = 'Kandidaten gevonden'
-    else if (current.hasFallbackCandidate) current.status = 'Geen externe match'
-
-    if (!current.contextKey && candidate.context_key) current.contextKey = String(candidate.context_key)
-    if (!current.receiptLineId && candidate.receipt_line_id) current.receiptLineId = String(candidate.receipt_line_id)
-    if (!current.purchaseImportLineId && candidate.purchase_import_line_id) current.purchaseImportLineId = String(candidate.purchase_import_line_id)
+    if (!current.catalogLinked && current.candidates.some((candidate) => !candidate.isFallbackCandidate)) current.status = 'Kandidaten gevonden'
+    if (!current.catalogLinked && !current.candidates.some((candidate) => !candidate.isFallbackCandidate) && current.candidates.some((candidate) => candidate.isFallbackCandidate)) current.status = 'Geen externe match'
     grouped.set(key, current)
   })
 
   return Array.from(grouped.values()).map((item) => {
-    const uniqueCandidates = dedupeCandidates(item.candidates)
-    const sortedCandidates = [...uniqueCandidates].sort((left, right) => Number(right.score || 0) - Number(left.score || 0))
-    const bestCandidate = bestCandidateForItem(sortedCandidates)
-    const externalArticleNumber = candidateExternalCode(bestCandidate)
-    const externalGtin = candidateExternalGtin(bestCandidate)
+    const candidates = dedupeCandidates(item.candidates).sort((left, right) => Number(right.score || 0) - Number(left.score || 0))
+    const bestCandidate = bestCandidateForItem(candidates)
     return {
       ...item,
-      articleNumber: externalArticleNumber || '-',
-      gtin: externalGtin,
-      candidateCount: item.candidateCount,
-      candidates: sortedCandidates,
+      candidates,
+      candidateCount: candidates.filter((candidate) => !candidate.isFallbackCandidate).length,
       bestCandidateName: text(bestCandidate?.candidateName, ''),
       bestCandidateScore: bestCandidate?.score ?? null,
+      articleNumber: text(bestCandidate?.externalCode, '-'),
+      gtin: gtinText(bestCandidate?.raw?.gtin || bestCandidate?.raw?.ean),
     }
   })
 }
@@ -368,27 +239,11 @@ function sortValue(item, key) {
   if (key === 'candidateCount') return Number(item.candidateCount || 0)
   if (key === 'bestCandidateScore') return Number(item.bestCandidateScore || 0)
   if (key === 'catalogLinked') return item.catalogLinked ? 1 : 0
-  if (key === 'selected') return 0
   return String(item[key] || '').toLowerCase()
 }
 
 function csvValue(value) {
-  const normalized = String(value ?? '').replaceAll('"', '""')
-  return `"${normalized}"`
-}
-
-function CandidateProgressOverlay({ progress, percent }) {
-  if (!progress?.active) return null
-  return (
-    <div className="rz-modal-backdrop" role="presentation">
-      <div className="rz-modal-card" role="status" aria-live="polite" aria-label="Bonartikelen worden ingelezen">
-        <h3 className="rz-modal-title">Bonartikelen inlezen</h3>
-        <p className="rz-modal-text">{progress.label}</p>
-        <div className="rz-external-progress-track"><div className="rz-external-progress-bar" style={{ width: `${percent}%` }} /></div>
-        <p className="rz-modal-text">{progress.current} van {progress.total} verwerkt</p>
-      </div>
-    </div>
-  )
+  return `"${String(value ?? '').replaceAll('"', '""')}"`
 }
 
 export default function ReceiptItemsOverview({ onError, onMessage }) {
@@ -397,18 +252,10 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   const [selectedCandidateId, setSelectedCandidateId] = useState('')
   const [selectedItemIds, setSelectedItemIds] = useState([])
   const [isLoading, setIsLoading] = useState(false)
-  const [isProcessingCandidate, setIsProcessingCandidate] = useState(false)
-  const [isUnlinking, setIsUnlinking] = useState(false)
-  const [confirmOverwrite, setConfirmOverwrite] = useState(false)
   const [filters, setFilters] = useState({ receiptLineText: '', retailerCode: '', catalogLinked: 'all', articleNumber: '', gtin: '', quantity: '', price: '', amount: '', bestCandidateName: '', bestCandidateScore: '', candidateCount: '' })
   const [sortKey, setSortKey] = useState('receiptLineText')
   const [sortDesc, setSortDesc] = useState(false)
   const [page, setPage] = useState(1)
-  const [ensuredPages, setEnsuredPages] = useState([])
-  const [candidateProgress, setCandidateProgress] = useState({ active: false, current: 0, total: 0, label: '' })
-  const [selectedItemCandidateLoadingId, setSelectedItemCandidateLoadingId] = useState('')
-  const ensuringRef = useRef(false)
-  const selectedItemRequestRef = useRef(0)
 
   async function fetchItems() {
     const response = await fetchJsonWithAuth('/api/external-databases/receipt-items?limit=500', { method: 'GET' })
@@ -422,7 +269,7 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
     try {
       const nextItems = await fetchItems()
       setItems(nextItems)
-      if (selectedItem) setSelectedItem(nextItems.find((item) => item.id === selectedItem.id) || null)
+      setSelectedItem((current) => current ? nextItems.find((item) => item.id === current.id) || null : null)
       setSelectedItemIds((current) => current.filter((id) => nextItems.some((item) => item.id === id)))
     } catch (err) {
       onError?.(err?.message || 'Bonartikelen konden niet worden geladen')
@@ -457,101 +304,55 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
     return rows
   }, [items, filters, sortKey, sortDesc])
 
-  const dedupedItems = filteredItems
-  const pageCount = Math.max(1, Math.ceil(dedupedItems.length / PAGE_SIZE))
-  const currentPage = Math.min(page, pageCount)
-  const visibleItems = dedupedItems.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
-  const emptyRows = Math.max(0, 3 - visibleItems.length)
-  const visibleIds = visibleItems.map((item) => item.id)
-  const allVisibleSelected = visibleIds.length > 0 && visibleIds.every((id) => selectedItemIds.includes(id))
-  const selectedLinkedCount = items.filter((item) => selectedItemIds.includes(item.id) && item.catalogLinked).length
-  const selectedItemCandidatesAreLoading = Boolean(selectedItem && selectedItemCandidateLoadingId === selectedItem.id)
-  const selectedCandidates = selectedItemCandidatesAreLoading ? [] : (selectedItem?.candidates || [])
-  const selectedCandidate = selectedCandidates.find((candidate) => candidate.id === selectedCandidateId) || null
-
   useEffect(() => {
     if (!selectedItem) return
     if (filteredItems.some((item) => item.id === selectedItem.id)) return
     setSelectedItem(null)
     setSelectedCandidateId('')
-    setConfirmOverwrite(false)
   }, [filteredItems, selectedItem])
 
-  const selectedCandidateIsLinked = selectedCandidate?.isLinkedToCatalog === true
-  const selectedCandidateCanBeLinked = Boolean(selectedCandidate && selectedCandidate.isLinkableToCatalog === true && selectedCandidate.isFallbackCandidate !== true && selectedCandidateIsLinked === false)
+  const pageCount = Math.max(1, Math.ceil(filteredItems.length / PAGE_SIZE))
+  const currentPage = Math.min(page, pageCount)
+  const visibleItems = filteredItems.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
+  const emptyRows = Math.max(0, 3 - visibleItems.length)
+  const visibleIds = visibleItems.map((item) => item.id)
+  const allVisibleSelected = visibleIds.length > 0 && visibleIds.every((id) => selectedItemIds.includes(id))
+  const selectedCandidates = selectedItem?.candidates || []
+  const selectedCandidate = selectedCandidates.find((candidate) => candidate.id === selectedCandidateId) || null
+  const selectedCandidateCanBeLinked = Boolean(selectedCandidate && selectedCandidate.isLinkableToCatalog && !selectedCandidate.isFallbackCandidate && !selectedCandidate.isLinkedToCatalog)
 
-  async function ensureCandidatesForPage(targetPage, sourceItems) {
-    if (ensuringRef.current || ensuredPages.includes(targetPage)) return
-    const rows = sourceItems.slice((targetPage - 1) * PAGE_SIZE, targetPage * PAGE_SIZE)
-    if (!rows.length) return
-    ensuringRef.current = true
-    setCandidateProgress({ active: true, current: 0, total: rows.length, label: 'Kandidaatartikelen bijlezen en wegen' })
-    try {
-      for (let index = 0; index < rows.length; index += 1) {
-        const item = rows[index]
-        setCandidateProgress({ active: true, current: index + 1, total: rows.length, label: `Bijlezen en wegen: ${item.receiptLineText}` })
-        const response = await fetchJsonWithAuth('/api/external-databases/receipt-items/ensure-candidates', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ include_below_threshold: true, items: [{ receipt_line_text: item.receiptLineText, retailer_code: item.retailerCodeRaw || item.retailerCode, purchase_import_line_id: item.purchaseImportLineId, receipt_line_id: item.receiptLineId }] }),
-        })
-        const data = await response.json().catch(() => ({}))
-        if (!response.ok) throw new Error(data?.detail || 'Kandidaten bijlezen is mislukt')
-      }
-      setEnsuredPages((current) => Array.from(new Set([...current, targetPage])))
-      setItems(await fetchItems())
-    } catch (err) {
-      onError?.(err?.message || 'Kandidaten bijlezen is mislukt')
-    } finally {
-      setCandidateProgress({ active: false, current: 0, total: 0, label: '' })
-      ensuringRef.current = false
-    }
-  }
-
-  useEffect(() => {
-    if (items.length && dedupedItems.length) ensureCandidatesForPage(currentPage, dedupedItems)
-  }, [items.length, dedupedItems.length, currentPage])
-
-  async function selectReceiptItem(item) {
-    const requestId = selectedItemRequestRef.current + 1
-    selectedItemRequestRef.current = requestId
+  function selectReceiptItem(item) {
+    setSelectedItem(item)
     setSelectedCandidateId('')
-    setConfirmOverwrite(false)
-    setSelectedItemCandidateLoadingId('')
-    if (!item) { setSelectedItem(null); return }
-    if (item.candidates?.length) { setSelectedItem(item); return }
-    setSelectedItem({ ...item, candidates: [], candidateCount: 0 })
-    setSelectedItemCandidateLoadingId(item.id)
-    setCandidateProgress({ active: true, current: 1, total: 1, label: `Bijlezen en wegen: ${item.receiptLineText}` })
-    try {
-      const response = await fetchJsonWithAuth('/api/external-databases/receipt-items/ensure-candidates', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ include_below_threshold: true, items: [{ receipt_line_text: item.receiptLineText, retailer_code: item.retailerCodeRaw || item.retailerCode, purchase_import_line_id: item.purchaseImportLineId, receipt_line_id: item.receiptLineId }] }),
-      })
-      const data = await response.json().catch(() => ({}))
-      if (!response.ok) throw new Error(data?.detail || 'Kandidaten bijlezen is mislukt')
-      const refreshed = await fetchItems()
-      if (selectedItemRequestRef.current !== requestId) return
-      setItems(refreshed)
-      setSelectedItem(refreshed.find((nextItem) => nextItem.id === item.id) || { ...item, candidates: [], candidateCount: 0 })
-    } catch (err) {
-      if (selectedItemRequestRef.current === requestId) onError?.(err?.message || 'Kandidaten bijlezen is mislukt')
-    } finally {
-      if (selectedItemRequestRef.current === requestId) {
-        setCandidateProgress({ active: false, current: 0, total: 0, label: '' })
-        setSelectedItemCandidateLoadingId('')
-      }
-    }
   }
 
-  function toggleSelectedItem(itemId) { setSelectedItemIds((current) => current.includes(itemId) ? current.filter((id) => id !== itemId) : [...current, itemId]) }
-  function toggleVisibleItems() {
-    const allSelected = visibleIds.length > 0 && visibleIds.every((id) => selectedItemIds.includes(id))
-    setSelectedItemIds((current) => allSelected ? current.filter((id) => !visibleIds.includes(id)) : Array.from(new Set([...current, ...visibleIds])))
+  function toggleSelectedItem(itemId) {
+    setSelectedItemIds((current) => current.includes(itemId) ? current.filter((id) => id !== itemId) : [...current, itemId])
   }
-  function goToPage(targetPage) { setPage(Math.max(1, Math.min(pageCount, targetPage))) }
-  function updateFilter(key, value) { setFilters((current) => ({ ...current, [key]: value })); setPage(1); setEnsuredPages([]) }
-  function updateSort(key) { if (sortKey === key) setSortDesc((value) => !value); else { setSortKey(key); setSortDesc(false) }; setPage(1); setEnsuredPages([]) }
-  function sortMark(key) { if (sortKey !== key) return 'v'; return sortDesc ? 'v' : '^' }
+
+  function toggleVisibleItems() {
+    setSelectedItemIds((current) => allVisibleSelected ? current.filter((id) => !visibleIds.includes(id)) : Array.from(new Set([...current, ...visibleIds])))
+  }
+
+  function updateFilter(key, value) {
+    setFilters((current) => ({ ...current, [key]: value }))
+    setPage(1)
+  }
+
+  function updateSort(key) {
+    if (sortKey === key) setSortDesc((value) => !value)
+    else { setSortKey(key); setSortDesc(false) }
+    setPage(1)
+  }
+
+  function sortMark(key) {
+    if (sortKey !== key) return 'v'
+    return sortDesc ? 'v' : '^'
+  }
+
+  function goToPage(targetPage) {
+    setPage(Math.max(1, Math.min(pageCount, targetPage)))
+  }
 
   function exportSelectedItems() {
     const selectedRows = items.filter((item) => selectedItemIds.includes(item.id))
@@ -561,72 +362,46 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
     const url = URL.createObjectURL(blob)
     const link = document.createElement('a')
-    link.href = url; link.download = 'rezzerv-externe-databases-bonartikelen.csv'; link.click(); URL.revokeObjectURL(url)
+    link.href = url
+    link.download = 'rezzerv-externe-databases-bonartikelen.csv'
+    link.click()
+    URL.revokeObjectURL(url)
     onMessage?.(`Export gemaakt voor ${selectedRows.length} bonartikel(en).`)
   }
 
-  async function unlinkByContextKeys(contextKeys) {
-    const normalizedContextKeys = contextKeys.filter(Boolean)
-    if (!normalizedContextKeys.length) { onMessage?.('Er zijn geen gekoppelde bonartikelen geselecteerd om te ontkoppelen.'); return }
-    setIsUnlinking(true)
-    try {
-      const response = await fetchJsonWithAuth('/api/external-databases/catalog/unlink', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ context_keys: normalizedContextKeys }) })
-      const data = await response.json().catch(() => ({}))
-      if (!response.ok) throw new Error(data?.detail || 'Ontkoppelen is mislukt')
-      onMessage?.(`Ontkoppeld: ${data?.unlinked_count ?? 0} koppeling(en).`)
-      setSelectedItemIds([])
-      await loadItems()
-    } catch (err) { onError?.(err?.message || 'Ontkoppelen is mislukt') } finally { setIsUnlinking(false) }
-  }
-  async function unlinkSelectedItems() { await unlinkByContextKeys(items.filter((item) => selectedItemIds.includes(item.id) && item.catalogLinked).map((item) => item.contextKey)) }
-  async function unlinkCandidate(candidate) {
-    if (!candidate?.id) return
-    setIsUnlinking(true)
-    try {
-      const response = await fetchJsonWithAuth('/api/external-databases/catalog/unlink', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ candidate_ids: [candidate.id] }) })
-      const data = await response.json().catch(() => ({}))
-      if (!response.ok) throw new Error(data?.detail || 'Ontkoppelen is mislukt')
-      onMessage?.(`Ontkoppeld: ${data?.unlinked_count ?? 0} koppeling(en).`)
-      await loadItems()
-    } catch (err) { onError?.(err?.message || 'Ontkoppelen is mislukt') } finally { setIsUnlinking(false) }
-  }
-  async function handleUnlinkSelectedCandidate() {
-    if (!selectedCandidate) { onMessage?.('Selecteer eerst een kandidaat om te ontkoppelen.'); return }
-    if (!selectedCandidateIsLinked) { onMessage?.('Deze kandidaat is nog niet gekoppeld en kan daarom niet worden ontkoppeld.'); return }
-    if (selectedCandidate.isExistingLinkForReceiptItem || selectedCandidate.raw?.is_synthetic_catalog_link) await unlinkByContextKeys([selectedItem?.contextKey])
-    else await unlinkCandidate(selectedCandidate)
-    setSelectedCandidateId('')
-  }
-  async function processSelectedCandidate(options = {}) {
+  async function processSelectedCandidate() {
     if (!selectedItem || !selectedCandidate || !selectedCandidateCanBeLinked) return
-    setConfirmOverwrite(false); setIsProcessingCandidate(true)
     try {
-      const response = await fetchJsonWithAuth('/api/external-databases/catalog/promote-candidate', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ candidate_id: selectedCandidate.raw?.id || selectedCandidate.id, force_overwrite: Boolean(options.forceOverwrite) }) })
+      const response = await fetchJsonWithAuth('/api/external-databases/catalog/promote-candidate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ candidate_id: selectedCandidate.raw?.id || selectedCandidate.id }),
+      })
       const data = await response.json().catch(() => ({}))
       if (!response.ok) throw new Error(data?.detail || 'Kandidaat verwerken is mislukt')
-      if (data?.requires_overwrite && !options.forceOverwrite) { setConfirmOverwrite(true); return }
       onMessage?.(data?.promoted ? 'Kandidaat is gekoppeld.' : 'Cataloguskoppeling is afgerond zonder mutatie.')
-      setSelectedCandidateId(''); await loadItems()
-    } catch (err) { onError?.(err?.message || 'Kandidaat verwerken is mislukt') } finally { setIsProcessingCandidate(false) }
+      setSelectedCandidateId('')
+      await loadItems()
+    } catch (err) {
+      onError?.(err?.message || 'Kandidaat verwerken is mislukt')
+    }
   }
-
-  const progressPercent = candidateProgress.total ? Math.round((candidateProgress.current / candidateProgress.total) * 100) : 0
 
   return (
     <div className="rz-external-receipt-overview">
-      <div className="rz-external-databases-section-header"><h3>Bonartikelen voor externe herkenning</h3><Button type="button" variant="secondary" disabled={isLoading || candidateProgress.active} onClick={loadItems}>Vernieuwen</Button></div>
-      {isLoading ? <div>Bonartikelen worden geladen...</div> : null}
-      <CandidateProgressOverlay progress={candidateProgress} percent={progressPercent} />
+      <div className="rz-external-databases-section-header">
+        <h3>Bonartikelen voor externe herkenning</h3>
+        <Button type="button" variant="secondary" disabled={isLoading} onClick={loadItems}>Vernieuwen</Button>
+      </div>
       <div className="rz-external-databases-actions">
         <Button type="button" variant="secondary" disabled={!selectedItemIds.length} onClick={exportSelectedItems}>Exporteren</Button>
-        <Button type="button" variant="secondary" disabled={!selectedLinkedCount || isUnlinking} onClick={unlinkSelectedItems}>{isUnlinking ? 'Ontkoppelen...' : 'Ontkoppelen'}</Button>
         <span className="rz-external-databases-muted">Geselecteerd: {selectedItemIds.length}</span>
       </div>
-      {confirmOverwrite ? <div className="rz-modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="external-overwrite-title"><div className="rz-modal-card"><h3 id="external-overwrite-title" className="rz-modal-title">Cataloguskoppeling overschrijven?</h3><p className="rz-modal-text">Dit bonartikel is al gekoppeld aan een catalogusartikel.</p><p className="rz-modal-text">Wil je de bestaande koppeling overschrijven?</p><div className="rz-modal-actions"><Button type="button" variant="primary" disabled={isProcessingCandidate} onClick={() => processSelectedCandidate({ forceOverwrite: true })}>Overschrijven</Button><Button type="button" variant="secondary" disabled={isProcessingCandidate} onClick={() => setConfirmOverwrite(false)}>Annuleren</Button></div></div></div> : null}
+      {isLoading ? <div>Bonartikelen worden geladen...</div> : null}
 
       <div className="rz-table-scroll rz-table-scroll--wide">
         <Table dataTestId="external-receipt-items-table" tableClassName="rz-external-receipt-table" resizableColumns>
-          <colgroup><col className="rz-external-receipt-col-select" /><col className="rz-external-receipt-col-receipt" /><col className="rz-external-receipt-col-retailer" /><col className="rz-external-receipt-col-catalog" /><col className="rz-external-receipt-col-code" /><col className="rz-external-receipt-col-gtin" /><col className="rz-external-receipt-col-quantity" /><col className="rz-external-receipt-col-price" /><col className="rz-external-receipt-col-amount" /><col className="rz-external-receipt-col-candidate" /><col className="rz-external-receipt-col-candidate-score" /><col className="rz-external-receipt-col-candidates" /></colgroup>
+          <colgroup><col /><col /><col /><col /><col /><col /><col /><col /><col /><col /><col /><col /></colgroup>
           <thead>
             <tr className="rz-table-header"><th className="rz-check"><input type="checkbox" checked={allVisibleSelected} onChange={toggleVisibleItems} /></th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('receiptLineText')}>Bonartikel <span>{sortMark('receiptLineText')}</span></button></th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('retailerCode')}>Winkelketen <span>{sortMark('retailerCode')}</span></button></th><th className="rz-check"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('catalogLinked')}>Catalogus <span>{sortMark('catalogLinked')}</span></button></th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('articleNumber')}>Artikelnummer <span>{sortMark('articleNumber')}</span></button></th><th>GTIN / EAN</th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('quantity')}>Omvang / gewicht <span>{sortMark('quantity')}</span></button></th><th className="rz-num">Prijs</th><th className="rz-num">Aantal</th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('bestCandidateName')}>Kandidaat <span>{sortMark('bestCandidateName')}</span></button></th><th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('bestCandidateScore')}>Score <span>{sortMark('bestCandidateScore')}</span></button></th><th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('candidateCount')}>Externe kandidaten <span>{sortMark('candidateCount')}</span></button></th></tr>
             <tr className="rz-external-databases-filter-row"><th></th><th><input className="rz-table-filter" value={filters.receiptLineText} onChange={(event) => updateFilter('receiptLineText', event.target.value)} placeholder="Zoek" /></th><th><input className="rz-table-filter" value={filters.retailerCode} onChange={(event) => updateFilter('retailerCode', event.target.value)} placeholder="Filter" /></th><th><select className="rz-table-filter" value={filters.catalogLinked} onChange={(event) => updateFilter('catalogLinked', event.target.value)} aria-label="Catalogus filter"><option value="all">Alle</option><option value="linked">Gekoppeld</option><option value="unlinked">Niet gekoppeld</option></select></th><th><input className="rz-table-filter" value={filters.articleNumber} onChange={(event) => updateFilter('articleNumber', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.gtin} onChange={(event) => updateFilter('gtin', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.quantity} onChange={(event) => updateFilter('quantity', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.price} onChange={(event) => updateFilter('price', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.amount} onChange={(event) => updateFilter('amount', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.bestCandidateName} onChange={(event) => updateFilter('bestCandidateName', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.bestCandidateScore} onChange={(event) => updateFilter('bestCandidateScore', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.candidateCount} onChange={(event) => updateFilter('candidateCount', event.target.value)} placeholder="Filter" /></th></tr>
@@ -646,7 +421,7 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
         <Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => goToPage(pageCount)}>Laatste</Button>
       </div>
 
-      {selectedItem ? <div className="rz-external-receipt-detail"><h3>Kandidaten voor: {selectedItem.receiptLineText}</h3><dl><dt>Winkelketen</dt><dd>{selectedItem.retailerCode}</dd><dt>Artikelnummer</dt><dd>{selectedItem.articleNumber}</dd><dt>GTIN / EAN</dt><dd>{selectedItem.gtin}</dd><dt>Status</dt><dd>{selectedItem.status}</dd></dl><Table tableClassName="rz-external-candidate-detail-table" resizableColumns><colgroup><col className="rz-external-candidate-col-choice" /><col className="rz-external-candidate-col-name" /><col className="rz-external-candidate-col-brand" /><col className="rz-external-candidate-col-source" /><col className="rz-external-candidate-col-code" /><col className="rz-external-candidate-col-variant" /><col className="rz-external-candidate-col-score" /><col className="rz-external-candidate-col-status" /></colgroup><thead><tr className="rz-table-header"><th>Keuze</th><th>Kandidaat</th><th>Merk</th><th>Bron</th><th>Artikelnummer</th><th>Variant</th><th className="rz-num">Score</th><th>Status</th></tr></thead><tbody>{selectedItem.candidates.length ? selectedItem.candidates.map((candidate) => <tr key={candidate.id} className={selectedCandidateId === candidate.id ? 'rz-row-selected' : ''}><td className="rz-check"><input type="radio" name="external-candidate" checked={selectedCandidateId === candidate.id} disabled={!candidate.isLinkableToCatalog && !candidate.isLinkedToCatalog} onChange={() => setSelectedCandidateId(candidate.id)} /></td><td>{candidate.candidateName}</td><td>{candidate.brand}</td><td>{candidate.source}</td><td>{candidate.externalCode}</td><td>{candidate.variant}</td><td className="rz-num">{scoreText(candidate.score)}</td><td>{candidate.status}</td></tr>) : <tr><td colSpan="8">Geen externe kandidaten voor dit bonartikel.</td></tr>}</tbody></Table><div className="rz-external-databases-actions"><Button type="button" disabled={!selectedCandidateCanBeLinked || isProcessingCandidate} onClick={() => processSelectedCandidate()}>{isProcessingCandidate ? 'Verwerken...' : 'Kandidaat koppelen'}</Button><Button type="button" variant="secondary" disabled={!selectedCandidateIsLinked || isUnlinking} onClick={handleUnlinkSelectedCandidate}>{isUnlinking ? 'Ontkoppelen...' : 'Koppeling verwijderen'}</Button></div></div> : null}
+      {selectedItem ? <div className="rz-external-receipt-detail"><h3>Koppelen kandidaten in artikel-catalogus</h3><p>Kandidaten voor: {selectedItem.receiptLineText}</p><dl><dt>Winkelketen</dt><dd>{selectedItem.retailerCode}</dd><dt>Artikelnummer</dt><dd>{selectedItem.articleNumber}</dd><dt>GTIN / EAN</dt><dd>{selectedItem.gtin}</dd><dt>Status</dt><dd>{selectedItem.status}</dd></dl><Table dataTestId="external-receipt-item-candidates-table" tableClassName="rz-external-candidate-detail-table" resizableColumns><thead><tr className="rz-table-header"><th>Keuze</th><th>Kandidaat</th><th>Merk</th><th>Bron</th><th>Artikelnummer</th><th>Variant</th><th className="rz-num">Score</th><th>Status</th></tr></thead><tbody>{selectedCandidates.length ? selectedCandidates.map((candidate) => <tr key={candidate.id} className={selectedCandidateId === candidate.id ? 'rz-row-selected' : ''}><td className="rz-check"><input type="radio" name="external-candidate" checked={selectedCandidateId === candidate.id} disabled={!candidate.isLinkableToCatalog && !candidate.isLinkedToCatalog} onChange={() => setSelectedCandidateId(candidate.id)} /></td><td>{candidate.candidateName}</td><td>{candidate.brand}</td><td>{candidate.source}</td><td>{candidate.externalCode}</td><td>{candidate.variant}</td><td className="rz-num">{scoreText(candidate.score)}</td><td>{candidate.status}</td></tr>) : <tr><td colSpan="8">Geen externe kandidaten voor dit bonartikel.</td></tr>}</tbody></Table><div className="rz-external-databases-actions"><Button type="button" disabled={!selectedCandidateCanBeLinked} onClick={processSelectedCandidate}>Koppel artikel</Button></div></div> : null}
     </div>
   )
 }


### PR DESCRIPTION
## Samenvatting

Deze PR voegt generieke ondersteuning toe voor spaarzegelregels op kassabonnen.

Belangrijkste wijzigingen:
- spaarzegeltermen naar beheerde dictionarydata
- betaalde spaarzegelregels blijven meetellen in kassaboncontrole
- spaarzegels worden uitgesloten van voorraad en externe kandidaatmatching
- labelregel en detailregel kunnen samen worden genormaliseerd
- quantity, unit_price en line_total blijven behouden
- regressietest voor spaarzegel-normalisatie toegevoegd

## Validatie

Lokaal groen gevalideerd:
- backend health: ok
- spaarzegels backendtest: SPAARZEGELS_NORMALIZATION_OK
- frontend regressie: 12 passed
- fixture cleanup voor en na regressie: ok

## Scope

Geen UI, geen database-migratie en geen nieuwe winkelketen-specifieke parseruitbreiding.