### PR TITLE
fix(receipts): include line discounts in API SSOT status

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12099,11 +12099,18 @@ def list_unpack_start_batches(householdId: str = Query(...), authorization: Opti
                         WHERE rtl.receipt_table_id = rt.id
                           AND COALESCE(rtl.is_deleted, 0) = 0
                     ), 0) AS line_total_sum,
-                    COALESCE(rt.discount_total, 0) AS discount_total_effective,
                     COALESCE((
-                        SELECT SUM(COALESCE(COALESCE(rtl.corrected_line_total, rtl.line_total), 0))
+                        SELECT SUM(COALESCE(rtl.discount_amount, 0))
                         FROM receipt_table_lines rtl
                         WHERE rtl.receipt_table_id = rt.id
+                          AND COALESCE(rtl.is_deleted, 0) = 0
+                    ), 0) AS line_discount_sum,
+                    COALESCE(rt.discount_total, 0) AS discount_total_effective,
+                    COALESCE((
+                        SELECT SUM(COALESCE(COALESCE(rtl.corrected_line_total, rtl.line_total), 0) + COALESCE(rtl.discount_amount, 0))
+                        FROM receipt_table_lines rtl
+                        WHERE rtl.receipt_table_id = rt.id
+                          AND COALESCE(rtl.is_deleted, 0) = 0
                     ), 0) + COALESCE(rt.discount_total, 0) AS net_line_total_sum
                 FROM receipt_tables rt
                 JOIN raw_receipts rr ON rr.id = rt.raw_receipt_id
@@ -12205,11 +12212,18 @@ def list_receipts(householdId: str = Query(...), authorization: Optional[str] = 
                         WHERE rtl.receipt_table_id = rt.id
                           AND COALESCE(rtl.is_deleted, 0) = 0
                     ), 0) AS line_total_sum,
-                    COALESCE(rt.discount_total, 0) AS discount_total_effective,
                     COALESCE((
-                        SELECT SUM(COALESCE(COALESCE(rtl.corrected_line_total, rtl.line_total), 0))
+                        SELECT SUM(COALESCE(rtl.discount_amount, 0))
                         FROM receipt_table_lines rtl
                         WHERE rtl.receipt_table_id = rt.id
+                          AND COALESCE(rtl.is_deleted, 0) = 0
+                    ), 0) AS line_discount_sum,
+                    COALESCE(rt.discount_total, 0) AS discount_total_effective,
+                    COALESCE((
+                        SELECT SUM(COALESCE(COALESCE(rtl.corrected_line_total, rtl.line_total), 0) + COALESCE(rtl.discount_amount, 0))
+                        FROM receipt_table_lines rtl
+                        WHERE rtl.receipt_table_id = rt.id
+                          AND COALESCE(rtl.is_deleted, 0) = 0
                     ), 0) + COALESCE(rt.discount_total, 0) AS net_line_total_sum
                 FROM receipt_tables rt
                 JOIN raw_receipts rr ON rr.id = rt.raw_receipt_id
@@ -12302,11 +12316,18 @@ def get_receipt_detail(receipt_table_id: str, authorization: Optional[str] = Hea
                         WHERE rtl.receipt_table_id = rt.id
                           AND COALESCE(rtl.is_deleted, 0) = 0
                     ), 0) AS line_total_sum,
-                    COALESCE(rt.discount_total, 0) AS discount_total_effective,
                     COALESCE((
-                        SELECT SUM(COALESCE(COALESCE(rtl.corrected_line_total, rtl.line_total), 0))
+                        SELECT SUM(COALESCE(rtl.discount_amount, 0))
                         FROM receipt_table_lines rtl
                         WHERE rtl.receipt_table_id = rt.id
+                          AND COALESCE(rtl.is_deleted, 0) = 0
+                    ), 0) AS line_discount_sum,
+                    COALESCE(rt.discount_total, 0) AS discount_total_effective,
+                    COALESCE((
+                        SELECT SUM(COALESCE(COALESCE(rtl.corrected_line_total, rtl.line_total), 0) + COALESCE(rtl.discount_amount, 0))
+                        FROM receipt_table_lines rtl
+                        WHERE rtl.receipt_table_id = rt.id
+                          AND COALESCE(rtl.is_deleted, 0) = 0
                     ), 0) + COALESCE(rt.discount_total, 0) AS net_line_total_sum
                 FROM receipt_tables rt
                 JOIN raw_receipts rr ON rr.id = rt.raw_receipt_id
