### PR TITLE
M2C2i-26D — Loyalty stamp transactions

### DIFF
--- a/backend/app/services/external_receipt_auto_coverage.py
+++ b/backend/app/services/external_receipt_auto_coverage.py
@@ -11,6 +11,7 @@ from sqlalchemy import text
 from app.db import engine
 from app.receipt_ingestion.spaarzegels_terms import is_spaarzegels_flow_excluded
 from app.services.external_database_matchflow_evidence import ensure_external_receipt_item_candidates
+from app.services.loyalty_stamp_transaction_service import sync_loyalty_stamp_transactions_for_receipt_table
 
 LOGGER = logging.getLogger(__name__)
 
@@ -94,6 +95,11 @@ def _receipt_table_items(receipt_table_id: str) -> list[dict[str, Any]]:
     return items
 
 
+def _sync_stamp_transactions(receipt_table_id: str) -> dict[str, Any]:
+    with engine.begin() as conn:
+        return sync_loyalty_stamp_transactions_for_receipt_table(conn, receipt_table_id)
+
+
 def auto_ensure_external_candidates_for_receipt_table(
     receipt_table_id: str,
     include_below_threshold: bool = True,
@@ -156,6 +162,12 @@ def _with_receipt_auto_coverage(original: Callable[..., Any]) -> Callable[..., A
             return next_result
 
         try:
+            next_result["loyalty_stamp_transactions"] = _sync_stamp_transactions(receipt_table_id)
+        except Exception as exc:  # pragma: no cover
+            LOGGER.warning("Spaarzegeltransacties synchroniseren mislukt voor bon %s: %s", receipt_table_id, exc)
+            next_result["loyalty_stamp_transactions"] = {"ok": False, "receipt_table_id": receipt_table_id, "error": str(exc)}
+
+        try:
             next_result["external_candidate_coverage"] = auto_ensure_external_candidates_for_receipt_table(
                 receipt_table_id,
                 include_below_threshold=True,
@@ -197,6 +209,12 @@ def _with_reparse_auto_coverage(original: Callable[..., Any]) -> Callable[..., A
                 receipt_table_id = _text(kwargs.get("receipt_table_id"))
         if not receipt_table_id:
             return next_result
+
+        try:
+            next_result["loyalty_stamp_transactions"] = _sync_stamp_transactions(receipt_table_id)
+        except Exception as exc:  # pragma: no cover
+            LOGGER.warning("Spaarzegeltransacties synchroniseren na heranalyse mislukt voor bon %s: %s", receipt_table_id, exc)
+            next_result["loyalty_stamp_transactions"] = {"ok": False, "receipt_table_id": receipt_table_id, "error": str(exc)}
 
         try:
             next_result["external_candidate_coverage"] = auto_ensure_external_candidates_for_receipt_table(

--- a/backend/app/services/loyalty_stamp_transaction_service.py
+++ b/backend/app/services/loyalty_stamp_transaction_service.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any
+
+from sqlalchemy import text
+
+from app.receipt_ingestion.spaarzegels_terms import is_spaarzegels_flow_excluded
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _number(value: Any) -> float | None:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        return float(str(value).replace(",", "."))
+    except (TypeError, ValueError):
+        return None
+
+
+def _stamp_program_code(store_name: str | None) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "_", _text(store_name).lower()).strip("_")
+    return f"{normalized or 'unknown'}_spaarzegels"
+
+
+def ensure_loyalty_stamp_transactions_schema(conn) -> None:
+    conn.execute(
+        text(
+            """
+            CREATE TABLE IF NOT EXISTS loyalty_stamp_transactions (
+                id TEXT PRIMARY KEY,
+                household_id TEXT NOT NULL,
+                receipt_table_id TEXT NOT NULL,
+                receipt_line_id TEXT NOT NULL,
+                store_name TEXT,
+                stamp_program_code TEXT NOT NULL,
+                quantity REAL,
+                unit_price REAL,
+                line_total REAL,
+                transaction_type TEXT NOT NULL DEFAULT 'purchase',
+                source TEXT NOT NULL DEFAULT 'receipt_table_line',
+                purchase_at TEXT,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+    )
+    conn.execute(
+        text(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_loyalty_stamp_transactions_receipt_line
+            ON loyalty_stamp_transactions (receipt_line_id)
+            """
+        )
+    )
+    conn.execute(
+        text(
+            """
+            CREATE INDEX IF NOT EXISTS idx_loyalty_stamp_transactions_household_store
+            ON loyalty_stamp_transactions (household_id, store_name, purchase_at)
+            """
+        )
+    )
+    conn.execute(
+        text(
+            """
+            CREATE INDEX IF NOT EXISTS idx_loyalty_stamp_transactions_receipt_table
+            ON loyalty_stamp_transactions (receipt_table_id)
+            """
+        )
+    )
+
+
+def _spaarzegels_transaction_rows(conn, receipt_table_id: str) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        text(
+            """
+            SELECT
+                rt.household_id,
+                rt.id AS receipt_table_id,
+                rt.store_name,
+                rt.purchase_at,
+                rtl.id AS receipt_line_id,
+                rtl.raw_label,
+                rtl.normalized_label,
+                TRIM(COALESCE(CAST(rtl.quantity AS TEXT), '') || ' ' || COALESCE(CAST(rtl.unit AS TEXT), '')) AS quantity_label,
+                rtl.quantity,
+                rtl.unit_price,
+                rtl.line_total
+            FROM receipt_table_lines rtl
+            JOIN receipt_tables rt ON rt.id = rtl.receipt_table_id
+            WHERE rtl.receipt_table_id = :receipt_table_id
+            ORDER BY rtl.line_index ASC, rtl.id ASC
+            """
+        ),
+        {"receipt_table_id": _text(receipt_table_id)},
+    ).mappings().all()
+
+    transaction_rows: list[dict[str, Any]] = []
+    for row in rows:
+        row_data = dict(row)
+        if not is_spaarzegels_flow_excluded({
+            "receipt_line_text": row_data.get("raw_label") or row_data.get("normalized_label"),
+            "raw_label": row_data.get("raw_label"),
+            "normalized_label": row_data.get("normalized_label"),
+            "quantity_label": row_data.get("quantity_label"),
+            "quantity": row_data.get("quantity"),
+            "unit_price": row_data.get("unit_price"),
+            "line_total": row_data.get("line_total"),
+            "price": row_data.get("line_total"),
+        }):
+            continue
+        transaction_rows.append({
+            "id": uuid.uuid4().hex,
+            "household_id": _text(row_data.get("household_id")),
+            "receipt_table_id": _text(row_data.get("receipt_table_id")),
+            "receipt_line_id": _text(row_data.get("receipt_line_id")),
+            "store_name": _text(row_data.get("store_name")) or None,
+            "stamp_program_code": _stamp_program_code(row_data.get("store_name")),
+            "quantity": _number(row_data.get("quantity")),
+            "unit_price": _number(row_data.get("unit_price")),
+            "line_total": _number(row_data.get("line_total")),
+            "transaction_type": "purchase",
+            "source": "receipt_table_line",
+            "purchase_at": _text(row_data.get("purchase_at")) or None,
+        })
+    return transaction_rows
+
+
+def sync_loyalty_stamp_transactions_for_receipt_table(conn, receipt_table_id: str) -> dict[str, Any]:
+    normalized_receipt_table_id = _text(receipt_table_id)
+    if not normalized_receipt_table_id:
+        return {"ok": True, "receipt_table_id": "", "transaction_count": 0, "deleted_count": 0, "inserted_count": 0}
+
+    ensure_loyalty_stamp_transactions_schema(conn)
+    rows = _spaarzegels_transaction_rows(conn, normalized_receipt_table_id)
+
+    existing = conn.execute(
+        text("SELECT COUNT(*) AS total FROM loyalty_stamp_transactions WHERE receipt_table_id = :receipt_table_id"),
+        {"receipt_table_id": normalized_receipt_table_id},
+    ).mappings().first()
+    deleted_count = int((existing or {}).get("total") or 0)
+
+    conn.execute(
+        text("DELETE FROM loyalty_stamp_transactions WHERE receipt_table_id = :receipt_table_id"),
+        {"receipt_table_id": normalized_receipt_table_id},
+    )
+
+    if rows:
+        conn.execute(
+            text(
+                """
+                INSERT INTO loyalty_stamp_transactions (
+                    id, household_id, receipt_table_id, receipt_line_id, store_name, stamp_program_code,
+                    quantity, unit_price, line_total, transaction_type, source, purchase_at
+                ) VALUES (
+                    :id, :household_id, :receipt_table_id, :receipt_line_id, :store_name, :stamp_program_code,
+                    :quantity, :unit_price, :line_total, :transaction_type, :source, :purchase_at
+                )
+                """
+            ),
+            rows,
+        )
+
+    return {
+        "ok": True,
+        "receipt_table_id": normalized_receipt_table_id,
+        "transaction_count": len(rows),
+        "deleted_count": deleted_count,
+        "inserted_count": len(rows),
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+        "creates_external_database_candidate": False,
+    }

--- a/backend/app/services/loyalty_stamp_transaction_service.py
+++ b/backend/app/services/loyalty_stamp_transaction_service.py
@@ -22,6 +22,13 @@ def _number(value: Any) -> float | None:
         return None
 
 
+def _amount_text(value: Any) -> str:
+    number = _number(value)
+    if number is None:
+        return ""
+    return f"{number:.2f}"
+
+
 def _stamp_program_code(store_name: str | None) -> str:
     normalized = re.sub(r"[^a-z0-9]+", "_", _text(store_name).lower()).strip("_")
     return f"{normalized or 'unknown'}_spaarzegels"
@@ -104,15 +111,17 @@ def _spaarzegels_transaction_rows(conn, receipt_table_id: str) -> list[dict[str,
     transaction_rows: list[dict[str, Any]] = []
     for row in rows:
         row_data = dict(row)
+        line_total_text = _amount_text(row_data.get("line_total"))
+        unit_price_text = _amount_text(row_data.get("unit_price"))
         if not is_spaarzegels_flow_excluded({
             "receipt_line_text": row_data.get("raw_label") or row_data.get("normalized_label"),
             "raw_label": row_data.get("raw_label"),
             "normalized_label": row_data.get("normalized_label"),
             "quantity_label": row_data.get("quantity_label"),
             "quantity": row_data.get("quantity"),
-            "unit_price": row_data.get("unit_price"),
-            "line_total": row_data.get("line_total"),
-            "price": row_data.get("line_total"),
+            "unit_price": unit_price_text,
+            "line_total": line_total_text,
+            "price": line_total_text,
         }):
             continue
         transaction_rows.append({

--- a/backend/tests/test_spaarzegels_financial_normalization.py
+++ b/backend/tests/test_spaarzegels_financial_normalization.py
@@ -4,6 +4,8 @@ import sys
 from decimal import Decimal
 from pathlib import Path
 
+from sqlalchemy import create_engine, text
+
 APP_ROOT = Path(__file__).resolve().parents[1]
 if str(APP_ROOT) not in sys.path:
     sys.path.insert(0, str(APP_ROOT))
@@ -15,6 +17,7 @@ from app.receipt_ingestion.spaarzegels_terms import (
     spaarzegels_financial_metadata,
 )
 from app.services.external_database_matchflow_evidence import _filter_external_matching_items
+from app.services.loyalty_stamp_transaction_service import sync_loyalty_stamp_transactions_for_receipt_table
 
 
 def _clean(value: str | None) -> str:
@@ -143,8 +146,71 @@ def test_spaarzegels_are_excluded_from_external_database_items():
     assert filtered_items == [product_line]
 
 
+def test_spaarzegels_transactions_are_stored_idempotently():
+    db = create_engine("sqlite:///:memory:")
+    with db.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE receipt_tables (
+                id TEXT PRIMARY KEY,
+                household_id TEXT NOT NULL,
+                store_name TEXT,
+                purchase_at TEXT
+            )
+        """))
+        conn.execute(text("""
+            CREATE TABLE receipt_table_lines (
+                id TEXT PRIMARY KEY,
+                receipt_table_id TEXT NOT NULL,
+                line_index INTEGER,
+                raw_label TEXT,
+                normalized_label TEXT,
+                quantity REAL,
+                unit TEXT,
+                unit_price REAL,
+                line_total REAL
+            )
+        """))
+        conn.execute(
+            text("""
+                INSERT INTO receipt_tables (id, household_id, store_name, purchase_at)
+                VALUES ('rt1', '1', 'Jumbo', '2026-06-28')
+            """),
+        )
+        conn.execute(
+            text("""
+                INSERT INTO receipt_table_lines (
+                    id, receipt_table_id, line_index, raw_label, normalized_label, quantity, unit, unit_price, line_total
+                ) VALUES
+                    ('rtl-spaarzegels', 'rt1', 1, 'Koopzegels', 'Koopzegels', 2, NULL, 0.10, 0.20),
+                    ('rtl-product', 'rt1', 2, 'Halfvolle melk', 'Halfvolle melk', 1, NULL, 1.29, 1.29)
+            """),
+        )
+
+        first = sync_loyalty_stamp_transactions_for_receipt_table(conn, 'rt1')
+        second = sync_loyalty_stamp_transactions_for_receipt_table(conn, 'rt1')
+
+        rows = conn.execute(
+            text("SELECT * FROM loyalty_stamp_transactions ORDER BY receipt_line_id")
+        ).mappings().all()
+
+    assert first["transaction_count"] == 1
+    assert second["transaction_count"] == 1
+    assert len(rows) == 1
+    row = dict(rows[0])
+    assert row["receipt_line_id"] == "rtl-spaarzegels"
+    assert row["household_id"] == "1"
+    assert row["store_name"] == "Jumbo"
+    assert row["stamp_program_code"] == "jumbo_spaarzegels"
+    assert row["quantity"] == 2.0
+    assert row["unit_price"] == 0.10
+    assert row["line_total"] == 0.20
+    assert row["transaction_type"] == "purchase"
+    assert row["source"] == "receipt_table_line"
+
+
 if __name__ == "__main__":
     test_spaarzegels_financial_pair_combines_label_and_detail_line()
     test_gateway_preserves_quantity_unit_price_total_for_spaarzegels_pair()
     test_spaarzegels_are_excluded_from_external_database_items()
+    test_spaarzegels_transactions_are_stored_idempotently()
     print("SPAARZEGELS_NORMALIZATION_OK")


### PR DESCRIPTION
Backend-only wijziging voor idempotente opslag van spaarzegeltransacties.

Validatie lokaal groen:
- backend health ok
- backendtest SPAARZEGELS_NORMALIZATION_OK
- frontend regressie 12 passed
- fixture cleanup ok

Scope: geen UI, geen saldo, geen voorraadmutatie, geen externe database-mutatie.