### PR TITLE
M2C2i-28A OFF zichtbaar raadplegen

### DIFF
--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -15,6 +15,10 @@ const FALLBACK_CANDIDATE_STATUSES = new Set([
 ])
 
 function text(value, fallback = '-') {
+  if (Array.isArray(value)) {
+    const normalized = value.map((item) => text(item, '')).filter(Boolean).join(', ')
+    return normalized || fallback
+  }
   const normalized = String(value || '').trim()
   return normalized || fallback
 }
@@ -181,7 +185,6 @@ function bestCandidateForItem(candidates) {
 
 function buildReceiptItems(rawItems) {
   const grouped = new Map()
-
   rawItems.forEach((rawItem) => {
     const key = rowKey(rawItem)
     const current = grouped.get(key) || {
@@ -201,7 +204,6 @@ function buildReceiptItems(rawItems) {
       status: 'Nog niet verwerkt',
       candidates: [],
     }
-
     const nestedCandidates = rawItem.is_receipt_item_placeholder && Array.isArray(rawItem.candidates) ? rawItem.candidates : [rawItem]
     nestedCandidates.forEach((candidate) => {
       if (rawItem.is_receipt_item_placeholder && !candidate) return
@@ -214,12 +216,10 @@ function buildReceiptItems(rawItems) {
         }
       }
     })
-
     if (!current.catalogLinked && current.candidates.some((candidate) => !candidate.isFallbackCandidate)) current.status = 'Kandidaten gevonden'
     if (!current.catalogLinked && !current.candidates.some((candidate) => !candidate.isFallbackCandidate) && current.candidates.some((candidate) => candidate.isFallbackCandidate)) current.status = 'Geen externe match'
     grouped.set(key, current)
   })
-
   return Array.from(grouped.values()).map((item) => {
     const candidates = dedupeCandidates(item.candidates).sort((left, right) => Number(right.score || 0) - Number(left.score || 0))
     const bestCandidate = bestCandidateForItem(candidates)
@@ -246,12 +246,27 @@ function csvValue(value) {
   return `"${String(value ?? '').replaceAll('"', '""')}"`
 }
 
+function offCandidateKey(candidate) {
+  return text(candidate.code || candidate.gtin || candidate.ean || candidate.source_product_code || candidate.product_name, 'off-candidate')
+}
+
+function offStatusLabel(preview) {
+  if (!preview) return '-'
+  if (preview.status === 'found') return 'Gevonden'
+  if (preview.status === 'no_results') return 'Geen resultaten'
+  if (preview.status === 'external_source_unavailable') return 'OFF niet beschikbaar'
+  return text(preview.status)
+}
+
 export default function ReceiptItemsOverview({ onError, onMessage }) {
   const [items, setItems] = useState([])
   const [selectedItem, setSelectedItem] = useState(null)
   const [selectedCandidateId, setSelectedCandidateId] = useState('')
   const [selectedItemIds, setSelectedItemIds] = useState([])
   const [isLoading, setIsLoading] = useState(false)
+  const [isOffLoading, setIsOffLoading] = useState(false)
+  const [offPreview, setOffPreview] = useState(null)
+  const [offError, setOffError] = useState('')
   const [filters, setFilters] = useState({ receiptLineText: '', retailerCode: '', catalogLinked: 'all', articleNumber: '', gtin: '', quantity: '', price: '', amount: '', bestCandidateName: '', bestCandidateScore: '', candidateCount: '' })
   const [sortKey, setSortKey] = useState('receiptLineText')
   const [sortDesc, setSortDesc] = useState(false)
@@ -309,21 +324,26 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
     if (filteredItems.some((item) => item.id === selectedItem.id)) return
     setSelectedItem(null)
     setSelectedCandidateId('')
+    setOffPreview(null)
+    setOffError('')
   }, [filteredItems, selectedItem])
 
   const pageCount = Math.max(1, Math.ceil(filteredItems.length / PAGE_SIZE))
   const currentPage = Math.min(page, pageCount)
   const visibleItems = filteredItems.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
-  const emptyRows = Math.max(0, 3 - visibleItems.length)
+  const emptyRows = Math.max(0, PAGE_SIZE - visibleItems.length)
   const visibleIds = visibleItems.map((item) => item.id)
   const allVisibleSelected = visibleIds.length > 0 && visibleIds.every((id) => selectedItemIds.includes(id))
   const selectedCandidates = selectedItem?.candidates || []
   const selectedCandidate = selectedCandidates.find((candidate) => candidate.id === selectedCandidateId) || null
   const selectedCandidateCanBeLinked = Boolean(selectedCandidate && selectedCandidate.isLinkableToCatalog && !selectedCandidate.isFallbackCandidate && !selectedCandidate.isLinkedToCatalog)
+  const offResults = Array.isArray(offPreview?.results) ? offPreview.results : []
 
   function selectReceiptItem(item) {
     setSelectedItem(item)
     setSelectedCandidateId('')
+    setOffPreview(null)
+    setOffError('')
   }
 
   function toggleSelectedItem(itemId) {
@@ -387,6 +407,33 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
     }
   }
 
+  async function consultOpenFoodFacts() {
+    if (!selectedItem) return
+    setIsOffLoading(true)
+    setOffPreview(null)
+    setOffError('')
+    try {
+      const response = await fetchJsonWithAuth('/api/external-databases/off/search-preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          receipt_line_text: selectedItem.receiptLineText,
+          retailer_code: selectedItem.retailerCodeRaw,
+          candidate_name: selectedItem.bestCandidateName || selectedItem.receiptLineText,
+          quantity_label: selectedItem.quantity,
+          limit: 5,
+        }),
+      })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data?.detail || 'Open Food Facts kon niet worden geraadpleegd')
+      setOffPreview(data)
+    } catch (err) {
+      setOffError(err?.message || 'Open Food Facts kon niet worden geraadpleegd')
+    } finally {
+      setIsOffLoading(false)
+    }
+  }
+
   return (
     <div className="rz-external-receipt-overview">
       <div className="rz-external-databases-section-header">
@@ -421,7 +468,18 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
         <Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => goToPage(pageCount)}>Laatste</Button>
       </div>
 
