### PR TITLE
M2C2i-28F GTIN guardrail

### DIFF
--- a/backend/app/services/external_database_matchflow_evidence.py
+++ b/backend/app/services/external_database_matchflow_evidence.py
@@ -33,6 +33,24 @@ def _meaningful_tokens(value: str) -> set[str]:
     return {token for token in normalize_match_text(value).split() if len(token) >= 3}
 
 
+def _is_valid_gtin(value: Any) -> bool:
+    normalized = str(value or "").strip()
+    return bool(normalized.isdigit() and len(normalized) in {8, 12, 13, 14})
+
+
+def _item_has_known_gtin(item: dict[str, Any]) -> bool:
+    return any(
+        _is_valid_gtin(item.get(field))
+        for field in (
+            "gtin",
+            "ean",
+            "barcode",
+            "retailer_article_number",
+            "external_article_code",
+        )
+    )
+
+
 def _candidate_source_code(candidate: dict[str, Any]) -> str:
     for key in ("candidate_source_product_code", "source_product_code", "code", "retailer_article_number"):
         value = str(candidate.get(key) or "").strip()
@@ -194,7 +212,7 @@ def _external_matching_blocked_result(retailer_code: str, receipt_line_text: str
 
 
 def _item_allows_external_matching(item: dict[str, Any]) -> bool:
-    return not is_spaarzegels_flow_excluded(item)
+    return not is_spaarzegels_flow_excluded(item) and not _item_has_known_gtin(item)
 
 
 def _filter_external_matching_items(items: Any) -> list[dict[str, Any]]:
@@ -238,8 +256,19 @@ def ensure_external_receipt_item_candidates(*args: Any, **kwargs: Any) -> dict[s
             result = candidate_store.ensure_external_receipt_item_candidates(*args, **kwargs)
             if isinstance(original_items, list):
                 result = dict(result)
-                result["spaarzegels_excluded_count"] = len(original_items) - len(filtered_items)
-                result["external_matching_guardrail"] = "spaarzegels_financial_lines_excluded"
+                excluded_count = len(original_items) - len(filtered_items)
+                spaarzegels_count = len([
+                    item for item in original_items
+                    if isinstance(item, dict) and is_spaarzegels_flow_excluded(item)
+                ])
+                known_gtin_count = len([
+                    item for item in original_items
+                    if isinstance(item, dict) and _item_has_known_gtin(item)
+                ])
+                result["spaarzegels_excluded_count"] = spaarzegels_count
+                result["known_gtin_excluded_count"] = known_gtin_count
+                result["external_matching_excluded_count"] = excluded_count
+                result["external_matching_guardrail"] = "spaarzegels_and_known_gtin_rows_excluded"
             return result
         return candidate_store.ensure_external_receipt_item_candidates(*args, **kwargs)
     finally:

--- a/backend/app/services/external_receipt_auto_coverage.py
+++ b/backend/app/services/external_receipt_auto_coverage.py
@@ -20,6 +20,11 @@ def _text(value: Any) -> str:
     return str(value or "").strip()
 
 
+def _is_valid_gtin(value: Any) -> bool:
+    normalized = _text(value)
+    return bool(normalized.isdigit() and len(normalized) in {8, 12, 13, 14})
+
+
 def _receipt_table_exists(conn) -> bool:
     dialect_name = str(engine.dialect.name or "").lower()
     if dialect_name == "sqlite":
@@ -40,7 +45,9 @@ def _receipt_table_exists(conn) -> bool:
 
 
 def _is_external_matching_allowed(row: dict[str, Any]) -> bool:
-    return not is_spaarzegels_flow_excluded(row)
+    if is_spaarzegels_flow_excluded(row):
+        return False
+    return not _is_valid_gtin(row.get("gtin") or row.get("barcode") or row.get("retailer_article_number"))
 
 
 def _receipt_table_items(receipt_table_id: str) -> list[dict[str, Any]]:
@@ -62,6 +69,7 @@ def _receipt_table_items(receipt_table_id: str) -> list[dict[str, Any]]:
                     rtl.raw_label AS raw_label,
                     rtl.normalized_label AS normalized_label,
                     rtl.barcode AS retailer_article_number,
+                    rtl.barcode AS gtin,
                     TRIM(COALESCE(CAST(rtl.quantity AS TEXT), '') || ' ' || COALESCE(CAST(rtl.unit AS TEXT), '')) AS quantity_label,
                     rtl.unit_price AS unit_price,
                     rtl.line_total AS line_total,
@@ -88,6 +96,7 @@ def _receipt_table_items(receipt_table_id: str) -> list[dict[str, Any]]:
             "receipt_line_text": receipt_text,
             "retailer_code": _text(row_data.get("retailer_code")),
             "retailer_article_number": _text(row_data.get("retailer_article_number")),
+            "gtin": _text(row_data.get("gtin")),
             "quantity_label": _text(row_data.get("quantity_label")),
             "price": row_data.get("price"),
         })
@@ -104,12 +113,13 @@ def auto_ensure_external_candidates_for_receipt_table(
     receipt_table_id: str,
     include_below_threshold: bool = True,
 ) -> dict[str, Any]:
-    """Lees echte externe kandidaten bij voor alle productregels van een nieuw opgeslagen bon.
+    """Lees echte externe kandidaten bij voor productregels zonder bekende GTIN/EAN.
 
     Dit is productgedrag, geen PO-rapport. De functie mag uitsluitend kandidaatcache
     vullen in `external_product_candidates`. Ze maakt geen Mijn artikel, geen
-    global product en geen voorraadmutatie. Spaarzegels blijven financiële
-    bonregels voor de kassasom, maar worden niet naar productmatching gestuurd.
+    global product en geen voorraadmutatie. Regels met een bestaande geldige
+    GTIN/EAN hebben al een externe identiteit en worden niet opnieuw van
+    kandidaatartikelen voorzien.
     """
     items = _receipt_table_items(receipt_table_id)
     if not items:
@@ -258,28 +268,33 @@ def install_receipt_auto_candidate_coverage() -> dict[str, Any]:
     """Installeer runtime hooks voor nieuwe bonnen.
 
     FastAPI importeert `ingest_receipt` en `reparse_receipt` ook rechtstreeks in
-    `app.main`. Daarom patchen we zowel de service-module als, als die al geladen
-    is, de globale namen in `app.main`.
+    route-modules. Daarom patchen we zowel de oorspronkelijke modules als reeds
+    geladen route-modules die callable referenties bevatten.
     """
     patched: list[str] = []
 
-    receipt_service = importlib.import_module("app.services.receipt_service")
-    if _patch_module_function(receipt_service, "ingest_receipt", _with_receipt_auto_coverage):
-        patched.append("app.services.receipt_service.ingest_receipt")
-    if _patch_module_function(receipt_service, "reparse_receipt", _with_reparse_auto_coverage):
-        patched.append("app.services.receipt_service.reparse_receipt")
+    targets = [
+        ("app.receipt_ingestion.service", ["ingest_receipt"]),
+        ("app.receipt_ingestion.receipt_reparse_service", ["reparse_receipt"]),
+    ]
 
-    main_module = sys.modules.get("app.main")
-    if main_module is not None:
-        if _patch_module_function(main_module, "ingest_receipt", _with_receipt_auto_coverage):
-            patched.append("app.main.ingest_receipt")
-        if _patch_module_function(main_module, "reparse_receipt", _with_reparse_auto_coverage):
-            patched.append("app.main.reparse_receipt")
+    for module_name, function_names in targets:
+        try:
+            module = importlib.import_module(module_name)
+        except Exception as exc:  # pragma: no cover
+            LOGGER.warning("Module %s kon niet worden geladen voor kandidaatdekking: %s", module_name, exc)
+            continue
+        for function_name in function_names:
+            wrapper_factory = _with_reparse_auto_coverage if function_name == "reparse_receipt" else _with_receipt_auto_coverage
+            if _patch_module_function(module, function_name, wrapper_factory):
+                patched.append(f"{module_name}.{function_name}")
 
-    return {
-        "ok": True,
-        "patched": patched,
-        "creates_global_product": False,
-        "creates_household_article": False,
-        "creates_inventory_event": False,
-    }
+    for module_name, module in list(sys.modules.items()):
+        if not module_name.startswith("app.api"):
+            continue
+        for function_name in ["ingest_receipt", "reparse_receipt"]:
+            wrapper_factory = _with_reparse_auto_coverage if function_name == "reparse_receipt" else _with_receipt_auto_coverage
+            if _patch_module_function(module, function_name, wrapper_factory):
+                patched.append(f"{module_name}.{function_name}")
+
+    return {"ok": True, "patched": patched}

--- a/backend/app/services/open_food_facts_candidate_store.py
+++ b/backend/app/services/open_food_facts_candidate_store.py
@@ -24,6 +24,18 @@ def _text(value: Any) -> str:
     return str(value or "").strip()
 
 
+def _is_valid_gtin(value: Any) -> bool:
+    normalized = _text(value)
+    return bool(normalized.isdigit() and len(normalized) in {8, 12, 13, 14})
+
+
+def _payload_has_known_gtin(payload: dict[str, Any]) -> bool:
+    return any(
+        _is_valid_gtin(payload.get(field))
+        for field in ("gtin", "ean", "barcode", "retailer_article_number", "article_number")
+    )
+
+
 def _off_candidate_from_result(result: dict[str, Any]) -> dict[str, Any]:
     code = _text(
         result.get("candidate_source_product_code")
@@ -57,7 +69,8 @@ def save_open_food_facts_preview_candidates(payload: dict[str, Any]) -> dict[str
 
     This creates external candidate rows only. It does not create global products,
     household articles or inventory events. A separate explicit user action is still
-    required to link/promote a candidate.
+    required to link/promote a candidate. Rows that already carry a valid GTIN/EAN
+    are skipped because the external identity is already known.
     """
     ensure_external_product_candidates_schema()
 
