### PR TITLE
M2C2i-33 - Ontkoppel kassabon-testbaseline van productie-status

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 Technical Design Reference:
 - TD Section: TD-02 Backend API-laag
 - Module Role: FastAPI entrypoint and route container
@@ -12501,12 +12501,38 @@ def get_receipt_explainability(receipt_table_id: str, authorization: Optional[st
     }
 
     explainability = build_receipt_explainability(result, source_context=source_context)
-    status_payload = apply_po_norm_status(serialize_receipt_row(dict(header_dict)))
+
+    status_input = serialize_receipt_row(dict(header_dict))
+    line_total_sum = Decimal("0")
+    line_discount_sum = Decimal("0")
+    for line in active_lines:
+        try:
+            line_total_sum += Decimal(str(line.get("line_total") or 0))
+        except Exception:
+            pass
+        try:
+            line_discount_sum += Decimal(str(line.get("discount_amount") or 0))
+        except Exception:
+            pass
+
+    try:
+        discount_total = Decimal(str(status_input.get("discount_total") or 0))
+    except Exception:
+        discount_total = Decimal("0")
+
+    status_input["line_count"] = len(active_lines)
+    status_input["line_total_sum"] = float(line_total_sum)
+    status_input["net_line_total_sum"] = float(line_total_sum + discount_total)
+
+    status_payload = apply_po_norm_status(status_input)
 
     return {
         "receipt_table_id": receipt_table_id,
         "read_only": True,
         "po_norm_status_label": status_payload.get("po_norm_status_label"),
+        "po_norm_status": status_payload.get("po_norm_status"),
+        "po_norm_failed_criteria": status_payload.get("po_norm_failed_criteria") or [],
+        "po_norm_reason": status_payload.get("po_norm_reason"),
         "explainability": explainability,
         "line_count": len(active_lines),
         "ignored_line_count": len(ignored_lines),

--- a/backend/app/receipt_ingestion/explainability.py
+++ b/backend/app/receipt_ingestion/explainability.py
@@ -1,12 +1,12 @@
-"""
+﻿"""
 Technical Design Reference:
 - TD Section: TD-03 Receipt ingestion en parsers
 - Module Role: Receipt source parsing and data extraction
 - Runtime Type: production
 - Used By: see docs/technical/PYTHON-MODULE-CATALOG.md
 - Depends On: see generated inventory
-- Reads Data: see generated inventory
-- Writes Data: see generated inventory
+- Reads Data: none
+- Writes Data: none
 - Status Authority: no
 - Refactor Status: classify
 """
@@ -16,13 +16,13 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Any
 
-FUNCTIONAL_STATUS_LABELS = {
-    "approved": "Gecontroleerd",
-    "parsed": "Controle nodig",
-    "partial": "Controle nodig",
-    "review_needed": "Controle nodig",
-    "failed": "Controle nodig",
-    "duplicate": "Controle nodig",
+PARSER_QUALITY_LABELS = {
+    "approved": "Parser bruikbaar",
+    "parsed": "Controle parser nodig",
+    "partial": "Controle parser nodig",
+    "review_needed": "Controle parser nodig",
+    "failed": "Controle parser nodig",
+    "duplicate": "Controle parser nodig",
 }
 
 
@@ -62,7 +62,7 @@ def _discount_sum(lines: list[dict[str, Any]]) -> Decimal:
 
 def _status_explanation(result: Any, net_line_sum: Decimal | None, chosen_total: Decimal | None) -> dict[str, Any]:
     parse_status = str(getattr(result, "parse_status", "") or "").strip().lower()
-    label = FUNCTIONAL_STATUS_LABELS.get(parse_status, "Controle nodig")
+    label = PARSER_QUALITY_LABELS.get(parse_status, "Controle parser nodig")
     reasons: list[str] = []
 
     if not getattr(result, "is_receipt", False):
@@ -88,9 +88,12 @@ def _status_explanation(result: Any, net_line_sum: Decimal | None, chosen_total:
 
     return {
         "technical_parse_status": parse_status or None,
-        "po_norm_status_label": label,
+        "parser_quality_label": label,
         "reasons": reasons,
-        "ssot_note": "Functionele status voor Kassa blijft afkomstig uit receipt_status_baseline_service_v4 / apply_po_norm_status; deze explainability wijzigt geen status.",
+        "ssot_note": (
+            "Deze explainability beschrijft parserkwaliteit. De functionele "
+            "Kassa-status komt uitsluitend uit apply_po_norm_status."
+        ),
     }
 
 
@@ -98,7 +101,7 @@ def build_receipt_explainability(result: Any, source_context: dict[str, Any] | N
     """Build generic receipt parser explainability without changing parser decisions.
 
     Read-only: this explains the existing parser result and must not select a
-    different total, article line, OCR route or status.
+    different total, article line, OCR route or functional PO status.
     """
     lines = getattr(result, "lines", None) or []
     parser_diagnostics = getattr(result, "parser_diagnostics", None)

--- a/backend/app/services/receipt_ssot_status.py
+++ b/backend/app/services/receipt_ssot_status.py
@@ -1,113 +1,179 @@
-"""
+﻿"""
 Technical Design Reference:
 - TD Section: TD-04 Status en SSOT
-- Module Role: Map PO norm status to API/UI fields
+- Module Role: Map production PO norm status to API/UI fields
 - Runtime Type: production
 - Used By: see docs/technical/PYTHON-MODULE-CATALOG.md
-- Depends On: see generated inventory
-- Reads Data: see generated inventory
-- Writes Data: see generated inventory
-- Status Authority: no
+- Depends On: receipt payload content only
+- Reads Data: none
+- Writes Data: none
+- Status Authority: yes
 - Refactor Status: cleanup
 """
 
-
 from __future__ import annotations
-import logging
-import time
+
+from decimal import Decimal
 from typing import Any
 
-from app.db import engine
-from app.services.receipt_status_baseline_service_v4 import validate_receipt_status_baseline
 
-LOGGER = logging.getLogger(__name__)
-_CACHE: dict[str, Any] = {"loaded_at": 0.0, "items": {}}
-_CACHE_TTL_SECONDS = 1.0
+def _safe_decimal(value: Any) -> Decimal | None:
+    if value is None or value == "":
+        return None
+    try:
+        return Decimal(str(value))
+    except Exception:
+        return None
+
+
+def _amount_equals(left: Any, right: Any, tolerance: Decimal = Decimal("0.01")) -> bool:
+    left_dec = _safe_decimal(left)
+    right_dec = _safe_decimal(right)
+    if left_dec is None or right_dec is None:
+        return False
+    return abs(left_dec - right_dec) <= tolerance
 
 
 def _normalize_status_label(label: Any) -> str:
-    """Normalize legacy receipt status labels for the active Kassa UI.
+    """Normalize active Kassa status labels.
 
-    Historical parser/status diagnostics may still contain manual/Handmatig.
     The active Kassa contract exposes only Gecontroleerd or Controle nodig.
     """
     normalized = str(label or "").strip()
-    if normalized in {"", "Handmatig", "manual"}:
-        return "Controle nodig"
-    return normalized
+    if normalized == "Gecontroleerd":
+        return "Gecontroleerd"
+    return "Controle nodig"
 
 
 def _status_code(label: str) -> str:
-    normalized_label = _normalize_status_label(label)
-    if normalized_label == "Gecontroleerd":
-        return "controlled"
-    return "review"
+    return "controlled" if _normalize_status_label(label) == "Gecontroleerd" else "review"
+
+
+def _line_count(payload: dict[str, Any]) -> int:
+    value = payload.get("line_count")
+    if value is None and isinstance(payload.get("lines"), list):
+        value = len([
+            line for line in payload.get("lines") or []
+            if isinstance(line, dict) and int(line.get("is_deleted") or 0) == 0
+        ])
+    try:
+        return int(value or 0)
+    except Exception:
+        return 0
+
+
+def _net_line_total(payload: dict[str, Any]) -> Decimal | None:
+    for key in ("net_line_total_sum", "line_total_sum"):
+        value = _safe_decimal(payload.get(key))
+        if value is not None:
+            return value
+
+    lines = payload.get("lines")
+    if not isinstance(lines, list):
+        return None
+
+    total = Decimal("0")
+    seen = False
+    for line in lines:
+        if not isinstance(line, dict) or int(line.get("is_deleted") or 0):
+            continue
+        value = _safe_decimal(
+            line.get("display_line_total")
+            if line.get("display_line_total") is not None
+            else line.get("corrected_line_total")
+            if line.get("corrected_line_total") is not None
+            else line.get("line_total")
+        )
+        if value is None:
+            continue
+        total += value
+        seen = True
+    return total if seen else None
+
+
+def _production_status_item(payload: dict[str, Any]) -> dict[str, Any]:
+    """Determine production Kassa status from receipt content only.
+
+    The 14-receipt baseline is regression fixture data. Baseline membership is
+    not a production criterion and must never create NO_BASELINE_MATCH.
+    """
+    failed: list[str] = []
+
+    store_name = str(payload.get("store_name") or payload.get("store_branch") or "").strip()
+    if not store_name:
+        failed.append("STORE_NAME_MISSING")
+
+    total_amount = _safe_decimal(payload.get("total_amount"))
+    if total_amount is None:
+        failed.append("TOTAL_AMOUNT_MISSING")
+
+    line_count = _line_count(payload)
+    if line_count <= 0:
+        failed.append("NO_ARTICLE_LINES")
+
+    net_line_sum = _net_line_total(payload)
+    if total_amount is not None and line_count > 0:
+        if net_line_sum is None:
+            failed.append("LINE_SUM_MISSING")
+        elif not _amount_equals(net_line_sum, total_amount):
+            failed.append("LINE_SUM_TOTAL_MISMATCH")
+
+    label = "Gecontroleerd" if not failed else "Controle nodig"
+
+    if not failed:
+        reason = (
+            "Gecontroleerd: winkel, totaalbedrag en som van artikelregels "
+            "voldoen aan productieve Kassa-statuscriteria."
+        )
+    else:
+        labels = {
+            "STORE_NAME_MISSING": "winkelnaam ontbreekt",
+            "TOTAL_AMOUNT_MISSING": "totaalbedrag ontbreekt",
+            "NO_ARTICLE_LINES": "geen artikelregels gevonden",
+            "LINE_SUM_MISSING": "som van artikelregels ontbreekt",
+            "LINE_SUM_TOTAL_MISMATCH": "som van artikelregels sluit niet aan op kassabontotaal",
+        }
+        reason = "Controle nodig: " + "; ".join(labels.get(code, code) for code in failed)
+
+    return {
+        "po_norm_status": _status_code(label),
+        "po_norm_status_label": label,
+        "po_norm_failed_criteria": failed,
+        "po_norm_reason": reason,
+    }
 
 
 def load_po_norm_status_items() -> dict[str, dict[str, Any]]:
-    now = time.monotonic()
-    cached_items = _CACHE.get("items") or {}
-    if cached_items and (now - float(_CACHE.get("loaded_at") or 0.0)) < _CACHE_TTL_SECONDS:
-        return dict(cached_items)
+    """Compatibility shim.
 
-    items: dict[str, dict[str, Any]] = {}
-    try:
-        with engine.connect() as conn:
-            validation = validate_receipt_status_baseline(conn)
-        for item in validation.get("details", []) or []:
-            receipt_table_id = str(item.get("receipt_table_id") or "").strip()
-            if not receipt_table_id:
-                continue
-            label = _normalize_status_label(item.get("po_norm_status_label") or "Controle nodig")
-            items[receipt_table_id] = {
-                "po_norm_status": _status_code(label),
-                "po_norm_status_label": label,
-                "po_norm_failed_criteria": item.get("failed_criteria") or [],
-                "po_norm_reason": item.get("reason"),
-            }
-    except Exception as exc:
-        LOGGER.warning("po_norm_status_items_load_failed error=%s", exc)
-
-    _CACHE["loaded_at"] = now
-    _CACHE["items"] = items
-    return items
+    Production status is computed per receipt payload in apply_po_norm_status.
+    The regression baseline is intentionally not loaded here.
+    """
+    return {}
 
 
 def apply_po_norm_status(payload: dict[str, Any]) -> dict[str, Any]:
     """Apply the SSOT status contract to a receipt payload for Kassa.
 
-    Parser status fields are allowed to exist in storage as diagnostics, but they
-    are not allowed to drive Kassa categorisation. This function removes them
-    from the Kassa payload and exposes only the baseline-derived status fields.
+    Parser status fields may exist in storage as diagnostics, but they are not
+    allowed to drive Kassa categorisation. The 14-receipt regression baseline is
+    also not allowed to drive production categorisation.
     """
     if not isinstance(payload, dict):
         return payload
 
-    receipt_table_id = str(payload.get("id") or payload.get("receipt_table_id") or "").strip()
-    item = load_po_norm_status_items().get(receipt_table_id) if receipt_table_id else None
-    if not item:
-        item = {
-            "po_norm_status": "review",
-            "po_norm_status_label": "Controle nodig",
-            "po_norm_failed_criteria": ["NO_BASELINE_MATCH"],
-            "po_norm_reason": "Controle nodig: geen baseline-match gevonden voor deze actieve kassabon.",
-        }
-
+    item = _production_status_item(payload)
     label = _normalize_status_label(item.get("po_norm_status_label"))
     status_code = _status_code(label)
 
     payload.pop("parse_status", None)
     payload.pop("actual_parse_status", None)
     payload.pop("actual_status_label", None)
+
     payload["po_norm_status"] = status_code
     payload["po_norm_status_label"] = label
     payload["po_norm_failed_criteria"] = item.get("po_norm_failed_criteria") or []
     payload["po_norm_reason"] = item.get("po_norm_reason")
-
-    # R9-38E4b:
-    # PO/baseline status is diagnostic for new receipts.
-    # It must not override runtime status when the parser approved the receipt
-    # and the full net formula closes.
     payload["inbox_status"] = label
     payload["status"] = label
 

--- a/backend/tests/test_receipt_ssot_status.py
+++ b/backend/tests/test_receipt_ssot_status.py
@@ -1,0 +1,40 @@
+﻿from app.services.receipt_ssot_status import apply_po_norm_status, load_po_norm_status_items
+
+
+def test_non_baseline_receipt_with_matching_totals_is_controlled():
+    payload = {
+        "id": "not-in-baseline",
+        "store_name": "Lidl",
+        "total_amount": 33.80,
+        "line_count": 11,
+        "line_total_sum": 33.80,
+        "net_line_total_sum": 33.80,
+        "parse_status": "approved",
+    }
+
+    result = apply_po_norm_status(payload)
+
+    assert result["po_norm_status_label"] == "Gecontroleerd"
+    assert result["po_norm_status"] == "controlled"
+    assert "NO_BASELINE_MATCH" not in result["po_norm_failed_criteria"]
+    assert "parse_status" not in result
+
+
+def test_line_sum_mismatch_still_requires_review():
+    payload = {
+        "id": "content-error",
+        "store_name": "Lidl",
+        "total_amount": 33.80,
+        "line_count": 11,
+        "line_total_sum": 31.80,
+        "net_line_total_sum": 31.80,
+    }
+
+    result = apply_po_norm_status(payload)
+
+    assert result["po_norm_status_label"] == "Controle nodig"
+    assert "LINE_SUM_TOTAL_MISMATCH" in result["po_norm_failed_criteria"]
+
+
+def test_baseline_loader_is_not_used_for_production_status():
+    assert load_po_norm_status_items() == {}


### PR DESCRIPTION
## Samenvatting
- Ontkoppelt de 14-bonnen testbaseline van de productieve Kassa-statuslogica.
- Verwijdert `NO_BASELINE_MATCH` als productie-faalcriterium.
- Bepaalt productie-status op inhoudelijke criteria:
  - winkel aanwezig
  - totaalbedrag aanwezig
  - artikelregels aanwezig
  - som artikelregels sluit aan op totaal
- Harmoniseert explainability met dezelfde SSOT-status.
- Houdt parserkwaliteit gescheiden van functionele Kassa-status.

## Validatie
- Backend health: groen.
- Backend smoke zonder lokale pytest: groen.
- Lidl-bon `d97aef8c354d4fe8a0d6fcb51a7ea5f7`:
  - `po_norm_status_label = Gecontroleerd`
  - `po_norm_failed_criteria = []`
  - geen `NO_BASELINE_MATCH`
- Explainability:
  - `po_norm_status_label = Gecontroleerd`
  - `po_norm_status = controlled`
  - `po_norm_failed_criteria = []`
  - parserkwaliteit blijft apart als `parser_quality_label`
- De 7 bonnen op `Controle nodig` falen allemaal terecht op `LINE_SUM_TOTAL_MISMATCH`.

## Open punt
De laatste frontend-regressie had nog 1 falende test op `/kassa/nieuw`.
Deze lijkt los te staan van de backend/statuswijziging, maar moet voor merge opnieuw worden beoordeeld of groen worden gedraaid.