### PR TITLE
M2C2i-32K/32L — Normalize AH leading quantities and show normalized receipt labels

### DIFF
--- a/backend/app/receipt_ingestion/product_candidate_gateway.py
+++ b/backend/app/receipt_ingestion/product_candidate_gateway.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Any
+import re
 
 from app.receipt_ingestion.duplicate_lines import is_near_duplicate_of_previous
 from app.receipt_ingestion.line_classifier import classification_allows_append
@@ -36,6 +37,79 @@ InvalidLabelCheck = Callable[[str], bool]
 def _is_validated_savings_action_path(function_name: str, append_branch: str) -> bool:
     """Return True only for the existing savings/action value-line parser path."""
     return function_name == '_extract_savings_action_lines' and append_branch == 'savings_action_line'
+
+
+
+
+def _is_ah_receipt_context(
+    *,
+    store_name: str | None,
+    filename: str | None,
+    raw_line: str | None,
+    normalized_line: str | None,
+    parser_path: str | None,
+) -> bool:
+    haystack = " ".join([
+        str(store_name or ""),
+        str(filename or ""),
+        str(raw_line or ""),
+        str(normalized_line or ""),
+        str(parser_path or ""),
+    ]).lower()
+    return (
+        "albert heijn" in haystack
+        or "ah to go" in haystack
+        or "bonuskaart" in haystack
+        or "jouw voordeel" in haystack
+        or "je voordeel" in haystack
+        or "profiles.ah" in haystack
+    )
+
+
+def _split_ah_leading_quantity_label(
+    label_value: str,
+    *,
+    qty_raw: str | None,
+    store_name: str | None,
+    filename: str | None,
+    raw_line: str | None,
+    normalized_line: str | None,
+    parser_path: str | None,
+) -> tuple[str, int | None, dict[str, Any] | None]:
+    if qty_raw:
+        return label_value, None, None
+    if not _is_ah_receipt_context(
+        store_name=store_name,
+        filename=filename,
+        raw_line=raw_line,
+        normalized_line=normalized_line,
+        parser_path=parser_path,
+    ):
+        return label_value, None, None
+
+    original_label = str(label_value or "").strip()
+    match = re.match(r"^\s*(?P<token>\d{1,2}|[TtIi|Nn])\s+(?P<label>\S.*)$", original_label)
+    if not match:
+        return label_value, None, None
+
+    token = match.group("token").strip()
+    remaining_label = re.sub(r"\s+", " ", match.group("label")).strip()
+    if not remaining_label or not any(ch.isalpha() for ch in remaining_label):
+        return label_value, None, None
+
+    if token.upper() in {"T", "I", "|"}:
+        quantity = 1
+    elif token.upper() == "N":
+        quantity = 2
+    else:
+        quantity = int(token)
+
+    return remaining_label, quantity, {
+        "original_label": original_label,
+        "normalized_label": remaining_label,
+        "quantity": quantity,
+        "token": token,
+    }
 
 
 def _as_float(value: Any) -> float | None:
@@ -96,6 +170,18 @@ def append_product_candidate(
     if not label_value or len(label_value) < 2 or label_value.replace(' ', '').isdigit():
         return None
 
+    ah_leading_quantity_metadata = None
+    ah_leading_quantity = None
+    label_value, ah_leading_quantity, ah_leading_quantity_metadata = _split_ah_leading_quantity_label(
+        label_value,
+        qty_raw=qty_raw,
+        store_name=store_name,
+        filename=filename,
+        raw_line=raw_line,
+        normalized_line=normalized_line,
+        parser_path=parser_path,
+    )
+
     savings_action_path = _is_validated_savings_action_path(function_name, append_branch)
     if is_invalid_label is not None and is_invalid_label(label_value) and not savings_action_path:
         return None
@@ -116,6 +202,8 @@ def append_product_candidate(
         }
 
     quantity = parse_quantity((qty_raw or '').replace('kg', '').replace('KG', '').strip()) if qty_raw else None
+    if quantity is None and ah_leading_quantity is not None:
+        quantity = ah_leading_quantity
     try:
         if quantity is not None and quantity <= 0:
             quantity = None
@@ -134,7 +222,11 @@ def append_product_candidate(
         unit_price = amount1
         line_total = amount1
 
-    raw_label_value = clean_label(raw_line) if savings_action_path and raw_line else label_value
+    raw_label_value = (
+        clean_label(raw_line)
+        if savings_action_path and raw_line
+        else (ah_leading_quantity_metadata.get('original_label') if ah_leading_quantity_metadata else label_value)
+    )
     label_value, quantity, unit_value, package_metadata = apply_package_extraction_to_candidate(
         label_value,
         quantity=quantity,
@@ -203,6 +295,14 @@ def append_product_candidate(
             'package_text': package_metadata.get('package_text'),
             'package_quantity': package_metadata.get('package_quantity'),
             'package_unit': package_metadata.get('package_unit'),
+        })
+    if ah_leading_quantity_metadata:
+        producer_trace.update({
+            'ah_leading_quantity_normalization_applied': True,
+            'ah_leading_quantity_original_label': ah_leading_quantity_metadata.get('original_label'),
+            'ah_leading_quantity_normalized_label': ah_leading_quantity_metadata.get('normalized_label'),
+            'ah_leading_quantity': ah_leading_quantity_metadata.get('quantity'),
+            'ah_leading_quantity_token': ah_leading_quantity_metadata.get('token'),
         })
     if name_metadata:
         producer_trace.update({

--- a/frontend/src/features/receipts/KassaPage.jsx
+++ b/frontend/src/features/receipts/KassaPage.jsx
@@ -958,7 +958,7 @@ function ReceiptDetailInfoCard({ receipt, canEdit = false, onReceiptUpdated, onF
     const nextDrafts = {}
     ;(receipt?.lines || []).forEach((line) => {
       nextDrafts[line.id] = {
-        article_name: line?.display_label ?? line?.corrected_raw_label ?? line?.raw_label ?? '',
+        article_name: line?.normalized_label ?? line?.display_label ?? line?.corrected_raw_label ?? line?.raw_label ?? '',
         quantity: line?.display_quantity ?? line?.corrected_quantity ?? line?.quantity ?? '',
         unit: line?.display_unit ?? line?.corrected_unit ?? line?.unit ?? '',
         unit_price: line?.display_unit_price ?? line?.corrected_unit_price ?? line?.unit_price ?? '',
@@ -976,7 +976,7 @@ function ReceiptDetailInfoCard({ receipt, canEdit = false, onReceiptUpdated, onF
   const lines = baseLines.filter((line) => !Boolean(lineDrafts[line.id]?.is_deleted ?? line?.is_deleted))
   const sortedLines = useMemo(() => sortItems(lines, lineSort, {
     lineIndex: (line) => Number(line?.line_index ?? 0),
-    article: (line) => lineDrafts[line.id]?.article_name || line?.display_label || line?.raw_label || '',
+    article: (line) => lineDrafts[line.id]?.article_name || line?.normalized_label || line?.display_label || line?.raw_label || '',
     quantity: (line) => Number(lineDrafts[line.id]?.quantity ?? line?.display_quantity ?? line?.quantity ?? 0),
     unit: (line) => lineDrafts[line.id]?.unit || line?.display_unit || line?.unit || '',
     unitPrice: (line) => Number(lineDrafts[line.id]?.unit_price ?? line?.display_unit_price ?? line?.unit_price ?? 0),
@@ -1038,7 +1038,7 @@ function ReceiptDetailInfoCard({ receipt, canEdit = false, onReceiptUpdated, onF
       filterable: true,
       filterLabel: filterLabels[column.key],
       getSortValue: (line) => {
-        if (column.key === 'article') return lineDrafts[line.id]?.article_name || line?.display_label || line?.raw_label || ''
+        if (column.key === 'article') return lineDrafts[line.id]?.article_name || line?.normalized_label || line?.display_label || line?.raw_label || ''
         if (column.key === 'quantity') return Number(lineDrafts[line.id]?.quantity ?? line?.display_quantity ?? line?.quantity ?? 0)
         if (column.key === 'unit') return lineDrafts[line.id]?.unit || line?.display_unit || line?.unit || ''
         if (column.key === 'unitPrice') return Number(lineDrafts[line.id]?.unit_price ?? line?.display_unit_price ?? line?.unit_price ?? 0)
@@ -1047,7 +1047,7 @@ function ReceiptDetailInfoCard({ receipt, canEdit = false, onReceiptUpdated, onF
         return ''
       },
       getFilterValue: (line) => {
-        if (column.key === 'article') return lineDrafts[line.id]?.article_name || line?.display_label || line?.raw_label || ''
+        if (column.key === 'article') return lineDrafts[line.id]?.article_name || line?.normalized_label || line?.display_label || line?.raw_label || ''
         if (column.key === 'quantity') return lineDrafts[line.id]?.quantity ?? line?.display_quantity ?? line?.quantity ?? ''
         if (column.key === 'unit') return lineDrafts[line.id]?.unit || line?.display_unit || line?.unit || ''
         if (column.key === 'unitPrice') return lineDrafts[line.id]?.unit_price ?? line?.display_unit_price ?? line?.unit_price ?? ''
@@ -1261,7 +1261,7 @@ async function saveLine(lineId, overrides = null) {
     const exportLines = lines.filter((line) => selectedSet.has(line.id))
     const rows = exportLines.map((line) => {
       const draft = lineDrafts[line.id] || {}
-      return [draft.article_name || line.display_label || line.raw_label || '', draft.quantity ?? '', draft.unit || '', draft.unit_price ?? '', draft.line_total ?? '', line.discount_amount ?? '', line.barcode || '']
+      return [draft.article_name || line.normalized_label || line.display_label || line.raw_label || '', draft.quantity ?? '', draft.unit || '', draft.unit_price ?? '', draft.line_total ?? '', line.discount_amount ?? '', line.barcode || '']
     })
     const csv = [['Artikel in bon', 'Aantal', 'Eenheid', 'Stukprijs', 'Regelbedrag', 'Korting', 'Barcode'], ...rows].map((row) => row.map((value) => `"${String(value ?? '').replace(/"/g, '""')}"`).join(';')).join('\n')
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
@@ -1408,8 +1408,8 @@ async function saveLine(lineId, overrides = null) {
                     const draft = lineDrafts[line.id] || {}
                     return (
                       <tr key={line.id} data-testid={`receipt-line-row-${line.id}`} className={selected ? 'rz-row-selected' : ''}>
-                        <td><input type="checkbox" data-testid={`receipt-line-select-${line.id}`} checked={selected} onChange={() => toggleLine(line.id)} aria-label={`Selecteer regel ${draft.article_name || line.display_label || line.id}`} /></td>
-                        <td>{canEdit ? <input className="rz-input" value={draft.article_name ?? ''} onFocus={(event) => rememberLineFieldValue(line.id, 'article_name', event.target.value)} onChange={(event) => updateLineDraft(line.id, 'article_name', event.target.value)} onBlur={(event) => saveLineFieldOnBlur(line.id, 'article_name', event.target.value)} /> : <span data-testid={`receipt-line-status-${line.id}`}>{draft.article_name || line.display_label || '-'}</span>}</td>
+                        <td><input type="checkbox" data-testid={`receipt-line-select-${line.id}`} checked={selected} onChange={() => toggleLine(line.id)} aria-label={`Selecteer regel ${draft.article_name || line.normalized_label || line.display_label || line.id}`} /></td>
+                        <td>{canEdit ? <input className="rz-input" value={draft.article_name ?? ''} onFocus={(event) => rememberLineFieldValue(line.id, 'article_name', event.target.value)} onChange={(event) => updateLineDraft(line.id, 'article_name', event.target.value)} onBlur={(event) => saveLineFieldOnBlur(line.id, 'article_name', event.target.value)} /> : <span data-testid={`receipt-line-status-${line.id}`}>{draft.article_name || line.normalized_label || line.display_label || '-'}</span>}</td>
                         <td className="rz-num">{canEdit ? <input className="rz-input" type="number" step="0.001" value={draft.quantity ?? ''} onFocus={(event) => rememberLineFieldValue(line.id, 'quantity', event.target.value)} onChange={(event) => updateLineDraft(line.id, 'quantity', event.target.value)} onBlur={(event) => saveLineFieldOnBlur(line.id, 'quantity', event.target.value)} /> : formatQuantity(draft.quantity ?? line.display_quantity ?? line.quantity)}</td>
                         <td>{canEdit ? <input className="rz-input" value={draft.unit ?? ''} onFocus={(event) => rememberLineFieldValue(line.id, 'unit', event.target.value)} onChange={(event) => updateLineDraft(line.id, 'unit', event.target.value)} onBlur={(event) => saveLineFieldOnBlur(line.id, 'unit', event.target.value)} /> : (draft.unit || line.display_unit || '-')}</td>
                         <td className="rz-num">{canEdit ? <input className="rz-input" type="number" step="0.01" value={draft.unit_price ?? ''} onFocus={(event) => rememberLineFieldValue(line.id, 'unit_price', event.target.value)} onChange={(event) => updateLineDraft(line.id, 'unit_price', event.target.value)} onBlur={(event) => saveLineFieldOnBlur(line.id, 'unit_price', event.target.value)} /> : formatMoney(draft.unit_price ?? line.display_unit_price ?? line.unit_price, receipt?.currency)}</td>


### PR DESCRIPTION
## Doel

Deze PR lost het zichtbare AH-JPG probleem op waarbij OCR de eerste aantalkolom `1` als `T` leest en die `T` in de artikelnaam zichtbaar bleef.

## Wijzigingen

### Backend

- AH leading quantity tokens worden bij nieuwe imports opgesplitst.
- `T`, `I` en `|` worden als quantity `1` geïnterpreteerd.
- `N` wordt als quantity `2` geïnterpreteerd.
- `raw_label` blijft de originele bron/OCR-tekst.
- `normalized_label` wordt opgeschoond.

### Frontend

- Kassa bonregels tonen `normalized_label` vóór `display_label` / `raw_label`.
- Sorteren, filteren, exporteren en aria-label gebruiken dezelfde labelvolgorde.

## Bewijs

Nieuw ingelezen AH-JPG:

- `raw_label = T AH M GEHAKT`
- `normalized_label = AH M GEHAKT`
- `quantity = 1`

Nieuw ingelezen AH-JPG:

- `raw_label = T SOEPGR BASIS`
- `normalized_label = SOEPGR BASIS`
- `quantity = 1`

Browser hard-refresh toont correct:

- `AH M GEHAKT`
- `SOEPGR BASIS`
- `Aantal = 1`

Frontend regressie:

- `15 passed`

## Niet gewijzigd

- Geen parserwijziging buiten AH-context.
- Geen database-migratie.
- Geen externe kandidaatselectie.
- Geen voorraadlogica.
- Geen main-claim.

## Release Gate v1.10 – Compliance Check

Basisversie: main na M2C2i-32I (`abb965d5`)

Nieuwe versie: M2C2i-32K/32L featurebranch (`30eecae3`)

Releasecategorie: backend ingestion-normalisatie + frontend weergavecorrectie

Wijzigingsdoel: AH-JPG leading quantity-token correct splitsen en normalized receipt labels tonen in Kassa.

Niet gewijzigd: externe kandidaatselectie, database-schema, voorraadlogica, productkoppeling, parserroutes buiten AH-context.

Getest: backend health, frontend regressie, nieuwe AH-JPG import, visuele browsercontrole na hard-refresh.

Niet getest: main na merge, lokale main-pull/rebuild/regressie.

Risiconiveau: middel.

Database locatie: `/app/data/rezzerv.db`, storage `sqlite_data`.

Database validatie: nieuwste AH-JPG regels tonen `raw_label` met `T`, `normalized_label` zonder `T`, `quantity = 1`.

Scope Gate: akkoord; scope beperkt tot AH leading quantity en Kassa-labelweergave.

QA/QC Gate: featurebranch functioneel groen; main-gate volgt na merge.

Packaging Gate: geen packagewijziging.