@@ -83,6 +96,35 @@ def save_open_food_facts_preview_candidates(payload: dict[str, Any]) -> dict[str
         receipt_line_id=receipt_line_id,
         purchase_import_line_id=purchase_import_line_id,
     )
+
+    if _payload_has_known_gtin(payload):
+        return {
+            "ok": True,
+            "preview": {
+                "ok": True,
+                "status": "skipped_known_gtin",
+                "provider": "known_gtin_guardrail",
+                "result_count": 0,
+                "creates_global_product": False,
+                "creates_household_article": False,
+                "creates_inventory_event": False,
+            },
+            "source_name": "open_food_facts",
+            "context_key": context_key,
+            "retailer_code": retailer_code,
+            "receipt_line_text": receipt_line_text,
+            "candidate_count": 0,
+            "saved_count": 0,
+            "updated_count": 0,
+            "skipped_count": 1,
+            "skipped": [{"reason": "known_gtin_present"}],
+            "candidates": [],
+            "requires_user_selection": False,
+            "creates_global_product": False,
+            "creates_household_article": False,
+            "creates_inventory_event": False,
+        }
+
     storage_purchase_import_line_id = purchase_import_line_id or build_preview_import_line_fallback(context_key)
 
     preview = search_open_food_facts_preview(payload)

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -29,9 +29,21 @@ function gtinText(value) {
   return /^\d{8}$|^\d{12}$|^\d{13}$|^\d{14}$/.test(normalized) ? normalized : '-'
 }
 
+function hasKnownGtin(value) {
+  return gtinText(value) !== '-'
+}
+
 function retailerLabel(value) {
   const normalized = text(value, '')
-  const labels = { ah: 'Albert Heijn', albert_heijn: 'Albert Heijn', jumbo: 'Jumbo', lidl: 'Lidl', aldi: 'Aldi', plus: 'PLUS', picnic: 'Picnic' }
+  const labels = {
+    ah: 'Albert Heijn',
+    albert_heijn: 'Albert Heijn',
+    jumbo: 'Jumbo',
+    lidl: 'Lidl',
+    aldi: 'Aldi',
+    plus: 'PLUS',
+    picnic: 'Picnic',
+  }
   return labels[normalized.toLowerCase()] || normalized || 'Onbekend'
 }
 
@@ -66,11 +78,22 @@ function candidateStatusLabel(candidate, linked, fallback) {
 }
 
 function candidateKey(candidate) {
-  return text(candidate?.candidate_id || candidate?.id || `${candidate?.candidate_name}-${candidate?.candidate_source_product_code || candidate?.external_source_product_code}-${candidate?.variant}`, 'candidate')
+  return text(
+    candidate?.candidate_id ||
+    candidate?.id ||
+    `${candidate?.candidate_name}-${candidate?.candidate_source_product_code || candidate?.external_source_product_code}-${candidate?.variant}`,
+    'candidate'
+  )
 }
 
 function hasCatalogLink(candidate) {
-  return Boolean(candidate?.is_linked_to_catalog === true || text(candidate?.global_product_id, '') || text(candidate?.product_identity_id, '') || text(candidate?.matched_global_product_id, '') || text(candidate?.matched_global_article_id, ''))
+  return Boolean(
+    candidate?.is_linked_to_catalog === true ||
+    text(candidate?.global_product_id, '') ||
+    text(candidate?.product_identity_id, '') ||
+    text(candidate?.matched_global_product_id, '') ||
+    text(candidate?.matched_global_article_id, '')
+  )
 }
 
 function buildCandidate(candidate) {
@@ -99,9 +122,14 @@ function dedupeCandidates(candidates) {
     const raw = candidate.raw || {}
     const source = text(candidate.source || raw.external_source_name || raw.candidate_source_name || raw.source_name, '').toLowerCase()
     const code = text(candidate.externalCode || raw.external_source_product_code || raw.candidate_source_product_code || raw.source_product_code || raw.retailer_article_number, '').toLowerCase()
-    const key = source && code ? `${source}:${code}` : `${candidate.candidateName}:${candidate.brand}:${candidate.variant}`.toLowerCase()
+    const rawGtin = text(raw.gtin || raw.ean, '').toLowerCase()
+    const key = source && code
+      ? `${source}:${code}`
+      : rawGtin || `${candidate.candidateName}:${candidate.brand}:${candidate.variant}`.toLowerCase()
     const current = deduped.get(key)
-    if (!current || candidate.isLinkedToCatalog || Number(candidate.score || 0) > Number(current.score || 0)) deduped.set(key, candidate)
+    if (!current || candidate.isLinkedToCatalog || Number(candidate.score || 0) > Number(current.score || 0)) {
+      deduped.set(key, candidate)
+    }
   })
   return Array.from(deduped.values())
 }
@@ -110,10 +138,25 @@ function rowKey(item) {
   return text(item.context_key || item.receipt_line_id || item.purchase_import_line_id || item.receipt_line_text, 'receipt-item')
 }
 
