### PR TITLE
M2C2i-26C — Spaarzegels uitsluiten van Externe database-flow

### DIFF
--- a/backend/app/receipt_ingestion/spaarzegels_terms.py
+++ b/backend/app/receipt_ingestion/spaarzegels_terms.py
@@ -110,6 +110,34 @@ def is_spaarzegels_financial_pair(*, label_text: str | None, detail_text: str | 
     return contains_spaarzegels_priced_token(combined) is not None
 
 
+def is_spaarzegels_financial_context(*values: str | None) -> bool:
+    combined = _combined_text(*values)
+    if not combined or not _has_amount(combined):
+        return False
+    return contains_spaarzegels_priced_token(combined) is not None
+
+
+def is_spaarzegels_flow_excluded(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    if value.get("line_type") == "spaarzegels" or value.get("is_spaarzegels") is True:
+        return True
+    if value.get("exclude_from_inventory") is True or value.get("external_matching_allowed") is False:
+        return True
+    trace = value.get("producer_trace")
+    if isinstance(trace, dict):
+        return is_spaarzegels_flow_excluded(trace)
+    return is_spaarzegels_financial_context(
+        value.get("receipt_line_text"),
+        value.get("raw_label"),
+        value.get("normalized_label"),
+        value.get("line_total"),
+        value.get("unit_price"),
+        value.get("price"),
+        value.get("quantity_label"),
+    )
+
+
 def spaarzegels_financial_metadata(
     value: str | None = None,
     *,

--- a/backend/app/services/external_database_matchflow_evidence.py
+++ b/backend/app/services/external_database_matchflow_evidence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.receipt_ingestion.spaarzegels_terms import is_spaarzegels_flow_excluded, is_spaarzegels_financial_context
 from app.services import external_product_candidate_store as candidate_store
 from app.services.external_candidate_normalization import normalize_external_candidates
 from app.services.external_database_matchers import (
@@ -170,7 +171,39 @@ def _with_evidence_scoring(result: dict[str, Any], receipt_line_text: str, retai
     return enriched
 
 
+def _external_matching_blocked_result(retailer_code: str, receipt_line_text: str) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "retailer_code": retailer_code,
+        "receipt_line_text": receipt_line_text,
+        "candidates": [],
+        "candidate_count": 0,
+        "processed": 0,
+        "saved_count": 0,
+        "updated_count": 0,
+        "skipped_count": 1,
+        "external_matching_allowed": False,
+        "excluded_from_external_database": True,
+        "exclusion_reason": "spaarzegels_financial_line",
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+    }
+
+
+def _item_allows_external_matching(item: dict[str, Any]) -> bool:
+    return not is_spaarzegels_flow_excluded(item)
+
+
+def _filter_external_matching_items(items: Any) -> list[dict[str, Any]]:
+    if not isinstance(items, list):
+        return []
+    return [dict(item) for item in items if isinstance(item, dict) and _item_allows_external_matching(item)]
+
+
 def match_retailer_receipt_line(retailer_code: str, receipt_line_text: str, include_below_threshold: bool = True) -> dict[str, Any]:
+    if is_spaarzegels_financial_context(receipt_line_text):
+        return _external_matching_blocked_result(retailer_code, receipt_line_text)
     result = _base_match_retailer_receipt_line(
         retailer_code=retailer_code,
         receipt_line_text=receipt_line_text,
@@ -183,6 +216,9 @@ def save_matchpreview_candidates(*args: Any, **kwargs: Any) -> dict[str, Any]:
     previous_matcher = candidate_store.match_retailer_receipt_line
     candidate_store.match_retailer_receipt_line = match_retailer_receipt_line
     try:
+        if "items" in kwargs:
+            kwargs = dict(kwargs)
+            kwargs["items"] = _filter_external_matching_items(kwargs.get("items"))
         return candidate_store.save_matchpreview_candidates(*args, **kwargs)
     finally:
         candidate_store.match_retailer_receipt_line = previous_matcher
@@ -192,6 +228,17 @@ def ensure_external_receipt_item_candidates(*args: Any, **kwargs: Any) -> dict[s
     previous_matcher = candidate_store.match_retailer_receipt_line
     candidate_store.match_retailer_receipt_line = match_retailer_receipt_line
     try:
+        if "items" in kwargs:
+            kwargs = dict(kwargs)
+            original_items = kwargs.get("items")
+            filtered_items = _filter_external_matching_items(original_items)
+            kwargs["items"] = filtered_items
+            result = candidate_store.ensure_external_receipt_item_candidates(*args, **kwargs)
+            if isinstance(original_items, list):
+                result = dict(result)
+                result["spaarzegels_excluded_count"] = len(original_items) - len(filtered_items)
+                result["external_matching_guardrail"] = "spaarzegels_financial_lines_excluded"
+            return result
         return candidate_store.ensure_external_receipt_item_candidates(*args, **kwargs)
     finally:
         candidate_store.match_retailer_receipt_line = previous_matcher

--- a/backend/app/services/external_receipt_auto_coverage.py
+++ b/backend/app/services/external_receipt_auto_coverage.py
@@ -9,7 +9,7 @@ from typing import Any, Callable
 from sqlalchemy import text
 
 from app.db import engine
-from app.receipt_ingestion.spaarzegels_terms import is_spaarzegels_financial_line
+from app.receipt_ingestion.spaarzegels_terms import is_spaarzegels_flow_excluded
 from app.services.external_database_matchflow_evidence import ensure_external_receipt_item_candidates
 
 LOGGER = logging.getLogger(__name__)
@@ -39,10 +39,7 @@ def _receipt_table_exists(conn) -> bool:
 
 
 def _is_external_matching_allowed(row: dict[str, Any]) -> bool:
-    receipt_text = _text(row.get("receipt_line_text")) or _text(row.get("normalized_label"))
-    if is_spaarzegels_financial_line(receipt_text):
-        return False
-    return True
+    return not is_spaarzegels_flow_excluded(row)
 
 
 def _receipt_table_items(receipt_table_id: str) -> list[dict[str, Any]]:
@@ -61,9 +58,12 @@ def _receipt_table_items(receipt_table_id: str) -> list[dict[str, Any]]:
                     rtl.id AS receipt_line_id,
                     rt.store_name AS retailer_code,
                     COALESCE(NULLIF(rtl.raw_label, ''), rtl.normalized_label) AS receipt_line_text,
+                    rtl.raw_label AS raw_label,
                     rtl.normalized_label AS normalized_label,
                     rtl.barcode AS retailer_article_number,
                     TRIM(COALESCE(CAST(rtl.quantity AS TEXT), '') || ' ' || COALESCE(CAST(rtl.unit AS TEXT), '')) AS quantity_label,
+                    rtl.unit_price AS unit_price,
+                    rtl.line_total AS line_total,
                     rtl.line_total AS price
                 FROM receipt_table_lines rtl
                 JOIN receipt_tables rt ON rt.id = rtl.receipt_table_id

--- a/backend/tests/test_spaarzegels_financial_normalization.py
+++ b/backend/tests/test_spaarzegels_financial_normalization.py
@@ -11,8 +11,10 @@ if str(APP_ROOT) not in sys.path:
 from app.receipt_ingestion.product_candidate_gateway import append_product_candidate
 from app.receipt_ingestion.spaarzegels_terms import (
     is_spaarzegels_financial_pair,
+    is_spaarzegels_flow_excluded,
     spaarzegels_financial_metadata,
 )
+from app.services.external_database_matchflow_evidence import _filter_external_matching_items
 
 
 def _clean(value: str | None) -> str:
@@ -41,24 +43,7 @@ def _classify(_value: str) -> str:
     return "product_candidate"
 
 
-def test_spaarzegels_financial_pair_combines_label_and_detail_line():
-    assert is_spaarzegels_financial_pair(
-        label_text="Koopzegels",
-        detail_text="2 x 0.10 0.20",
-    )
-
-    metadata = spaarzegels_financial_metadata(
-        label_text="Koopzegels",
-        detail_text="2 x 0.10 0.20",
-    )
-
-    assert metadata["line_type"] == "spaarzegels"
-    assert metadata["include_in_receipt_total"] is True
-    assert metadata["exclude_from_inventory"] is True
-    assert metadata["external_matching_allowed"] is False
-
-
-def test_gateway_preserves_quantity_unit_price_total_for_spaarzegels_pair():
+def _spaarzegels_line() -> dict:
     extracted: list[dict] = []
 
     appended_index = append_product_candidate(
@@ -85,8 +70,29 @@ def test_gateway_preserves_quantity_unit_price_total_for_spaarzegels_pair():
 
     assert appended_index == 0
     assert len(extracted) == 1
+    return extracted[0]
 
-    line = extracted[0]
+
+def test_spaarzegels_financial_pair_combines_label_and_detail_line():
+    assert is_spaarzegels_financial_pair(
+        label_text="Koopzegels",
+        detail_text="2 x 0.10 0.20",
+    )
+
+    metadata = spaarzegels_financial_metadata(
+        label_text="Koopzegels",
+        detail_text="2 x 0.10 0.20",
+    )
+
+    assert metadata["line_type"] == "spaarzegels"
+    assert metadata["include_in_receipt_total"] is True
+    assert metadata["exclude_from_inventory"] is True
+    assert metadata["external_matching_allowed"] is False
+
+
+def test_gateway_preserves_quantity_unit_price_total_for_spaarzegels_pair():
+    line = _spaarzegels_line()
+
     assert line["quantity"] == 2.0
     assert line["unit_price"] == 0.10
     assert line["line_total"] == 0.20
@@ -100,7 +106,45 @@ def test_gateway_preserves_quantity_unit_price_total_for_spaarzegels_pair():
     assert trace["external_matching_allowed"] is False
 
 
+def test_spaarzegels_are_excluded_from_external_database_items():
+    spaarzegels_line = _spaarzegels_line()
+    product_line = {
+        "receipt_line_id": "product-1",
+        "receipt_line_text": "Halfvolle melk",
+        "raw_label": "Halfvolle melk",
+        "normalized_label": "Halfvolle melk",
+        "line_total": 1.29,
+        "unit_price": 1.29,
+        "price": 1.29,
+    }
+
+    external_items = [
+        {
+            "receipt_line_id": "spaarzegels-1",
+            "receipt_line_text": spaarzegels_line["raw_label"],
+            "raw_label": spaarzegels_line["raw_label"],
+            "normalized_label": spaarzegels_line["normalized_label"],
+            "quantity_label": str(spaarzegels_line["quantity"]),
+            "unit_price": spaarzegels_line["unit_price"],
+            "line_total": spaarzegels_line["line_total"],
+            "price": spaarzegels_line["line_total"],
+            "line_type": spaarzegels_line["line_type"],
+            "is_spaarzegels": spaarzegels_line["is_spaarzegels"],
+            "external_matching_allowed": spaarzegels_line["external_matching_allowed"],
+        },
+        product_line,
+    ]
+
+    assert is_spaarzegels_flow_excluded(external_items[0]) is True
+    assert is_spaarzegels_flow_excluded(product_line) is False
+
+    filtered_items = _filter_external_matching_items(external_items)
+
+    assert filtered_items == [product_line]
+
+
 if __name__ == "__main__":
     test_spaarzegels_financial_pair_combines_label_and_detail_line()
     test_gateway_preserves_quantity_unit_price_total_for_spaarzegels_pair()
+    test_spaarzegels_are_excluded_from_external_database_items()
     print("SPAARZEGELS_NORMALIZATION_OK")


### PR DESCRIPTION
## Samenvatting

Deze PR sluit spaarzegels expliciet uit van artikel-, voorraad- en Externe database-flows.

Wijzigingen:
- centrale spaarzegel-flowguard toegevoegd
- Externe database auto-coverage gebruikt volledige rijcontext
- Externe database matchflow filtert spaarzegelregels vooraf uit
- regressietest uitgebreid met externe-database-uitsluiting

## Validatie

Lokaal groen gevalideerd:
- backend health: ok
- spaarzegels backendtest: SPAARZEGELS_NORMALIZATION_OK
- frontend regressie: 12 passed
- fixture cleanup voor en na regressie: ok

## Scope

Geen UI, geen database-migratie, geen saldo-opslag en geen nieuwe winkelketenadapter.