-      {selectedItem ? <div className="rz-external-receipt-detail"><h3>Koppelen kandidaten in artikel-catalogus</h3><p>Kandidaten voor: {selectedItem.receiptLineText}</p><dl><dt>Winkelketen</dt><dd>{selectedItem.retailerCode}</dd><dt>Artikelnummer</dt><dd>{selectedItem.articleNumber}</dd><dt>GTIN / EAN</dt><dd>{selectedItem.gtin}</dd><dt>Status</dt><dd>{selectedItem.status}</dd></dl><Table dataTestId="external-receipt-item-candidates-table" tableClassName="rz-external-candidate-detail-table" resizableColumns><thead><tr className="rz-table-header"><th>Keuze</th><th>Kandidaat</th><th>Merk</th><th>Bron</th><th>Artikelnummer</th><th>Variant</th><th className="rz-num">Score</th><th>Status</th></tr></thead><tbody>{selectedCandidates.length ? selectedCandidates.map((candidate) => <tr key={candidate.id} className={selectedCandidateId === candidate.id ? 'rz-row-selected' : ''}><td className="rz-check"><input type="radio" name="external-candidate" checked={selectedCandidateId === candidate.id} disabled={!candidate.isLinkableToCatalog && !candidate.isLinkedToCatalog} onChange={() => setSelectedCandidateId(candidate.id)} /></td><td>{candidate.candidateName}</td><td>{candidate.brand}</td><td>{candidate.source}</td><td>{candidate.externalCode}</td><td>{candidate.variant}</td><td className="rz-num">{scoreText(candidate.score)}</td><td>{candidate.status}</td></tr>) : <tr><td colSpan="8">Geen externe kandidaten voor dit bonartikel.</td></tr>}</tbody></Table><div className="rz-external-databases-actions"><Button type="button" disabled={!selectedCandidateCanBeLinked} onClick={processSelectedCandidate}>Koppel artikel</Button></div></div> : null}
+      {selectedItem ? (
+        <div className="rz-external-receipt-detail">
+          <h3>Koppelen kandidaten in artikel-catalogus</h3>
+          <p>Kandidaten voor: {selectedItem.receiptLineText}</p>
+          <dl><dt>Winkelketen</dt><dd>{selectedItem.retailerCode}</dd><dt>Artikelnummer</dt><dd>{selectedItem.articleNumber}</dd><dt>GTIN / EAN</dt><dd>{selectedItem.gtin}</dd><dt>Status</dt><dd>{selectedItem.status}</dd></dl>
+          <Table dataTestId="external-receipt-item-candidates-table" tableClassName="rz-external-candidate-detail-table" resizableColumns><thead><tr className="rz-table-header"><th>Keuze</th><th>Kandidaat</th><th>Merk</th><th>Bron</th><th>Artikelnummer</th><th>Variant</th><th className="rz-num">Score</th><th>Status</th></tr></thead><tbody>{selectedCandidates.length ? selectedCandidates.map((candidate) => <tr key={candidate.id} className={selectedCandidateId === candidate.id ? 'rz-row-selected' : ''}><td className="rz-check"><input type="radio" name="external-candidate" checked={selectedCandidateId === candidate.id} disabled={!candidate.isLinkableToCatalog && !candidate.isLinkedToCatalog} onChange={() => setSelectedCandidateId(candidate.id)} /></td><td>{candidate.candidateName}</td><td>{candidate.brand}</td><td>{candidate.source}</td><td>{candidate.externalCode}</td><td>{candidate.variant}</td><td className="rz-num">{scoreText(candidate.score)}</td><td>{candidate.status}</td></tr>) : <tr><td colSpan="8">Geen externe kandidaten voor dit bonartikel.</td></tr>}</tbody></Table>
+          <div className="rz-external-databases-actions"><Button type="button" disabled={!selectedCandidateCanBeLinked} onClick={processSelectedCandidate}>Koppel artikel</Button><Button type="button" variant="secondary" disabled={isOffLoading} onClick={consultOpenFoodFacts}>{isOffLoading ? 'OFF raadplegen...' : 'Raadpleeg OFF'}</Button><span className="rz-external-databases-muted">OFF is preview-only en maakt geen product-, artikel- of voorraadmutatie.</span></div>
+          {offError ? <div className="rz-inline-feedback">{offError}</div> : null}
+          {offPreview ? <div className="rz-external-databases-preview-meta" data-testid="external-off-preview-meta"><span>OFF-status: {offStatusLabel(offPreview)}</span><span>Provider: {text(offPreview.provider)}</span><span>Resultaten: {offPreview.result_count ?? offResults.length}</span><span>Productmutatie: nee</span></div> : null}
+          {offPreview ? <Table dataTestId="external-off-candidates-table" tableClassName="rz-external-off-candidate-table" resizableColumns><thead><tr className="rz-table-header"><th>Kandidaat</th><th>Merk</th><th>GTIN / EAN</th><th>Omvang</th><th className="rz-num">Score</th><th>Status</th></tr></thead><tbody>{offResults.length ? offResults.map((candidate) => <tr key={offCandidateKey(candidate)}><td>{text(candidate.product_name || candidate.candidate_name)}</td><td>{text(candidate.brands || candidate.candidate_brand)}</td><td>{gtinText(candidate.gtin || candidate.ean || candidate.barcode || candidate.code)}</td><td>{text(candidate.quantity || candidate.quantity_label)}</td><td className="rz-num">{scoreText(candidate.score)}</td><td>Alleen raadplegen</td></tr>) : <tr><td colSpan="6">Geen OFF-kandidaten gevonden.</td></tr>}</tbody></Table> : null}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/frontend/tests/e2e/external-databases-off.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases-off.frontend-regression.spec.js
@@ -1,0 +1,143 @@
+import { test, expect } from '@playwright/test';
+import {
+  attachConsoleErrorCollector,
+  expectNoConsoleErrors,
+  expectRouteLoads,
+} from './helpers/rezzervAssertions.js';
+
+test.describe('Externe databases OFF read-only preview', () => {
+  test('Raadpleeg OFF toont kandidaten zonder koppelbare mutatie', async ({ page }) => {
+    const consoleErrors = attachConsoleErrorCollector(page);
+
+    await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [
+            {
+              context_key: 'ctx-off-preview-regression',
+              receipt_line_id: 'receipt-line-off-preview-regression',
+              purchase_import_line_id: 'purchase-line-off-preview-regression',
+              receipt_line_text: 'halfvolle melk',
+              retailer_code: 'jumbo',
+              retailer_article_number: '',
+              gtin: '',
+              quantity_label: '1 l',
+              price: 1.29,
+              candidate_id: 'candidate-off-preview-existing',
+              candidate_name: 'Halfvolle melk',
+              candidate_brand: 'Jumbo',
+              external_source_name: 'Open Food Facts',
+              external_source_product_code: '8710000000000',
+              variant: 'Standaard',
+              score: 0.7,
+              candidate_status: 'candidate',
+              is_linked_to_catalog: false,
+              is_linkable_to_catalog: true,
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.route('**/api/external-databases/receipt-items/ensure-candidates', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok' }),
+      });
+    });
+
+    let offRequestBody = null;
+    await page.route('**/api/external-databases/off/search-preview', async (route) => {
+      offRequestBody = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          source_name: 'open_food_facts',
+          mode: 'read_only_search_preview',
+          status: 'found',
+          external_source_available: true,
+          provider: 'search_a_licious',
+          providers_used: ['search_a_licious'],
+          receipt_line_text: 'halfvolle melk',
+          retailer_code: 'jumbo',
+          queried_terms: ['halfvolle melk 1 l'],
+          query_limit: 1,
+          timeout_seconds: 8,
+          results: [
+            {
+              source_name: 'open_food_facts',
+              source_product_code: '8710000000002',
+              candidate_source_product_code: '8710000000002',
+              code: '8710000000002',
+              gtin: '8710000000002',
+              ean: '8710000000002',
+              barcode: '8710000000002',
+              product_name: 'Halfvolle melk',
+              candidate_name: 'Halfvolle melk',
+              brands: 'Jumbo',
+              candidate_brand: 'Jumbo',
+              quantity: '1 l',
+              quantity_label: '1 l',
+              score: 0.82,
+              candidate_status: 'off_candidate',
+              requires_user_selection: true,
+              creates_global_product: false,
+              creates_household_article: false,
+              creates_inventory_event: false,
+            },
+          ],
+          result_count: 1,
+          diagnostics: [{ search_term: 'halfvolle melk 1 l', provider: 'search_a_licious', http_status: 200, raw_count: 1 }],
+          errors: [],
+          requires_user_selection: true,
+          creates_global_product: false,
+          creates_household_article: false,
+          creates_inventory_event: false,
+        }),
+      });
+    });
+
+    await expectRouteLoads(page, '/externe-databases', [
+      'Externe databases',
+      'Bonartikelen',
+      'Kandidaten',
+      'Product',
+    ]);
+
+    const receiptTable = page.getByTestId('external-receipt-items-table');
+    await expect(receiptTable).toBeVisible();
+
+    const receiptRow = receiptTable.locator('tbody tr', { hasText: 'halfvolle melk' });
+    await expect(receiptRow).toBeVisible();
+    await receiptRow.dblclick();
+
+    await expect(page.getByText('Koppelen kandidaten in artikel-catalogus')).toBeVisible();
+    await page.getByRole('button', { name: 'Raadpleeg OFF' }).click();
+
+    await expect(page.getByTestId('external-off-preview-meta')).toContainText('OFF-status: Gevonden');
+    await expect(page.getByTestId('external-off-preview-meta')).toContainText('Provider: search_a_licious');
+    await expect(page.getByTestId('external-off-preview-meta')).toContainText('Productmutatie: nee');
+
+    const offTable = page.getByTestId('external-off-candidates-table');
+    await expect(offTable).toBeVisible();
+    await expect(offTable.getByText('Halfvolle melk')).toBeVisible();
+    await expect(offTable.getByText('8710000000002')).toBeVisible();
+    await expect(offTable.getByText('Alleen raadplegen')).toBeVisible();
+
+    await expect(page.getByRole('button', { name: 'Koppel artikel' })).toBeDisabled();
+    expect(offRequestBody).toMatchObject({
+      receipt_line_text: 'halfvolle melk',
+      retailer_code: 'jumbo',
+      candidate_name: 'Halfvolle melk',
+      quantity_label: '1 l',
+      limit: 5,
+    });
+
+    await expectNoConsoleErrors(consoleErrors);
+  });
+});