+function rawArticleNumber(rawItem) {
+  return text(
+    rawItem.retailer_article_number ||
+    rawItem.source_product_code ||
+    rawItem.candidate_source_product_code ||
+    rawItem.external_article_code,
+    '-'
+  )
+}
+
+function rawGtin(rawItem) {
+  return gtinText(rawItem.gtin || rawItem.ean || rawItem.barcode)
+}
+
 function buildReceiptItems(rawItems) {
   const grouped = new Map()
   rawItems.forEach((rawItem) => {
     const key = rowKey(rawItem)
+    const itemGtin = rawGtin(rawItem)
     const current = grouped.get(key) || {
       id: key,
       contextKey: text(rawItem.context_key, ''),
@@ -122,18 +165,25 @@ function buildReceiptItems(rawItems) {
       receiptLineText: text(rawItem.receipt_line_text),
       retailerCode: retailerLabel(rawItem.retailer_code),
       retailerCodeRaw: text(rawItem.retailer_code, ''),
-      articleNumber: text(rawItem.retailer_article_number || rawItem.source_product_code || rawItem.candidate_source_product_code),
-      gtin: gtinText(rawItem.gtin || rawItem.ean),
+      articleNumber: rawArticleNumber(rawItem),
+      gtin: itemGtin,
       quantity: text(rawItem.quantity_label),
       price: rawItem.price ?? '-',
       amount: '-',
       catalogLinked: false,
-      status: 'Nog niet verwerkt',
+      status: itemGtin !== '-' ? 'GTIN / EAN bekend' : 'Nog niet verwerkt',
       candidates: [],
+      hasKnownGtin: itemGtin !== '-',
     }
-    const nested = rawItem.is_receipt_item_placeholder && Array.isArray(rawItem.candidates) ? rawItem.candidates : [rawItem]
+
+    const nested = rawItem.is_receipt_item_placeholder && Array.isArray(rawItem.candidates)
+      ? rawItem.candidates
+      : [rawItem]
+
     nested.filter(Boolean).forEach((candidate) => {
+      if (current.hasKnownGtin) return
       const built = buildCandidate(candidate)
+      if (built.raw?.is_receipt_item_placeholder && built.raw?.candidate_status === 'no_candidate') return
       current.candidates.push(built)
       if (built.catalogLinked) {
         current.catalogLinked = true
@@ -142,21 +192,27 @@ function buildReceiptItems(rawItems) {
     })
     grouped.set(key, current)
   })
+
   return Array.from(grouped.values()).map((item) => {
-    const candidates = dedupeCandidates(item.candidates).sort((left, right) => Number(right.score || 0) - Number(left.score || 0))
+    const candidates = item.hasKnownGtin
+      ? []
+      : dedupeCandidates(item.candidates).sort((left, right) => Number(right.score || 0) - Number(left.score || 0))
     const linked = candidates.find((candidate) => candidate.isLinkedToCatalog)
     const best = linked || candidates.find((candidate) => !candidate.isFallbackCandidate) || null
     const hasRealCandidate = candidates.some((candidate) => !candidate.isFallbackCandidate)
     const hasFallback = candidates.some((candidate) => candidate.isFallbackCandidate)
+    const candidateGtin = gtinText(best?.raw?.gtin || best?.raw?.ean)
     return {
       ...item,
       candidates,
-      status: item.catalogLinked ? 'Gekoppeld' : (hasRealCandidate ? 'Kandidaten gevonden' : (hasFallback ? 'Geen externe match' : item.status)),
+      status: item.hasKnownGtin
+        ? 'GTIN / EAN bekend'
+        : (item.catalogLinked ? 'Gekoppeld' : (hasRealCandidate ? 'Kandidaten gevonden' : (hasFallback ? 'Geen externe match' : item.status))),
       candidateCount: candidates.filter((candidate) => !candidate.isFallbackCandidate).length,
-      bestCandidateName: text(best?.candidateName, ''),
-      bestCandidateScore: best?.score ?? null,
-      articleNumber: text(best?.externalCode, '-'),
-      gtin: gtinText(best?.raw?.gtin || best?.raw?.ean),
+      bestCandidateName: item.hasKnownGtin ? '' : text(best?.candidateName, ''),
+      bestCandidateScore: item.hasKnownGtin ? null : best?.score ?? null,
+      articleNumber: best ? text(best.externalCode, item.articleNumber) : item.articleNumber,
+      gtin: candidateGtin !== '-' ? candidateGtin : item.gtin,
     }
   })
 }
@@ -166,6 +222,7 @@ function offStatusLabel(preview) {
   if (preview.status === 'found') return 'Gevonden'
   if (preview.status === 'no_results') return 'Geen resultaten'
   if (preview.status === 'external_source_unavailable') return 'OFF niet beschikbaar'
+  if (preview.status === 'skipped_known_gtin') return 'GTIN / EAN al bekend'
   return text(preview.status)
 }
 
@@ -249,6 +306,7 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   const selectedCandidate = selectedCandidates.find((candidate) => candidate.id === selectedCandidateId) || null
   const selectedCandidateCanBeLinked = Boolean(selectedCandidate && selectedCandidate.isLinkableToCatalog && !selectedCandidate.isFallbackCandidate && !selectedCandidate.isLinkedToCatalog)
   const selectedCandidateCanBeUnlinked = Boolean(selectedCandidate && selectedCandidate.isLinkedToCatalog)
+  const selectedItemHasKnownGtin = Boolean(selectedItem?.hasKnownGtin || hasKnownGtin(selectedItem?.gtin))
 
   function updateFilter(key, value) { setFilters((current) => ({ ...current, [key]: value })); setPage(1) }
   function updateSort(key) { if (sortKey === key) setSortDesc((value) => !value); else { setSortKey(key); setSortDesc(false) }; setPage(1) }
@@ -262,13 +320,16 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
     setSelectedCandidateId('')
     setOffPreview(null)
     setOffError('')
-    consultOpenFoodFactsForItem(item)
+    if (!item.hasKnownGtin) consultOpenFoodFactsForItem(item)
   }
 
   function exportSelectedItems() {
     const selectedRows = items.filter((item) => selectedItemIds.includes(item.id))
     if (!selectedRows.length) { onMessage?.('Selecteer eerst één of meer bonartikelen om te exporteren.'); return }
-    const rows = [['Bonartikel', 'Winkelketen', 'Catalogus', 'Artikelnummer', 'GTIN / EAN', 'Omvang / gewicht', 'Prijs', 'Aantal', 'Kandidaat', 'Score', 'Externe kandidaten'], ...selectedRows.map((item) => [item.receiptLineText, item.retailerCode, item.catalogLinked ? 'Gekoppeld' : 'Niet gekoppeld', item.articleNumber, item.gtin, item.quantity, numberText(item.price), item.amount, item.bestCandidateName || '-', scoreText(item.bestCandidateScore), item.candidateCount])]
+    const rows = [
+      ['Bonartikel', 'Winkelketen', 'Catalogus', 'Artikelnummer', 'GTIN / EAN', 'Omvang / gewicht', 'Prijs', 'Aantal', 'Kandidaat', 'Score', 'Externe kandidaten'],
+      ...selectedRows.map((item) => [item.receiptLineText, item.retailerCode, item.catalogLinked ? 'Gekoppeld' : 'Niet gekoppeld', item.articleNumber, item.gtin, item.quantity, numberText(item.price), item.amount, item.bestCandidateName || '-', scoreText(item.bestCandidateScore), item.candidateCount]),
+    ]
     const blob = new Blob([rows.map((row) => row.map((value) => `"${String(value ?? '').replaceAll('"', '""')}"`).join(';')).join('\r\n')], { type: 'text/csv;charset=utf-8' })
     const url = URL.createObjectURL(blob)
     const link = document.createElement('a')
@@ -282,7 +343,11 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   async function processSelectedCandidate() {
     if (!selectedItem || !selectedCandidate || !selectedCandidateCanBeLinked) return
     try {
-      const response = await fetchJsonWithAuth('/api/external-databases/catalog/promote-candidate', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ candidate_id: selectedCandidate.raw?.id || selectedCandidate.id }) })
+      const response = await fetchJsonWithAuth('/api/external-databases/catalog/promote-candidate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ candidate_id: selectedCandidate.raw?.id || selectedCandidate.id }),
+      })
       const data = await response.json().catch(() => ({}))
       if (!response.ok) throw new Error(data?.detail || 'Kandidaat verwerken is mislukt')
       onMessage?.(data?.promoted ? 'Kandidaat is gekoppeld.' : 'Cataloguskoppeling is afgerond zonder mutatie.')
@@ -296,7 +361,11 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   async function unlinkSelectedCandidate() {
     if (!selectedItem || !selectedCandidate || !selectedCandidateCanBeUnlinked) return
     try {
-      const response = await fetchJsonWithAuth('/api/external-databases/catalog/unlink', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ context_keys: [selectedItem.contextKey || selectedItem.id], candidate_ids: [selectedCandidate.raw?.id || selectedCandidate.id] }) })
+      const response = await fetchJsonWithAuth('/api/external-databases/catalog/unlink', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ context_keys: [selectedItem.contextKey || selectedItem.id], candidate_ids: [selectedCandidate.raw?.id || selectedCandidate.id] }),
+      })
       const data = await response.json().catch(() => ({}))
       if (!response.ok) throw new Error(data?.detail || 'Kandidaat ontkoppelen is mislukt')
       onMessage?.('Kandidaat is ontkoppeld.')
@@ -308,12 +377,24 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   }
 
   async function consultOpenFoodFactsForItem(item) {
-    if (!item) return
+    if (!item || item.hasKnownGtin || hasKnownGtin(item.gtin)) return
     setIsOffLoading(true)
     setOffPreview(null)
     setOffError('')
     try {
-      const response = await fetchJsonWithAuth('/api/external-databases/off/save-candidates', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ receipt_line_text: item.receiptLineText, retailer_code: item.retailerCodeRaw, receipt_line_id: item.receiptLineId, purchase_import_line_id: item.purchaseImportLineId, candidate_name: item.bestCandidateName || item.receiptLineText, quantity_label: item.quantity, limit: 5 }) })
+      const response = await fetchJsonWithAuth('/api/external-databases/off/save-candidates', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          receipt_line_text: item.receiptLineText,
+          retailer_code: item.retailerCodeRaw,
+          receipt_line_id: item.receiptLineId,
+          purchase_import_line_id: item.purchaseImportLineId,
+          candidate_name: item.bestCandidateName || item.receiptLineText,
+          quantity_label: item.quantity,
+          limit: 5,
+        }),
+      })
       const data = await response.json().catch(() => ({}))
       if (!response.ok) throw new Error(data?.detail || 'Open Food Facts kon niet worden geraadpleegd')
       setOffPreview(data.preview || data)
