### PR TITLE
M2C2i-28D cleanup retry voor SQLite-lock

### DIFF
--- a/scripts/run-frontend-regression-report.ps1
+++ b/scripts/run-frontend-regression-report.ps1
@@ -7,9 +7,30 @@ $ErrorActionPreference = "Stop"
 Write-Host "=== Rezzerv frontend regressie: Kassa + Uitpakken ===" -ForegroundColor Cyan
 
 function Invoke-RegressionFixtureCleanup {
+  param(
+    [int]$MaxAttempts = 5
+  )
+
   Write-Host "`n=== Regression fixture cleanup ===" -ForegroundColor Cyan
   $headers = @{ Authorization = "Bearer rezzerv-dev-token::admin@rezzerv.local" }
-  Invoke-RestMethod -Method Post -Uri "http://localhost:8011/api/testing/fixtures/cleanup" -Headers $headers | Out-Host
+  $lastError = $null
+
+  for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+    try {
+      if ($attempt -gt 1) {
+        Write-Host "Cleanup opnieuw proberen ($attempt/$MaxAttempts)..." -ForegroundColor Yellow
+      }
+      Invoke-RestMethod -Method Post -Uri "http://localhost:8011/api/testing/fixtures/cleanup" -Headers $headers | Out-Host
+      return
+    } catch {
+      $lastError = $_
+      if ($attempt -lt $MaxAttempts) {
+        Start-Sleep -Seconds ([Math]::Min(2 * $attempt, 6))
+      }
+    }
+  }
+
+  throw $lastError
 }
 
 $repoRoot = Split-Path -Parent $PSScriptRoot


### PR DESCRIPTION
Samenvatting

Deze PR bevat een kleine release-fix bovenop M2C2i-28D.

Probleem:
- De 13 Playwright regressietests slaagden inhoudelijk.
- De run werd toch rood omdat de fixture cleanup direct na afloop soms 500 gaf.
- Backendlog bevestigde: sqlite3.OperationalError: database is locked.
- Handmatige cleanup kort daarna gaf 200 OK, dus dit was een tijdelijke SQLite-lock/race tijdens teardown.

Fix:
- scripts/run-frontend-regression-report.ps1 probeert fixture cleanup nu maximaal 5 keer.
- Tussen pogingen zit korte backoff.
- Tijdelijke SQLite-lock maakt de regressierun niet direct rood.

Scope:
- Alleen regressierunner aangepast.
- Geen applicatiegedrag gewijzigd.
- Geen frontendfunctionele code gewijzigd.
- Geen backendfunctionele code gewijzigd.

Gevalideerd op featurebranch m2c2i28dfixcleanup:
- Commit 8a5e10a
- Backend health ok
- Pre-cleanup ok
- Playwright frontend regressie: 13 passed
- Frontend regressie groen
- Post-cleanup ok

Bekende npm auditmeldingen blijven onveranderd:
- 2 vulnerabilities: 1 moderate, 1 high

Releaseadvies: GO voor merge naar main, gevolgd door main-validatie.