--- a/scripts/run-frontend-regression-report.ps1
+++ b/scripts/run-frontend-regression-report.ps1
@@ -46,6 +46,13 @@ try {
   $frontendPath = Join-Path $repoRoot "frontend"
   $frontendPath = $frontendPath.Replace("\", "/")
 
+  $testFiles = @(
+    "tests/e2e/kassa.frontend-regression.spec.js",
+    "tests/e2e/uitpakken.frontend-regression.spec.js",
+    "tests/e2e/external-databases.frontend-regression.spec.js",
+    "tests/e2e/external-databases-off.frontend-regression.spec.js"
+  ) -join " "
+
   docker run --rm `
     --add-host=host.docker.internal:host-gateway `
     -e PLAYWRIGHT_BASE_URL=http://host.docker.internal:5174 `
@@ -54,7 +61,7 @@ try {
     -v rezzerv_playwright_node_modules:/work/node_modules `
     -w /work `
     mcr.microsoft.com/playwright:v1.61.0-noble `
-    bash -lc "npm install --package-lock=false && ./node_modules/.bin/playwright test tests/e2e/kassa.frontend-regression.spec.js tests/e2e/uitpakken.frontend-regression.spec.js tests/e2e/external-databases.frontend-regression.spec.js tests/e2e/external-databases-off.frontend-regression.spec.js"
+    bash -lc "npm install --package-lock=false && ./node_modules/.bin/playwright test --workers=3 $testFiles"
 
   if ($LASTEXITCODE -ne 0) {
     throw "Playwright frontend regressie is gefaald met exitcode $LASTEXITCODE."

--- a/scripts/run-frontend-regression-report.ps1
+++ b/scripts/run-frontend-regression-report.ps1
@@ -54,7 +54,7 @@ try {
     -v rezzerv_playwright_node_modules:/work/node_modules `
     -w /work `
     mcr.microsoft.com/playwright:v1.61.0-noble `
-    bash -lc "npm install --package-lock=false && ./node_modules/.bin/playwright test tests/e2e/kassa.frontend-regression.spec.js tests/e2e/uitpakken.frontend-regression.spec.js tests/e2e/external-databases.frontend-regression.spec.js"
+    bash -lc "npm install --package-lock=false && ./node_modules/.bin/playwright test tests/e2e/kassa.frontend-regression.spec.js tests/e2e/uitpakken.frontend-regression.spec.js tests/e2e/external-databases.frontend-regression.spec.js tests/e2e/external-databases-off.frontend-regression.spec.js"
 
   if ($LASTEXITCODE -ne 0) {
     throw "Playwright frontend regressie is gefaald met exitcode $LASTEXITCODE."


### PR DESCRIPTION
Samenvatting

Deze PR maakt OFF-resultaten zichtbaar raadpleegbaar in het Externe databases-scherm.

In scope:
- knop Raadpleeg OFF in het detailblok van een bonartikel
- read-only call naar het bestaande OFF search-preview endpoint
- aparte OFF-preview met status, provider, aantal resultaten en Productmutatie: nee
- read-only OFF-kandidatentabel
- OFF-resultaten worden niet toegevoegd aan de koppelbare kandidaatselectie
- regressietest voor OFF read-only preview toegevoegd
- frontend regressierunner neemt OFF-preview spec mee
- Playwright workers vastgezet op 3 voor stabiele baselinecondities

Niet in scope:
- geen automatische koppeling
- geen productcreatie
- geen artikelcreatie
- geen voorraadmutatie
- geen backend datamodelwijziging

Lokaal gevalideerd:
- Frontend regressie groen
- 13 passed
- OFF preview regressietest meegenomen en groen
- Backend OFF-contracttest groen
- Spaarzegels-regressie groen

Releaseadvies: GO voor merge naar main, gevolgd door validatie op main.