@@ -327,12 +408,121 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
 
   return (
     <div className="rz-external-receipt-overview">
-      <div className="rz-external-databases-section-header"><h3>Bonartikelen voor externe herkenning</h3><Button type="button" variant="secondary" disabled={isLoading} onClick={loadItems}>Vernieuwen</Button></div>
-      <div className="rz-external-databases-actions"><Button type="button" variant="secondary" disabled={!selectedItemIds.length} onClick={exportSelectedItems}>Exporteren</Button><span className="rz-external-databases-muted">Geselecteerd: {selectedItemIds.length}</span></div>
+      <div className="rz-external-databases-section-header">
+        <h3>Bonartikelen voor externe herkenning</h3>
+        <Button type="button" variant="secondary" disabled={isLoading} onClick={loadItems}>Vernieuwen</Button>
+      </div>
+      <div className="rz-external-databases-actions">
+        <Button type="button" variant="secondary" disabled={!selectedItemIds.length} onClick={exportSelectedItems}>Exporteren</Button>
+        <span className="rz-external-databases-muted">Geselecteerd: {selectedItemIds.length}</span>
+      </div>
       {isLoading ? <div>Bonartikelen worden geladen...</div> : null}
-      <div className="rz-table-scroll rz-table-scroll--wide"><Table dataTestId="external-receipt-items-table" tableClassName="rz-external-receipt-table" resizableColumns><colgroup><col /><col /><col /><col /><col /><col /><col /><col /><col /><col /><col /><col /></colgroup><thead><tr className="rz-table-header"><th className="rz-check"><input type="checkbox" checked={allVisibleSelected} onChange={toggleVisibleItems} /></th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('receiptLineText')}>Bonartikel <span>{sortMark('receiptLineText')}</span></button></th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('retailerCode')}>Winkelketen <span>{sortMark('retailerCode')}</span></button></th><th className="rz-check"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('catalogLinked')}>Catalogus <span>{sortMark('catalogLinked')}</span></button></th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('articleNumber')}>Artikelnummer <span>{sortMark('articleNumber')}</span></button></th><th>GTIN / EAN</th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('quantity')}>Omvang / gewicht <span>{sortMark('quantity')}</span></button></th><th className="rz-num">Prijs</th><th className="rz-num">Aantal</th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('bestCandidateName')}>Kandidaat <span>{sortMark('bestCandidateName')}</span></button></th><th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('bestCandidateScore')}>Score <span>{sortMark('bestCandidateScore')}</span></button></th><th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('candidateCount')}>Externe kandidaten <span>{sortMark('candidateCount')}</span></button></th></tr><tr className="rz-external-databases-filter-row"><th></th><th><input className="rz-table-filter" value={filters.receiptLineText} onChange={(event) => updateFilter('receiptLineText', event.target.value)} placeholder="Zoek" /></th><th><input className="rz-table-filter" value={filters.retailerCode} onChange={(event) => updateFilter('retailerCode', event.target.value)} placeholder="Filter" /></th><th><select className="rz-table-filter" value={filters.catalogLinked} onChange={(event) => updateFilter('catalogLinked', event.target.value)} aria-label="Catalogus filter"><option value="all">Alle</option><option value="linked">Gekoppeld</option><option value="unlinked">Niet gekoppeld</option></select></th><th><input className="rz-table-filter" value={filters.articleNumber} onChange={(event) => updateFilter('articleNumber', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.gtin} onChange={(event) => updateFilter('gtin', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.quantity} onChange={(event) => updateFilter('quantity', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.price} onChange={(event) => updateFilter('price', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.amount} onChange={(event) => updateFilter('amount', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.bestCandidateName} onChange={(event) => updateFilter('bestCandidateName', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.bestCandidateScore} onChange={(event) => updateFilter('bestCandidateScore', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.candidateCount} onChange={(event) => updateFilter('candidateCount', event.target.value)} placeholder="Filter" /></th></tr></thead><tbody>{visibleItems.length ? visibleItems.map((item) => <tr key={item.id} className={selectedItem?.id === item.id ? 'rz-row-active' : ''} onDoubleClick={() => selectReceiptItem(item)}><td className="rz-check"><input type="checkbox" checked={selectedItemIds.includes(item.id)} onChange={() => toggleSelectedItem(item.id)} /></td><td>{item.receiptLineText}</td><td>{item.retailerCode}</td><td className="rz-check"><input type="checkbox" checked={item.catalogLinked} readOnly /></td><td>{item.articleNumber}</td><td>{item.gtin}</td><td>{item.quantity}</td><td className="rz-num">{numberText(item.price)}</td><td className="rz-num">{item.amount}</td><td>{item.bestCandidateName || '-'}</td><td className="rz-num">{scoreText(item.bestCandidateScore)}</td><td className="rz-num">{item.candidateCount}</td></tr>) : <tr><td colSpan="12">Geen bonartikelen beschikbaar voor externe herkenning.</td></tr>}{Array.from({ length: emptyRows }).map((_, index) => <tr key={`empty-${index}`}><td colSpan="12"></td></tr>)}</tbody></Table></div>
-      <div className="rz-external-databases-pagination" aria-label="Paginering bonartikelen"><Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => goToPage(1)}>Eerste</Button><Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => goToPage(currentPage - 1)}>Vorige</Button><span className="rz-external-databases-page-indicator">Pagina {currentPage} van {pageCount}</span><Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => goToPage(currentPage + 1)}>Volgende</Button><Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => goToPage(pageCount)}>Laatste</Button></div>
-      {selectedItem ? <div className="rz-external-receipt-detail"><h3>Koppelen kandidaten in artikel-catalogus</h3><p>Kandidaten voor: {selectedItem.receiptLineText}</p><dl><dt>Winkelketen</dt><dd>{selectedItem.retailerCode}</dd><dt>Artikelnummer</dt><dd>{selectedItem.articleNumber}</dd><dt>GTIN / EAN</dt><dd>{selectedItem.gtin}</dd><dt>Status</dt><dd>{selectedItem.status}</dd></dl><Table dataTestId="external-receipt-item-candidates-table" tableClassName="rz-external-candidate-detail-table" resizableColumns><thead><tr className="rz-table-header"><th>Keuze</th><th>Kandidaat</th><th>Merk</th><th>Bron</th><th>Artikelnummer</th><th>Variant</th><th className="rz-num">Score</th><th>Status</th></tr></thead><tbody>{selectedCandidates.length ? selectedCandidates.map((candidate) => <tr key={candidate.id} className={selectedCandidateId === candidate.id ? 'rz-row-selected' : ''}><td className="rz-check"><input type="radio" name="external-candidate" checked={selectedCandidateId === candidate.id} disabled={!candidate.isLinkableToCatalog && !candidate.isLinkedToCatalog} onChange={() => setSelectedCandidateId(candidate.id)} /></td><td>{candidate.candidateName}</td><td>{candidate.brand}</td><td>{candidate.source}</td><td>{candidate.externalCode}</td><td>{candidate.variant}</td><td className="rz-num">{scoreText(candidate.score)}</td><td>{candidate.status}</td></tr>) : <tr><td colSpan="8">Geen externe kandidaten voor dit bonartikel.</td></tr>}</tbody></Table><div className="rz-external-databases-actions"><Button type="button" disabled={!selectedCandidateCanBeLinked} onClick={processSelectedCandidate}>Koppel artikel</Button><Button type="button" variant="secondary" disabled={!selectedCandidateCanBeUnlinked} onClick={unlinkSelectedCandidate}>Ontkoppel artikel</Button><span className="rz-external-databases-muted">{isOffLoading ? 'OFF wordt automatisch geraadpleegd...' : 'OFF wordt automatisch geraadpleegd bij openen van dit detail; koppelen blijft een expliciete keuze.'}</span></div>{offError ? <div className="rz-inline-feedback">{offError}</div> : null}{offPreview ? <div className="rz-external-databases-preview-meta" data-testid="external-off-preview-meta"><span>OFF-status: {offStatusLabel(offPreview)}</span><span>Provider: {text(offPreview.provider)}</span><span>Productmutatie: nee</span></div> : null}</div> : null}
+
+      <div className="rz-table-scroll rz-table-scroll--wide">
+        <Table dataTestId="external-receipt-items-table" tableClassName="rz-external-receipt-table" resizableColumns>
+          <colgroup><col /><col /><col /><col /><col /><col /><col /><col /><col /><col /><col /><col /></colgroup>
+          <thead>
+            <tr className="rz-table-header">
+              <th className="rz-check"><input type="checkbox" checked={allVisibleSelected} onChange={toggleVisibleItems} /></th>
+              <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('receiptLineText')}>Bonartikel <span>{sortMark('receiptLineText')}</span></button></th>
+              <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('retailerCode')}>Winkelketen <span>{sortMark('retailerCode')}</span></button></th>
+              <th className="rz-check"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('catalogLinked')}>Catalogus <span>{sortMark('catalogLinked')}</span></button></th>
+              <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('articleNumber')}>Artikelnummer <span>{sortMark('articleNumber')}</span></button></th>
+              <th>GTIN / EAN</th>
+              <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('quantity')}>Omvang / gewicht <span>{sortMark('quantity')}</span></button></th>
+              <th className="rz-num">Prijs</th>
+              <th className="rz-num">Aantal</th>
+              <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('bestCandidateName')}>Kandidaat <span>{sortMark('bestCandidateName')}</span></button></th>
+              <th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('bestCandidateScore')}>Score <span>{sortMark('bestCandidateScore')}</span></button></th>
+              <th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('candidateCount')}>Externe kandidaten <span>{sortMark('candidateCount')}</span></button></th>
+            </tr>
+            <tr className="rz-external-databases-filter-row">
+              <th></th>
+              <th><input className="rz-table-filter" value={filters.receiptLineText} onChange={(event) => updateFilter('receiptLineText', event.target.value)} placeholder="Zoek" /></th>
+              <th><input className="rz-table-filter" value={filters.retailerCode} onChange={(event) => updateFilter('retailerCode', event.target.value)} placeholder="Filter" /></th>
+              <th><select className="rz-table-filter" value={filters.catalogLinked} onChange={(event) => updateFilter('catalogLinked', event.target.value)} aria-label="Catalogus filter"><option value="all">Alle</option><option value="linked">Gekoppeld</option><option value="unlinked">Niet gekoppeld</option></select></th>
+              <th><input className="rz-table-filter" value={filters.articleNumber} onChange={(event) => updateFilter('articleNumber', event.target.value)} placeholder="Filter" /></th>
+              <th><input className="rz-table-filter" value={filters.gtin} onChange={(event) => updateFilter('gtin', event.target.value)} placeholder="Filter" /></th>
+              <th><input className="rz-table-filter" value={filters.quantity} onChange={(event) => updateFilter('quantity', event.target.value)} placeholder="Filter" /></th>
+              <th><input className="rz-table-filter" value={filters.price} onChange={(event) => updateFilter('price', event.target.value)} placeholder="Filter" /></th>
+              <th><input className="rz-table-filter" value={filters.amount} onChange={(event) => updateFilter('amount', event.target.value)} placeholder="Filter" /></th>
+              <th><input className="rz-table-filter" value={filters.bestCandidateName} onChange={(event) => updateFilter('bestCandidateName', event.target.value)} placeholder="Filter" /></th>
+              <th><input className="rz-table-filter" value={filters.bestCandidateScore} onChange={(event) => updateFilter('bestCandidateScore', event.target.value)} placeholder="Filter" /></th>
+              <th><input className="rz-table-filter" value={filters.candidateCount} onChange={(event) => updateFilter('candidateCount', event.target.value)} placeholder="Filter" /></th>
+            </tr>
+          </thead>
+          <tbody>
+            {visibleItems.length ? visibleItems.map((item) => (
+              <tr key={item.id} className={selectedItem?.id === item.id ? 'rz-row-active' : ''} onDoubleClick={() => selectReceiptItem(item)}>
+                <td className="rz-check"><input type="checkbox" checked={selectedItemIds.includes(item.id)} onChange={() => toggleSelectedItem(item.id)} /></td>
+                <td>{item.receiptLineText}</td>
+                <td>{item.retailerCode}</td>
+                <td className="rz-check"><input type="checkbox" checked={item.catalogLinked} readOnly /></td>
+                <td>{item.articleNumber}</td>
+                <td>{item.gtin}</td>
+                <td>{item.quantity}</td>
+                <td className="rz-num">{numberText(item.price)}</td>
+                <td className="rz-num">{item.amount}</td>
+                <td>{item.bestCandidateName || '-'}</td>
+                <td className="rz-num">{scoreText(item.bestCandidateScore)}</td>
+                <td className="rz-num">{item.candidateCount}</td>
+              </tr>
+            )) : <tr><td colSpan="12">Geen bonartikelen beschikbaar voor externe herkenning.</td></tr>}
+            {Array.from({ length: emptyRows }).map((_, index) => <tr key={`empty-${index}`}><td colSpan="12"></td></tr>)}
+          </tbody>
+        </Table>
+      </div>
+
+      <div className="rz-external-databases-pagination" aria-label="Paginering bonartikelen">
+        <Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => goToPage(1)}>Eerste</Button>
+        <Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => goToPage(currentPage - 1)}>Vorige</Button>
+        <span className="rz-external-databases-page-indicator">Pagina {currentPage} van {pageCount}</span>
+        <Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => goToPage(currentPage + 1)}>Volgende</Button>
+        <Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => goToPage(pageCount)}>Laatste</Button>
+      </div>
+
+      {selectedItem ? (
+        <div className="rz-external-receipt-detail">
+          <h3>Koppelen kandidaten in artikel-catalogus</h3>
+          <p>Kandidaten voor: {selectedItem.receiptLineText}</p>
+          <dl>
+            <dt>Winkelketen</dt><dd>{selectedItem.retailerCode}</dd>
+            <dt>Artikelnummer</dt><dd>{selectedItem.articleNumber}</dd>
+            <dt>GTIN / EAN</dt><dd>{selectedItem.gtin}</dd>
+            <dt>Status</dt><dd>{selectedItem.status}</dd>
+          </dl>
+          <Table dataTestId="external-receipt-item-candidates-table" tableClassName="rz-external-candidate-detail-table" resizableColumns>
+            <thead>
+              <tr className="rz-table-header"><th>Keuze</th><th>Kandidaat</th><th>Merk</th><th>Bron</th><th>Artikelnummer</th><th>Variant</th><th className="rz-num">Score</th><th>Status</th></tr>
+            </thead>
+            <tbody>
+              {selectedCandidates.length ? selectedCandidates.map((candidate) => (
+                <tr key={candidate.id} className={selectedCandidateId === candidate.id ? 'rz-row-selected' : ''}>
+                  <td className="rz-check"><input type="radio" name="external-candidate" checked={selectedCandidateId === candidate.id} disabled={!candidate.isLinkableToCatalog && !candidate.isLinkedToCatalog} onChange={() => setSelectedCandidateId(candidate.id)} /></td>
+                  <td>{candidate.candidateName}</td>
+                  <td>{candidate.brand}</td>
+                  <td>{candidate.source}</td>
+                  <td>{candidate.externalCode}</td>
+                  <td>{candidate.variant}</td>
+                  <td className="rz-num">{scoreText(candidate.score)}</td>
+                  <td>{candidate.status}</td>
+                </tr>
+              )) : <tr><td colSpan="8">Geen externe kandidaten voor dit bonartikel.</td></tr>}
+            </tbody>
+          </Table>
+          <div className="rz-external-databases-actions">
+            <Button type="button" disabled={!selectedCandidateCanBeLinked} onClick={processSelectedCandidate}>Koppel artikel</Button>
+            <Button type="button" variant="secondary" disabled={!selectedCandidateCanBeUnlinked} onClick={unlinkSelectedCandidate}>Ontkoppel artikel</Button>
+            <span className="rz-external-databases-muted">
+              {selectedItemHasKnownGtin
+                ? 'GTIN/EAN is al bekend; OFF-kandidaten worden niet automatisch toegevoegd.'
+                : (isOffLoading ? 'OFF wordt automatisch geraadpleegd...' : 'OFF wordt automatisch geraadpleegd bij openen van dit detail; koppelen blijft een expliciete keuze.')}
+            </span>
+          </div>
+          {offError ? <div className="rz-inline-feedback">{offError}</div> : null}
+          {offPreview ? <div className="rz-external-databases-preview-meta" data-testid="external-off-preview-meta"><span>OFF-status: {offStatusLabel(offPreview)}</span><span>Provider: {text(offPreview.provider)}</span><span>Productmutatie: nee</span></div> : null}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/frontend/tests/e2e/external-databases-known-gtin.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases-known-gtin.frontend-regression.spec.js
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+import {
+  attachConsoleErrorCollector,
+  expectNoConsoleErrors,
+  expectRouteLoads,
+} from './helpers/rezzervAssertions.js';
+
+test.describe('Externe databases bekende GTIN regressie', () => {
+  test('Bonartikel met bestaande GTIN behoudt artikelcode en krijgt geen kandidaten', async ({ page }) => {
+    const consoleErrors = attachConsoleErrorCollector(page);
+    let offSaveCalled = false;
+
+    await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [
+            {
+              context_key: 'ctx-known-gtin-regression',
+              receipt_line_id: 'receipt-line-known-gtin-regression',
+              purchase_import_line_id: 'purchase-line-known-gtin-regression',
+              receipt_line_text: 'Bekende GTIN regressietest',
+              retailer_code: 'lidl',
+              retailer_article_number: '8710000001234',
+              gtin: '8710000001234',
+              quantity_label: '1 stuk',
+              price: 1.23,
+              is_receipt_item_placeholder: true,
+              candidates: [
+                {
+                  candidate_id: 'candidate-should-be-ignored-for-known-gtin',
+                  id: 'candidate-should-be-ignored-for-known-gtin',
+                  candidate_name: 'Onterechte kandidaat',
+                  candidate_brand: 'Testmerk',
+                  external_source_name: 'Open Food Facts',
+                  candidate_source_name: 'Open Food Facts',
+                  external_source_product_code: '9999999999999',
+                  candidate_source_product_code: '9999999999999',
+                  source_product_code: '9999999999999',
+                  variant: 'Standaard',
+                  score: 0.99,
+                  candidate_status: 'candidate',
+                  is_linked_to_catalog: false,
+                  is_linkable_to_catalog: true,
+                },
+              ],
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.route('**/api/external-databases/off/save-candidates', async (route) => {
+      offSaveCalled = true;
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'OFF mocht niet worden aangeroepen voor bekende GTIN' }),
+      });
+    });
+
+    await expectRouteLoads(page, '/externe-databases', [
+      'Externe databases',
+      'Bonartikelen',
+      'Kandidaten',
+      'Product',
+    ]);
+
+    const receiptTable = page.getByTestId('external-receipt-items-table');
+    const receiptRow = receiptTable.locator('tbody tr', { hasText: 'Bekende GTIN regressietest' });
+    await expect(receiptRow).toBeVisible();
+    await expect(receiptRow.locator('td').nth(4)).toHaveText('8710000001234');
+    await expect(receiptRow.locator('td').nth(5)).toHaveText('8710000001234');
+    await expect(receiptRow.locator('td').nth(9)).toHaveText('-');
+    await expect(receiptRow.locator('td').nth(10)).toHaveText('-');
+    await expect(receiptRow.locator('td').nth(11)).toHaveText('0');
+
+    await receiptRow.dblclick();
+
+    const candidateTable = page.getByTestId('external-receipt-item-candidates-table');
+    await expect(candidateTable).toBeVisible();
+    await expect(candidateTable).toContainText('Geen externe kandidaten voor dit bonartikel.');
+    await expect(candidateTable.getByText('Onterechte kandidaat')).toHaveCount(0);
+    await expect(page.getByText('GTIN/EAN is al bekend; OFF-kandidaten worden niet automatisch toegevoegd.')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Koppel artikel', exact: true })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Ontkoppel artikel', exact: true })).toBeDisabled();
+    expect(offSaveCalled).toBe(false);
+
+    await expectNoConsoleErrors(consoleErrors);
+  });
+});