@@ -12522,7 +12543,8 @@ def get_receipt_explainability(receipt_table_id: str, authorization: Optional[st
 
     status_input["line_count"] = len(active_lines)
     status_input["line_total_sum"] = float(line_total_sum)
-    status_input["net_line_total_sum"] = float(line_total_sum + discount_total)
+    status_input["line_discount_sum"] = float(line_discount_sum)
+    status_input["net_line_total_sum"] = float(line_total_sum + line_discount_sum + discount_total)
 
     status_payload = apply_po_norm_status(status_input)
 
@@ -18607,9 +18629,3 @@ def generate_article_testdata(authorization: Optional[str] = Header(None)):
 
 from app.api.router import api_router
 app.include_router(api_router)
-
-
-
-
-
-

--- a/backend/app/services/receipt_ssot_status.py
+++ b/backend/app/services/receipt_ssot_status.py
@@ -62,12 +62,28 @@ def _line_count(payload: dict[str, Any]) -> int:
         return 0
 
 
-def _net_line_total(payload: dict[str, Any]) -> Decimal | None:
-    for key in ("net_line_total_sum", "line_total_sum"):
-        value = _safe_decimal(payload.get(key))
-        if value is not None:
-            return value
+def _line_discount_total(payload: dict[str, Any]) -> Decimal:
+    lines = payload.get("lines")
+    if isinstance(lines, list):
+        total = Decimal("0")
+        for line in lines:
+            if not isinstance(line, dict) or int(line.get("is_deleted") or 0):
+                continue
+            value = _safe_decimal(line.get("discount_amount"))
+            if value is not None:
+                total += value
+        return total
 
+    value = _safe_decimal(payload.get("line_discount_sum"))
+    return value if value is not None else Decimal("0")
+
+
+def _receipt_discount_total(payload: dict[str, Any]) -> Decimal:
+    value = _safe_decimal(payload.get("discount_total"))
+    return value if value is not None else Decimal("0")
+
+
+def _line_total_from_lines(payload: dict[str, Any]) -> Decimal | None:
     lines = payload.get("lines")
     if not isinstance(lines, list):
         return None
@@ -89,6 +105,18 @@ def _net_line_total(payload: dict[str, Any]) -> Decimal | None:
         total += value
         seen = True
     return total if seen else None
+
+
+def _net_line_total(payload: dict[str, Any]) -> Decimal | None:
+    line_total = _line_total_from_lines(payload)
+
+    if line_total is None:
+        line_total = _safe_decimal(payload.get("line_total_sum"))
+
+    if line_total is not None:
+        return line_total + _line_discount_total(payload) + _receipt_discount_total(payload)
+
+    return _safe_decimal(payload.get("net_line_total_sum"))
 
 
 def _production_status_item(payload: dict[str, Any]) -> dict[str, Any]:

--- a/backend/tests/test_receipt_ssot_status.py
+++ b/backend/tests/test_receipt_ssot_status.py
@@ -38,3 +38,39 @@ def test_line_sum_mismatch_still_requires_review():
 
 def test_baseline_loader_is_not_used_for_production_status():
     assert load_po_norm_status_items() == {}
+
+def test_line_discounts_are_part_of_functional_net_line_total():
+    from decimal import Decimal
+
+    unit = Decimal("1")
+
+    payload_from_sums = {
+        "store_name": "GenericChain",
+        "total_amount": unit,
+        "line_count": 1,
+        "line_total_sum": unit + unit,
+        "line_discount_sum": -unit,
+    }
+
+    result_from_sums = apply_po_norm_status(payload_from_sums)
+
+    assert result_from_sums["po_norm_status_label"] == "Gecontroleerd"
+    assert result_from_sums["po_norm_failed_criteria"] == []
+
+    payload_from_lines = {
+        "store_name": "GenericChain",
+        "total_amount": unit,
+        "line_count": 1,
+        "lines": [
+            {
+                "line_total": unit + unit,
+                "discount_amount": -unit,
+                "is_deleted": 0,
+            }
+        ],
+    }
+
+    result_from_lines = apply_po_norm_status(payload_from_lines)
+
+    assert result_from_lines["po_norm_status_label"] == "Gecontroleerd"
+    assert result_from_lines["po_norm_failed_criteria"] == []


### PR DESCRIPTION
M2C2i-34

- Include line_discount_sum in receipt API SSOT payloads.
- Compute net_line_total_sum including line discounts.
- Align /api/receipts output with direct SSOT DB status.
- Validated: 15/15 active receipts Gecontroleerd, 0 Controle nodig.
- No re-ingest, parser change, or frontend change required.