### PR TITLE
fix(kassa): replace inbox datatable with table pattern

### DIFF
--- a/frontend/src/features/receipts/KassaPage.jsx
+++ b/frontend/src/features/receipts/KassaPage.jsx
@@ -2221,9 +2221,9 @@ export default function KassaPage() {
   }
 
   useEffect(() => {
-    const visibleIds = new Set(receipts.map((receipt) => receipt.receipt_table_id))
-    setSelectedReceiptIds((current) => current.filter((id) => visibleIds.has(id)))
-    if (openedReceiptId && !visibleIds.has(openedReceiptId)) {
+    const visibleIds = new Set(receipts.map((receipt) => String(receipt?.receipt_table_id || '')).filter(Boolean))
+    setSelectedReceiptIds((current) => current.filter((id) => visibleIds.has(String(id))))
+    if (openedReceiptId && !visibleIds.has(String(openedReceiptId))) {
       setOpenedReceiptId('')
       setOpenedReceipt(null)
     }
@@ -2271,53 +2271,7 @@ export default function KassaPage() {
     })
   }, [inboxItems, filters, inboxSort])
 
-  const allVisibleSelected = listItems.length > 0 && listItems.every((item) => selectedReceiptIds.includes(item.receipt_table_id))
-
-  const inboxDataTableColumns = useMemo(() => inboxTableColumns.map((column) => {
-    if (column.key === 'select') {
-      return {
-        ...column,
-        header: <input type="checkbox" checked={allVisibleSelected} onChange={toggleSelectAllVisible} aria-label="Selecteer alle zichtbare bonnen" />,
-      }
-    }
-
-    const labels = {
-      store: 'Winkel',
-      date: 'Datum',
-      total: 'Totaal',
-      items: 'Artikelen',
-    }
-
-    const filterLabels = {
-      store: 'Filter op winkel',
-      date: 'Filter op datum',
-      total: 'Filter op totaal',
-      items: 'Filter op artikelen',
-    }
-
-    return {
-      ...column,
-      label: labels[column.key] || column.label || column.key,
-      align: ['total', 'items'].includes(column.key) ? 'right' : undefined,
-      sortable: true,
-      filterable: true,
-      filterLabel: filterLabels[column.key],
-      getSortValue: (item) => {
-        if (column.key === 'store') return item.store_name || ''
-        if (column.key === 'date') return item.purchase_at || ''
-        if (column.key === 'total') return Number(item.total_amount ?? 0)
-        if (column.key === 'items') return Number(item.line_count ?? 0)
-        return ''
-      },
-      getFilterValue: (item) => {
-        if (column.key === 'store') return item.store_name || ''
-        if (column.key === 'date') return formatDateTime(item.purchase_at)
-        if (column.key === 'total') return formatMoney(item.total_amount, item.currency)
-        if (column.key === 'items') return String(item.line_count ?? 0)
-        return ''
-      },
-    }
-  }), [allVisibleSelected])
+  const allVisibleSelected = listItems.length > 0 && listItems.every((item) => selectedReceiptIds.includes(String(item.receipt_table_id || '')))
 
   const inboxTableFilters = useMemo(() => ({
     store: filters.winkel,
@@ -2325,6 +2279,12 @@ export default function KassaPage() {
     total: filters.totaal,
     items: filters.artikelen,
   }), [filters.winkel, filters.datum, filters.totaal, filters.artikelen])
+
+  const inboxColumnDefaults = useMemo(
+    () => Object.fromEntries(inboxTableColumns.map(({ key, width }) => [key, width])),
+    [],
+  )
+  const { widths: inboxTableWidths, startResize: startInboxTableResize } = useResizableColumnWidths(inboxColumnDefaults)
 
   useLayoutEffect(() => {
     const frame = inboxScrollFrameRef.current
@@ -2403,16 +2363,20 @@ export default function KassaPage() {
   }
 
   function toggleSelectedReceipt(receiptTableId) {
+    const receiptId = String(receiptTableId || '')
+    if (!receiptId) return
     setSelectedReceiptIds((current) => (
-      current.includes(receiptTableId)
-        ? current.filter((id) => id !== receiptTableId)
-        : [...current, receiptTableId]
+      current.includes(receiptId)
+        ? current.filter((id) => id !== receiptId)
+        : [...current, receiptId]
     ))
   }
 
   function toggleSelectAllVisible() {
-    const visibleIds = listItems.map((item) => item.receipt_table_id)
-    setSelectedReceiptIds(allVisibleSelected ? [] : visibleIds)
+    const visibleIds = listItems.map((item) => String(item.receipt_table_id || '')).filter(Boolean)
+    if (!visibleIds.length) return
+    const allSelected = visibleIds.every((id) => selectedReceiptIds.includes(id))
+    setSelectedReceiptIds(allSelected ? [] : visibleIds)
   }
 
   function handleFilterChange(key, value) {
@@ -3001,60 +2965,126 @@ export default function KassaPage() {
                 aria-label="Kassaboninbox met maximaal tien zichtbare bonnen"
                 data-testid="kassa-inbox-scroll-container"
               >
-              <DataTable
-                columns={inboxDataTableColumns}
-                data={isLoading ? [] : listItems}
-                getRowKey={(item) => item.receipt_table_id}
+              <Table
                 wrapperClassName="rz-kassa-inbox-table-wrapper"
                 tableClassName="rz-kassa-inbox-table rz-table--compact"
                 dataTestId="kassa-table"
-                defaultSort={{ key: 'date', direction: 'desc' }}
-                sortState={inboxSort}
-                onSortChange={setInboxSort}
-                filterState={inboxTableFilters}
-                onFilterChange={handleFilterChange}
-                emptyMessage={isLoading ? 'Bonnen laden...' : 'Er zijn nog geen bonnen in de inbox beschikbaar.'}
-                renderRow={(item) => {
-                  const selected = selectedReceiptIds.includes(item.receipt_table_id)
-                  return (
-                    <tr
-                      key={item.receipt_table_id}
-                      className={selected ? 'rz-row-selected' : ''}
-                      onClick={() => toggleSelectedReceipt(item.receipt_table_id)}
-                      onDoubleClick={() => openReceiptDetail(item.receipt_table_id)}
-                      data-testid={`kassa-row-${item.receipt_table_id}`}
-                      style={{
-                        cursor: 'pointer',
-                        boxShadow: `inset 4px 0 0 ${item.inbox_status === 'Gecontroleerd' ? '#12B76A' : item.inbox_status === 'Controle nodig' ? '#F79009' : '#B54708'}`,
-                        background: String(item.receipt_table_id) === receiptInboxFocusId ? '#ECFDF3' : undefined,
-                        outline: String(item.receipt_table_id) === receiptInboxFocusId ? '2px solid #12B76A' : undefined,
-                        outlineOffset: String(item.receipt_table_id) === receiptInboxFocusId ? '-2px' : undefined,
-                      }}
-                    >
-                      <td onClick={(event) => event.stopPropagation()}>
-                        <button
-                          type="button"
-                          data-testid={`kassa-open-${item.receipt_table_id}`}
-                          onClick={(event) => { event.stopPropagation(); openReceiptDetail(item.receipt_table_id) }}
-                          style={{ display: 'none' }}
-                          aria-hidden="true"
-                          tabIndex={-1}
-                        />
-                        <input
-                          type="checkbox"
-                          checked={selected}
-                          onChange={() => toggleSelectedReceipt(item.receipt_table_id)}
-                          aria-label={`Selecteer bon ${item.store_name || 'onbekend'} van ${formatDateTime(item.purchase_at)}`}
-                        />
-                      </td>
-                      <td>{item.store_name || 'Onbekende winkel'}</td>
-                      <td>{formatDateTime(item.purchase_at)}</td>
-                      <td className="rz-num">{formatMoney(item.total_amount, item.currency)}</td>
-                      <td className="rz-num">{item.line_count ?? 0}</td>
-                    </tr>
-                  )
+                tableStyle={{
+                  tableLayout: 'fixed',
+                  width: buildTableWidth(inboxTableWidths),
+                  minWidth: buildTableWidth(inboxTableWidths),
                 }}
-              />
+              >
+                <colgroup>
+                  <col style={{ width: `${inboxTableWidths.select}px` }} />
+                  <col style={{ width: `${inboxTableWidths.store}px` }} />
+                  <col style={{ width: `${inboxTableWidths.date}px` }} />
+                  <col style={{ width: `${inboxTableWidths.total}px` }} />
+                  <col style={{ width: `${inboxTableWidths.items}px` }} />
+                </colgroup>
+                <thead>
+                  <tr className="rz-table-header">
+                    <ResizableHeaderCell columnKey="select" widths={inboxTableWidths} onStartResize={startInboxTableResize} style={{ width: '44px' }}>
+                      <input
+                        type="checkbox"
+                        checked={allVisibleSelected}
+                        onChange={toggleSelectAllVisible}
+                        aria-label="Selecteer alle zichtbare bonnen"
+                      />
+                    </ResizableHeaderCell>
+                    <ResizableHeaderCell columnKey="store" widths={inboxTableWidths} onStartResize={startInboxTableResize} sortable isSorted={inboxSort.key === 'store'} sortDirection={inboxSort.direction} onSort={(key) => setInboxSort((current) => nextSortState(current, key, { store: 'asc', date: 'desc', total: 'desc', items: 'desc' }))}>Winkel</ResizableHeaderCell>
+                    <ResizableHeaderCell columnKey="date" widths={inboxTableWidths} onStartResize={startInboxTableResize} sortable isSorted={inboxSort.key === 'date'} sortDirection={inboxSort.direction} onSort={(key) => setInboxSort((current) => nextSortState(current, key, { store: 'asc', date: 'desc', total: 'desc', items: 'desc' }))}>Datum</ResizableHeaderCell>
+                    <ResizableHeaderCell columnKey="total" widths={inboxTableWidths} onStartResize={startInboxTableResize} className="rz-num" sortable isSorted={inboxSort.key === 'total'} sortDirection={inboxSort.direction} onSort={(key) => setInboxSort((current) => nextSortState(current, key, { store: 'asc', date: 'desc', total: 'desc', items: 'desc' }))}>Totaal</ResizableHeaderCell>
+                    <ResizableHeaderCell columnKey="items" widths={inboxTableWidths} onStartResize={startInboxTableResize} className="rz-num" sortable isSorted={inboxSort.key === 'items'} sortDirection={inboxSort.direction} onSort={(key) => setInboxSort((current) => nextSortState(current, key, { store: 'asc', date: 'desc', total: 'desc', items: 'desc' }))}>Artikelen</ResizableHeaderCell>
+                  </tr>
+                  <tr className="rz-table-filters">
+                    <th />
+                    <th>
+                      <input
+                        className="rz-input rz-inline-input"
+                        value={inboxTableFilters.store}
+                        onChange={(event) => handleFilterChange('store', event.target.value)}
+                        placeholder="Filter"
+                        aria-label="Filter op winkel"
+                      />
+                    </th>
+                    <th>
+                      <input
+                        className="rz-input rz-inline-input"
+                        value={inboxTableFilters.date}
+                        onChange={(event) => handleFilterChange('date', event.target.value)}
+                        placeholder="Filter"
+                        aria-label="Filter op datum"
+                      />
+                    </th>
+                    <th>
+                      <input
+                        className="rz-input rz-inline-input"
+                        value={inboxTableFilters.total}
+                        onChange={(event) => handleFilterChange('total', event.target.value)}
+                        placeholder="Filter"
+                        aria-label="Filter op totaal"
+                      />
+                    </th>
+                    <th>
+                      <input
+                        className="rz-input rz-inline-input"
+                        value={inboxTableFilters.items}
+                        onChange={(event) => handleFilterChange('items', event.target.value)}
+                        placeholder="Filter"
+                        aria-label="Filter op artikelen"
+                      />
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {isLoading ? (
+                    <tr><td colSpan={5}>Bonnen laden...</td></tr>
+                  ) : listItems.length === 0 ? (
+                    <tr><td colSpan={5}>Er zijn nog geen bonnen in de inbox beschikbaar.</td></tr>
+                  ) : listItems.map((item) => {
+                    const receiptId = String(item.receipt_table_id || '')
+                    const selected = selectedReceiptIds.includes(receiptId)
+                    return (
+                      <tr
+                        key={receiptId}
+                        className={selected ? 'rz-row-selected' : ''}
+                        onClick={() => toggleSelectedReceipt(receiptId)}
+                        onDoubleClick={() => openReceiptDetail(receiptId)}
+                        data-testid={`kassa-row-${receiptId}`}
+                        style={{
+                          cursor: 'pointer',
+                          boxShadow: `inset 4px 0 0 ${item.inbox_status === 'Gecontroleerd' ? '#12B76A' : item.inbox_status === 'Controle nodig' ? '#F79009' : '#B54708'}`,
+                          background: receiptId === receiptInboxFocusId ? '#ECFDF3' : undefined,
+                          outline: receiptId === receiptInboxFocusId ? '2px solid #12B76A' : undefined,
+                          outlineOffset: receiptId === receiptInboxFocusId ? '-2px' : undefined,
+                        }}
+                      >
+                        <td onClick={(event) => event.stopPropagation()}>
+                          <button
+                            type="button"
+                            data-testid={`kassa-open-${receiptId}`}
+                            onClick={(event) => { event.stopPropagation(); openReceiptDetail(receiptId) }}
+                            style={{ display: 'none' }}
+                            aria-hidden="true"
+                            tabIndex={-1}
+                          />
+                          <input
+                            type="checkbox"
+                            checked={selected}
+                            onChange={() => toggleSelectedReceipt(receiptId)}
+                            aria-label={`Selecteer bon ${item.store_name || 'onbekend'} van ${formatDateTime(item.purchase_at)}`}
+                          />
+                        </td>
+                        <td>{item.store_name || 'Onbekende winkel'}</td>
+                        <td>{formatDateTime(item.purchase_at)}</td>
+                        <td className="rz-num">{formatMoney(item.total_amount, item.currency)}</td>
+                        <td className="rz-num">{item.line_count ?? 0}</td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </Table>
               </div>
 
             </div>


### PR DESCRIPTION
## Doel
Kassa-inbox vervangen van de oude `DataTable`-rendering naar hetzelfde handmatige `Table`-patroon als Uitpakken, zodat header- en rijcheckboxes weer werken.

## Gewijzigd
- `frontend/src/features/receipts/KassaPage.jsx`
- Kassa-inbox gebruikt nu `Table` met `colgroup`, `thead`, filterrij en `tbody`
- `receipt_table_id` wordt voor selectie consequent als string behandeld

## Niet gewijzigd
- Backend
- Parser
- Database
- Receipt baseline
- Uitpakken
- Externe databases
- Bonregels-detailtabel

## Functionele PO-check reeds uitgevoerd
- Header-checkbox in Kassa werkt weer
- Rijcheckboxes in Kassa werken separaat weer

## Nog vereist vóór merge
- Lokale build/runtime-check
- Frontend regressie voor geraakte flows
- Geen merge zonder volledige main-validatie na PR-merge