--- a/frontend/tests/e2e/external-databases.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases.frontend-regression.spec.js
@@ -1,10 +1,30 @@
-﻿import { test, expect } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import {
   attachConsoleErrorCollector,
   expectAnyVisible,
   expectNoConsoleErrors,
   expectRouteLoads,
 } from './helpers/rezzervAssertions.js';
+
+async function routeReceiptItems(page, items) {
+  await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items }),
+    });
+  });
+  await page.route('**/api/external-databases/receipt-items/ensure-candidates', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'ok' }) });
+  });
+}
+
+async function openExternalDatabases(page) {
+  await expectRouteLoads(page, '/externe-databases', ['Externe databases', 'Bonartikelen', 'Kandidaten', 'Product']);
+  const receiptTable = page.getByTestId('external-receipt-items-table');
+  await expect(receiptTable).toBeVisible();
+  return receiptTable;
+}
 
 test.describe('Externe databases frontend-regressie', () => {
   test('Externe databases scherm laadt en behoudt bonartikelen-overzicht', async ({ page }) => {
@@ -18,14 +38,7 @@ test.describe('Externe databases frontend-regressie', () => {
       'Product',
     ]);
 
-    await expectAnyVisible(page, [
-      'Externe databases',
-      'Open Food Facts',
-      'Bonartikelen',
-      'Kandidaten',
-      'Product',
-    ], 'Externe databases kernlabels');
-
+    await expectAnyVisible(page, ['Externe databases', 'Open Food Facts', 'Bonartikelen', 'Kandidaten', 'Product'], 'Externe databases kernlabels');
     await expect(page.getByText('Lidl-kandidaatpreview')).toHaveCount(0);
     await expect(page.getByRole('button', { name: 'Test kandidaat' })).toHaveCount(0);
 
@@ -38,84 +51,61 @@ test.describe('Externe databases frontend-regressie', () => {
 
     await expect(page.getByText('Koppelen kandidaten in artikel-catalogus')).toBeVisible();
     await expect(page.getByTestId('external-receipt-item-candidates-table')).toBeVisible();
-
     await expect(page.getByText(/Application error|Uncaught|TypeError|ReferenceError/i)).toHaveCount(0);
     await expectNoConsoleErrors(consoleErrors);
   });
+
   test('Kandidatenlijst ondertabel ontdubbelt dubbele externe kandidaten', async ({ page }) => {
     const consoleErrors = attachConsoleErrorCollector(page);
-
-    await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          items: [
-            {
-              context_key: 'ctx-dedupe-regression',
-              receipt_line_id: 'receipt-line-dedupe-regression',
-              purchase_import_line_id: 'purchase-line-dedupe-regression',
-              receipt_line_text: 'Dubbele kandidaat regressietest',
-              retailer_code: 'lidl',
-              retailer_article_number: '12345',
-              gtin: '8710000000001',
-              quantity_label: '1 stuk',
-              price: 1.23,
-              candidate_id: 'candidate-low-score',
-              candidate_name: 'Rezzerv Test Mosterd',
-              candidate_brand: 'Testmerk',
-              external_source_name: 'Open Food Facts',
-              external_source_product_code: '8710000000001',
-              variant: 'Standaard',
-              score: 0.4,
-              candidate_status: 'candidate',
-              is_linked_to_catalog: false,
-              is_linkable_to_catalog: true,
-            },
-            {
-              context_key: 'ctx-dedupe-regression',
-              receipt_line_id: 'receipt-line-dedupe-regression',
-              purchase_import_line_id: 'purchase-line-dedupe-regression',
-              receipt_line_text: 'Dubbele kandidaat regressietest',
-              retailer_code: 'lidl',
-              retailer_article_number: '12345',
-              gtin: '8710000000001',
-              quantity_label: '1 stuk',
-              price: 1.23,
-              candidate_id: 'candidate-high-score',
-              candidate_name: 'Rezzerv Test Mosterd',
-              candidate_brand: 'Testmerk',
-              external_source_name: 'Open Food Facts',
-              external_source_product_code: '8710000000001',
-              variant: 'Standaard',
-              score: 0.8,
-              candidate_status: 'candidate',
-              is_linked_to_catalog: false,
-              is_linkable_to_catalog: true,
-            },
-          ],
-        }),
-      });
-    });
-
-    await page.route('**/api/external-databases/receipt-items/ensure-candidates', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ status: 'ok' }),
-      });
-    });
-
-    await expectRouteLoads(page, '/externe-databases', [
-      'Externe databases',
-      'Bonartikelen',
-      'Kandidaten',
-      'Product',
+    await routeReceiptItems(page, [
+      {
+        context_key: 'ctx-dedupe-regression',
+        receipt_line_id: 'receipt-line-dedupe-regression',
+        purchase_import_line_id: 'purchase-line-dedupe-regression',
+        receipt_line_text: 'Dubbele kandidaat regressietest',
+        retailer_code: 'lidl',
+        retailer_article_number: '12345',
+        gtin: '',
+        quantity_label: '1 stuk',
+        price: 1.23,
+        candidate_id: 'candidate-low-score',
+        candidate_name: 'Rezzerv Test Mosterd',
+        candidate_brand: 'Testmerk',
+        external_source_name: 'Open Food Facts',
+        external_source_product_code: '8710000000001',
+        gtin_candidate: '8710000000001',
+        gtin: '',
+        variant: 'Standaard',
+        score: 0.4,
+        candidate_status: 'candidate',
+        is_linked_to_catalog: false,
+        is_linkable_to_catalog: true,
+      },
+      {
+        context_key: 'ctx-dedupe-regression',
+        receipt_line_id: 'receipt-line-dedupe-regression',
+        purchase_import_line_id: 'purchase-line-dedupe-regression',
+        receipt_line_text: 'Dubbele kandidaat regressietest',
+        retailer_code: 'lidl',
+        retailer_article_number: '12345',
+        gtin: '',
+        quantity_label: '1 stuk',
+        price: 1.23,
+        candidate_id: 'candidate-high-score',
+        candidate_name: 'Rezzerv Test Mosterd',
+        candidate_brand: 'Testmerk',
+        external_source_name: 'Open Food Facts',
+        external_source_product_code: '8710000000001',
+        ean: '8710000000001',
+        variant: 'Standaard',
+        score: 0.8,
+        candidate_status: 'candidate',
+        is_linked_to_catalog: false,
+        is_linkable_to_catalog: true,
+      },
     ]);
 
-    const receiptTable = page.getByTestId('external-receipt-items-table');
-    await expect(receiptTable).toBeVisible();
-
+    const receiptTable = await openExternalDatabases(page);
     const receiptRow = receiptTable.locator('tbody tr', { hasText: 'Dubbele kandidaat regressietest' });
     await expect(receiptRow).toBeVisible();
     await expect(receiptRow.locator('td').nth(4)).toHaveText('8710000000001');
@@ -124,278 +114,86 @@ test.describe('Externe databases frontend-regressie', () => {
     await expect(receiptRow.locator('td').nth(10)).toContainText('0,800');
 
     await receiptRow.dblclick();
-
     const candidateTable = page.getByTestId('external-receipt-item-candidates-table');
     await expect(candidateTable).toBeVisible();
-
-    const candidateRows = candidateTable.locator('tbody tr').filter({
-      has: page.locator('input[type="radio"]'),
-    });
-
-    await expect(candidateRows).toHaveCount(1);
+    await expect(candidateTable.locator('tbody tr').filter({ has: page.locator('input[type="radio"]') })).toHaveCount(1);
     await expect(candidateTable.getByText('0,800')).toBeVisible();
     await expect(candidateTable.getByText('0,400')).toHaveCount(0);
-
     await expectNoConsoleErrors(consoleErrors);
   });
+
   test('Bovenste tabel toont geen winkelspecifieke artikelcode als GTIN EAN', async ({ page }) => {
     const consoleErrors = attachConsoleErrorCollector(page);
+    await routeReceiptItems(page, [{
+      context_key: 'ctx-invalid-gtin-regression', receipt_line_id: 'receipt-line-invalid-gtin-regression', purchase_import_line_id: 'purchase-line-invalid-gtin-regression', receipt_line_text: 'Winkelspecifieke code regressietest', retailer_code: 'lidl', retailer_article_number: '12345', gtin: 'ART-8710000000001', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-invalid-gtin', candidate_name: 'Rezzerv Test Product', candidate_brand: 'Testmerk', external_source_name: 'Open Food Facts', external_source_product_code: 'LIDL-00999', variant: 'Standaard', score: 0.9, candidate_status: 'candidate', is_linked_to_catalog: false, is_linkable_to_catalog: true,
+    }]);
 
-    await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          items: [
-            {
-              context_key: 'ctx-invalid-gtin-regression',
-              receipt_line_id: 'receipt-line-invalid-gtin-regression',
-              purchase_import_line_id: 'purchase-line-invalid-gtin-regression',
-              receipt_line_text: 'Winkelspecifieke code regressietest',
-              retailer_code: 'lidl',
-              retailer_article_number: '12345',
-              gtin: 'ART-8710000000001',
-              quantity_label: '1 stuk',
-              price: 1.23,
-              candidate_id: 'candidate-invalid-gtin',
-              candidate_name: 'Rezzerv Test Product',
-              candidate_brand: 'Testmerk',
-              external_source_name: 'Open Food Facts',
-              external_source_product_code: 'LIDL-00999',
-              variant: 'Standaard',
-              score: 0.9,
-              candidate_status: 'candidate',
-              is_linked_to_catalog: false,
-              is_linkable_to_catalog: true,
-            },
-          ],
-        }),
-      });
-    });
-
-    await page.route('**/api/external-databases/receipt-items/ensure-candidates', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ status: 'ok' }),
-      });
-    });
-
-    await expectRouteLoads(page, '/externe-databases', [
-      'Externe databases',
-      'Bonartikelen',
-      'Kandidaten',
-      'Product',
-    ]);
-
-    const receiptTable = page.getByTestId('external-receipt-items-table');
-    await expect(receiptTable).toBeVisible();
-
+    const receiptTable = await openExternalDatabases(page);
     const receiptRow = receiptTable.locator('tbody tr', { hasText: 'Winkelspecifieke code regressietest' });
     await expect(receiptRow).toBeVisible();
     await expect(receiptRow.locator('td').nth(4)).toHaveText('LIDL-00999');
     await expect(receiptRow.locator('td').nth(5)).toHaveText('-');
     await expect(receiptRow.locator('td').nth(9)).toContainText('Rezzerv Test Product');
     await expect(receiptRow.locator('td').nth(10)).toContainText('0,900');
-
     await expectNoConsoleErrors(consoleErrors);
   });
 
   test('Bovenste tabel gebruikt gekoppelde kandidaat boven hoogste score', async ({ page }) => {
     const consoleErrors = attachConsoleErrorCollector(page);
-
-    await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          items: [
-            {
-              context_key: 'ctx-linked-wins-regression',
-              receipt_line_id: 'receipt-line-linked-wins-regression',
-              purchase_import_line_id: 'purchase-line-linked-wins-regression',
-              receipt_line_text: 'Gekoppelde kandidaat regressietest',
-              retailer_code: 'lidl',
-              retailer_article_number: '12345',
-              gtin: '',
-              quantity_label: '1 stuk',
-              price: 1.23,
-              candidate_id: 'candidate-highest-score-not-linked',
-              candidate_name: 'Niet gekoppelde hoogste score',
-              candidate_brand: 'Testmerk',
-              external_source_name: 'Open Food Facts',
-              external_source_product_code: 'LIDL-HIGH',
-              variant: 'Standaard',
-              score: 0.99,
-              candidate_status: 'candidate',
-              is_linked_to_catalog: false,
-              is_linkable_to_catalog: true,
-            },
-            {
-              context_key: 'ctx-linked-wins-regression',
-              receipt_line_id: 'receipt-line-linked-wins-regression',
-              purchase_import_line_id: 'purchase-line-linked-wins-regression',
-              receipt_line_text: 'Gekoppelde kandidaat regressietest',
-              retailer_code: 'lidl',
-              retailer_article_number: '12345',
-              gtin: '',
-              quantity_label: '1 stuk',
-              price: 1.23,
-              candidate_id: 'candidate-linked-lower-score',
-              candidate_name: 'Gekoppelde lagere score',
-              candidate_brand: 'Testmerk',
-              external_source_name: 'Open Food Facts',
-              external_source_product_code: 'LIDL-LINKED',
-              variant: 'Standaard',
-              score: 0.50,
-              candidate_status: 'linked_to_catalog',
-              is_linked_to_catalog: true,
-              is_linkable_to_catalog: false,
-            },
-          ],
-        }),
-      });
-    });
-
-    await page.route('**/api/external-databases/receipt-items/ensure-candidates', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ status: 'ok' }),
-      });
-    });
-
-    await expectRouteLoads(page, '/externe-databases', [
-      'Externe databases',
-      'Bonartikelen',
-      'Kandidaten',
-      'Product',
+    await routeReceiptItems(page, [
+      { context_key: 'ctx-linked-wins-regression', receipt_line_id: 'receipt-line-linked-wins-regression', purchase_import_line_id: 'purchase-line-linked-wins-regression', receipt_line_text: 'Gekoppelde kandidaat regressietest', retailer_code: 'lidl', retailer_article_number: '12345', gtin: '', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-highest-score-not-linked', candidate_name: 'Niet gekoppelde hoogste score', candidate_brand: 'Testmerk', external_source_name: 'Open Food Facts', external_source_product_code: 'LIDL-HIGH', variant: 'Standaard', score: 0.99, candidate_status: 'candidate', is_linked_to_catalog: false, is_linkable_to_catalog: true },
+      { context_key: 'ctx-linked-wins-regression', receipt_line_id: 'receipt-line-linked-wins-regression', purchase_import_line_id: 'purchase-line-linked-wins-regression', receipt_line_text: 'Gekoppelde kandidaat regressietest', retailer_code: 'lidl', retailer_article_number: '12345', gtin: '', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-linked-lower-score', candidate_name: 'Gekoppelde lagere score', candidate_brand: 'Testmerk', external_source_name: 'Open Food Facts', external_source_product_code: 'LIDL-LINKED', variant: 'Standaard', score: 0.50, candidate_status: 'linked_to_catalog', is_linked_to_catalog: true, is_linkable_to_catalog: false },
     ]);
 
-    const receiptTable = page.getByTestId('external-receipt-items-table');
-    await expect(receiptTable).toBeVisible();
-
+    const receiptTable = await openExternalDatabases(page);
     const receiptRow = receiptTable.locator('tbody tr', { hasText: 'Gekoppelde kandidaat regressietest' });
     await expect(receiptRow).toBeVisible();
     await expect(receiptRow.locator('td').nth(4)).toHaveText('LIDL-LINKED');
     await expect(receiptRow.locator('td').nth(5)).toHaveText('-');
-
     await receiptRow.dblclick();
-
-    const candidateTable = page.getByTestId('external-receipt-item-candidates-table');
-    await expect(candidateTable).toBeVisible();
-    const linkedCandidateRow = candidateTable.locator('tbody tr', { hasText: 'Gekoppelde lagere score' });
+    const linkedCandidateRow = page.getByTestId('external-receipt-item-candidates-table').locator('tbody tr', { hasText: 'Gekoppelde lagere score' });
     await expect(linkedCandidateRow).toBeVisible();
     await expect(linkedCandidateRow).toContainText('Gekoppeld');
-
     await expectNoConsoleErrors(consoleErrors);
   });
 
   test('Fallbackkandidaat is zichtbaar maar niet koppelbaar', async ({ page }) => {
     const consoleErrors = attachConsoleErrorCollector(page);
+    await routeReceiptItems(page, [{
+      context_key: 'ctx-fallback-regression', receipt_line_id: 'receipt-line-fallback-regression', purchase_import_line_id: 'purchase-line-fallback-regression', receipt_line_text: 'Fallback kandidaat regressietest', retailer_code: 'lidl', retailer_article_number: '12345', gtin: '', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-fallback-regression', candidate_name: 'Fallback kandidaat', candidate_brand: '-', external_source_name: 'receipt_product_intent_fallback', external_source_product_code: 'fallback:creme-frache', variant: 'Geen externe match', score: 0.1, candidate_status: 'candidate', is_linked_to_catalog: false, is_linkable_to_catalog: true,
+    }]);
 
-    await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          items: [
-            {
-              context_key: 'ctx-fallback-regression',
-              receipt_line_id: 'receipt-line-fallback-regression',
-              purchase_import_line_id: 'purchase-line-fallback-regression',
-              receipt_line_text: 'Fallback kandidaat regressietest',
-              retailer_code: 'lidl',
-              retailer_article_number: '12345',
-              gtin: '',
-              quantity_label: '1 stuk',
-              price: 1.23,
-              candidate_id: 'candidate-fallback-regression',
-              candidate_name: 'Fallback kandidaat',
-              candidate_brand: '-',
-              external_source_name: 'receipt_product_intent_fallback',
-              external_source_product_code: 'fallback:creme-frache',
-              variant: 'Geen externe match',
-              score: 0.1,
-              candidate_status: 'candidate',
-              is_linked_to_catalog: false,
-              is_linkable_to_catalog: true,
-            },
-          ],
-        }),
-      });
-    });
-
-    await page.route('**/api/external-databases/receipt-items/ensure-candidates', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ status: 'ok' }),
-      });
-    });
-
-    await expectRouteLoads(page, '/externe-databases', [
-      'Externe databases',
-      'Bonartikelen',
-      'Kandidaten',
-      'Product',
-    ]);
-
-    const receiptTable = page.getByTestId('external-receipt-items-table');
+    const receiptTable = await openExternalDatabases(page);
     const receiptRow = receiptTable.locator('tbody tr', { hasText: 'Fallback kandidaat regressietest' });
     await expect(receiptRow).toBeVisible();
     await expect(receiptRow.locator('td').nth(9)).toHaveText('-');
     await expect(receiptRow.locator('td').nth(10)).toHaveText('-');
     await expect(receiptRow.locator('td').nth(11)).toHaveText('0');
-
     await receiptRow.dblclick();
-
-    const candidateTable = page.getByTestId('external-receipt-item-candidates-table');
-    await expect(candidateTable).toBeVisible();
-    const fallbackRow = candidateTable.locator('tbody tr', { hasText: 'Fallback kandidaat' });
+    const fallbackRow = page.getByTestId('external-receipt-item-candidates-table').locator('tbody tr', { hasText: 'Fallback kandidaat' });
     await expect(fallbackRow).toBeVisible();
     await expect(fallbackRow).toContainText('Geen externe match');
     await expect(fallbackRow.locator('input[type="radio"]')).toBeDisabled();
     await expect(page.getByRole('button', { name: 'Koppel artikel', exact: true })).toBeDisabled();
-
     await expectNoConsoleErrors(consoleErrors);
   });
 
   test('Catalogusfilter reset detailselectie als geselecteerde rij verdwijnt', async ({ page }) => {
     const consoleErrors = attachConsoleErrorCollector(page);
+    await routeReceiptItems(page, [
+      { context_key: 'ctx-filter-linked', receipt_line_id: 'line-filter-linked', purchase_import_line_id: 'purchase-filter-linked', receipt_line_text: 'Gekoppeld filter product', retailer_code: 'lidl', retailer_article_number: 'LIDL-LINKED', gtin: '', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-filter-linked', candidate_name: 'Gekoppeld filter kandidaat', candidate_brand: '-', external_source_name: 'Open Food Facts', external_source_product_code: '8710000000001', variant: 'Standaard', score: 0.9, candidate_status: 'linked_to_catalog', is_linked_to_catalog: true, is_linkable_to_catalog: false, global_product_id: 'gp-filter-linked' },
+      { context_key: 'ctx-filter-unlinked', receipt_line_id: 'line-filter-unlinked', purchase_import_line_id: 'purchase-filter-unlinked', receipt_line_text: 'Niet gekoppeld filter product', retailer_code: 'lidl', retailer_article_number: 'LIDL-UNLINKED', gtin: '', quantity_label: '1 stuk', price: 1.45, candidate_id: 'candidate-filter-unlinked', candidate_name: 'Niet gekoppeld filter kandidaat', candidate_brand: '-', external_source_name: 'Open Food Facts', external_source_product_code: '8710000000002', variant: 'Standaard', score: 0.8, candidate_status: 'candidate', is_linked_to_catalog: false, is_linkable_to_catalog: true },
+    ]);
 
-    await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          items: [
-            { context_key: 'ctx-filter-linked', receipt_line_id: 'line-filter-linked', purchase_import_line_id: 'purchase-filter-linked', receipt_line_text: 'Gekoppeld filter product', retailer_code: 'lidl', retailer_article_number: 'LIDL-LINKED', gtin: '', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-filter-linked', candidate_name: 'Gekoppeld filter kandidaat', candidate_brand: '-', external_source_name: 'Open Food Facts', external_source_product_code: '8710000000001', variant: 'Standaard', score: 0.9, candidate_status: 'linked_to_catalog', is_linked_to_catalog: true, is_linkable_to_catalog: false, global_product_id: 'gp-filter-linked' },
-            { context_key: 'ctx-filter-unlinked', receipt_line_id: 'line-filter-unlinked', purchase_import_line_id: 'purchase-filter-unlinked', receipt_line_text: 'Niet gekoppeld filter product', retailer_code: 'lidl', retailer_article_number: 'LIDL-UNLINKED', gtin: '', quantity_label: '1 stuk', price: 1.45, candidate_id: 'candidate-filter-unlinked', candidate_name: 'Niet gekoppeld filter kandidaat', candidate_brand: '-', external_source_name: 'Open Food Facts', external_source_product_code: '8710000000002', variant: 'Standaard', score: 0.8, candidate_status: 'candidate', is_linked_to_catalog: false, is_linkable_to_catalog: true },
-          ],
-        }),
-      });
-    });
-
-    await page.route('**/api/external-databases/receipt-items/ensure-candidates', async (route) => {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'ok' }) });
-    });
-
-    await expectRouteLoads(page, '/externe-databases', ['Externe databases', 'Bonartikelen', 'Kandidaten', 'Product']);
-
-    const receiptTable = page.getByTestId('external-receipt-items-table');
+    const receiptTable = await openExternalDatabases(page);
     const unlinkedRow = receiptTable.locator('tbody tr', { hasText: 'Niet gekoppeld filter product' });
     await expect(unlinkedRow).toBeVisible();
     await unlinkedRow.dblclick();
     await expect(page.getByTestId('external-receipt-item-candidates-table')).toContainText('Niet gekoppeld filter kandidaat');
-
     await receiptTable.locator('select').first().selectOption('linked');
     await expect(receiptTable.locator('tbody tr', { hasText: 'Gekoppeld filter product' })).toBeVisible();
     await expect(receiptTable.locator('tbody tr', { hasText: 'Niet gekoppeld filter product' })).toHaveCount(0);
     await expect(page.getByText('Niet gekoppeld filter kandidaat')).toHaveCount(0);
-
     await expectNoConsoleErrors(consoleErrors);
   });
-
 });
-


### PR DESCRIPTION
Herstelt de GTIN/EAN guardrail voor Externe databases.

Bonartikelen met bestaande GTIN/EAN krijgen geen kandidaatartikelen en behouden hun artikelcode.

Validatie lokaal:
- Gerichte GTIN-test: passed
- Volledige frontend regressie: geslaagd