### PR TITLE
fix(receipts): enforce SSOT line classification gateway

### DIFF
--- a/backend/app/receipt_ingestion/line_classifier.py
+++ b/backend/app/receipt_ingestion/line_classifier.py
@@ -124,7 +124,9 @@ def _generic_non_article_trace(line: str) -> dict[str, Any] | None:
     upper = normalized.upper().replace(',', '.')
     supporting_amount_token = _token_match(lowered, GENERIC_SUPPORTING_AMOUNT_DETAIL_TOKENS)
     if supporting_amount_token:
-        return _decision('amount_detail', 'GENERIC_SUPPORTING_AMOUNT_DETAIL_TOKEN', supporting_amount_token)
+        suffix = lowered.split(supporting_amount_token, 1)[1].strip(" :-\t")
+        if not suffix or not any(ch.isalpha() for ch in suffix):
+            return _decision('amount_detail', 'GENERIC_SUPPORTING_AMOUNT_DETAIL_TOKEN', supporting_amount_token)
     if _is_value_line_label_without_amount(lowered):
         return _decision('product_candidate', 'GENERIC_VALUE_LINE_LABEL_FROM_SAVINGS_ACTION', normalized)
     if re.fullmatch(r'(?:ZA|ZO|ZON)\s+\d{1,2}\.\d{2}', upper):
@@ -379,4 +381,4 @@ def diagnose_article_line_classification(
 
 
 def classification_allows_append(classification: str | None) -> bool:
-    return str(classification or '') in ARTICLE_CLASSIFICATIONS
+    return str(classification or '') in (ARTICLE_CLASSIFICATIONS | {'continuation'})

--- a/backend/app/receipt_ingestion/line_classifier.py
+++ b/backend/app/receipt_ingestion/line_classifier.py
@@ -60,6 +60,11 @@ GENERIC_METADATA_TOKENS = (
 GENERIC_DEPOSIT_RETURN_TOKENS = (
     'statiegeld retour', 'retour statiegeld', 'emballage retour', 'fust retour',
 )
+GENERIC_SUPPORTING_AMOUNT_DETAIL_TOKENS = (
+    'prijs per kg',
+    'prijs/kg',
+    'prijs per stuk',
+)
 PRICED_DISCOUNT_ARTICLE_TOKENS = (
     'korting', 'bonus', 'actie', 'prijsvoordeel', 'jouw voordeel', 'uw voordeel',
     'lidl plus korting', 'totaal korting',
@@ -117,6 +122,9 @@ def _generic_non_article_trace(line: str) -> dict[str, Any] | None:
         return _decision('ignore', 'EMPTY_OR_WHITESPACE_LINE')
     lowered = normalized.lower()
     upper = normalized.upper().replace(',', '.')
+    supporting_amount_token = _token_match(lowered, GENERIC_SUPPORTING_AMOUNT_DETAIL_TOKENS)
+    if supporting_amount_token:
+        return _decision('amount_detail', 'GENERIC_SUPPORTING_AMOUNT_DETAIL_TOKEN', supporting_amount_token)
     if _is_value_line_label_without_amount(lowered):
         return _decision('product_candidate', 'GENERIC_VALUE_LINE_LABEL_FROM_SAVINGS_ACTION', normalized)
     if re.fullmatch(r'(?:ZA|ZO|ZON)\s+\d{1,2}\.\d{2}', upper):
@@ -371,4 +379,4 @@ def diagnose_article_line_classification(
 
 
 def classification_allows_append(classification: str | None) -> bool:
-    return classification not in BLOCKING_CLASSIFICATIONS
+    return str(classification or '') in ARTICLE_CLASSIFICATIONS

--- a/backend/app/receipt_ingestion/product_candidate_gateway.py
+++ b/backend/app/receipt_ingestion/product_candidate_gateway.py
@@ -121,6 +121,35 @@ def _as_float(value: Any) -> float | None:
         return None
 
 
+def _split_supporting_amount_product_label(label_value: str) -> tuple[str, dict[str, Any] | None]:
+    """Preserve product labels that were OCR/parser-prefixed with supporting amount text.
+
+    Examples:
+    - "Prijs per kg" stays unchanged and is blocked by the classifier.
+    - "Prijs per kg KOMKOMMER" becomes "KOMKOMMER" so the product line is preserved.
+    """
+    original_label = str(label_value or "").strip()
+    lowered = original_label.lower()
+
+    for token in ("prijs per kg", "prijs/kg", "prijs per stuk"):
+        token_lower = token.lower()
+        if lowered == token_lower:
+            return original_label, None
+
+        prefix = token_lower + " "
+        if lowered.startswith(prefix):
+            remaining = original_label[len(token):].strip(" :-\t")
+            if remaining and any(ch.isalpha() for ch in remaining):
+                return remaining, {
+                    "supporting_amount_prefix_normalization_applied": True,
+                    "supporting_amount_prefix_original_label": original_label,
+                    "supporting_amount_prefix_normalized_label": remaining,
+                    "supporting_amount_prefix_token": token,
+                }
+
+    return original_label, None
+
+
 def _consolidate_with_previous(previous: dict[str, Any], current: dict[str, Any]) -> None:
     previous_total = _as_float(previous.get('line_total'))
     current_total = _as_float(current.get('line_total'))
@@ -167,6 +196,7 @@ def append_product_candidate(
     """Single guarded gateway for appending receipt financial/product lines."""
     label_value = clean_label(label)
     label_value, encoding_metadata = normalize_receipt_text_encoding(label_value)
+    label_value, supporting_amount_prefix_metadata = _split_supporting_amount_product_label(label_value)
     if not label_value or len(label_value) < 2 or label_value.replace(' ', '').isdigit():
         return None
 
@@ -189,6 +219,17 @@ def append_product_candidate(
     classification_trace = trace_line(label_value) if trace_line is not None else None
     classification = str((classification_trace or {}).get('classification') or classify_line(label_value))
     classification_allowed = classification_allows_append(classification)
+
+    if supporting_amount_prefix_metadata and not classification_allowed and (amount1_raw or amount2_raw):
+        classification = 'product_candidate'
+        classification_allowed = True
+        classification_trace = {
+            'classification': classification,
+            'stage': 'runtime_gateway',
+            'rule': 'SUPPORTING_AMOUNT_PREFIX_PRODUCT_LABEL',
+            'matched': label_value,
+        }
+
     append_allowed = classification_allowed or savings_action_path
     if not append_allowed:
         return None
@@ -289,6 +330,8 @@ def append_product_candidate(
             'encoding_normalized_text': encoding_metadata.get('normalized_text'),
             'encoding_replacements': encoding_metadata.get('encoding_replacements'),
         })
+    if supporting_amount_prefix_metadata:
+        producer_trace.update(supporting_amount_prefix_metadata)
     if package_metadata:
         producer_trace.update({
             'package_extraction_applied': True,

--- a/backend/tests/test_receipt_line_classifier_ssot.py
+++ b/backend/tests/test_receipt_line_classifier_ssot.py
@@ -1,3 +1,13 @@
+"""Self-contained SSOT classifier checks for receipt line ingestion.
+
+Rezzerv local backend containers do not provide pytest. Keep this file runnable
+with plain Python so the PO can validate through the established Rezzerv route:
+
+    cd /app && PYTHONPATH=/app python backend/tests/test_receipt_line_classifier_ssot.py
+"""
+
+from __future__ import annotations
+
 import re
 
 from app.receipt_ingestion.line_classifier import (
@@ -17,7 +27,7 @@ LABEL_FIRST_RE = re.compile(
 )
 
 
-def test_gateway_allows_only_standalone_product_candidates():
+def check_gateway_allows_only_standalone_product_candidates() -> None:
     assert classification_allows_append('product_candidate') is True
     assert classification_allows_append('amount_detail') is False
     assert classification_allows_append('continuation') is False
@@ -26,7 +36,7 @@ def test_gateway_allows_only_standalone_product_candidates():
     assert classification_allows_append('ignore') is False
 
 
-def test_prijs_per_kg_is_supporting_detail_not_standalone_article():
+def check_prijs_per_kg_is_supporting_detail_not_standalone_article() -> None:
     diagnosis = diagnose_article_line_classification(
         'Prijs per kg 2,29',
         store_name='Albert Heijn',
@@ -41,7 +51,7 @@ def test_prijs_per_kg_is_supporting_detail_not_standalone_article():
     assert diagnosis['rule'] == 'GENERIC_SUPPORTING_AMOUNT_DETAIL_TOKEN'
 
 
-def test_prijs_per_kg_with_product_label_is_still_supporting_detail():
+def check_prijs_per_kg_with_product_label_is_still_supporting_detail() -> None:
     diagnosis = diagnose_article_line_classification(
         'Prijs per kg KOMKOMMER 2,29',
         store_name='Albert Heijn',
@@ -53,7 +63,7 @@ def test_prijs_per_kg_with_product_label_is_still_supporting_detail():
     assert diagnosis['include_in_article_sum'] is False
 
 
-def test_statiegeld_value_line_remains_product_candidate_when_it_has_amount():
+def check_statiegeld_value_line_remains_product_candidate_when_it_has_amount() -> None:
     trace = trace_receipt_text_line_classification(
         'STATIEGELD 0,60',
         store_name='Albert Heijn',
@@ -65,7 +75,7 @@ def test_statiegeld_value_line_remains_product_candidate_when_it_has_amount():
     assert classification_allows_append(trace['classification']) is True
 
 
-def test_koopzegels_value_line_remains_appendable_financial_line():
+def check_koopzegels_value_line_remains_appendable_financial_line() -> None:
     trace = trace_receipt_text_line_classification(
         '130 KOOPZEGELS PREMIUM 13,00',
         store_name='Albert Heijn',
@@ -75,3 +85,23 @@ def test_koopzegels_value_line_remains_appendable_financial_line():
 
     assert trace['classification'] == 'product_candidate'
     assert classification_allows_append(trace['classification']) is True
+
+
+def run_checks() -> None:
+    checks = [
+        check_gateway_allows_only_standalone_product_candidates,
+        check_prijs_per_kg_is_supporting_detail_not_standalone_article,
+        check_prijs_per_kg_with_product_label_is_still_supporting_detail,
+        check_statiegeld_value_line_remains_product_candidate_when_it_has_amount,
+        check_koopzegels_value_line_remains_appendable_financial_line,
+    ]
+
+    for check in checks:
+        check()
+        print(f"PASS {check.__name__}")
+
+    print(f"RESULT: {len(checks)} self-contained SSOT classifier checks passed")
+
+
+if __name__ == '__main__':
+    run_checks()

--- a/backend/tests/test_receipt_line_classifier_ssot.py
+++ b/backend/tests/test_receipt_line_classifier_ssot.py
@@ -30,7 +30,7 @@ LABEL_FIRST_RE = re.compile(
 def check_gateway_allows_only_standalone_product_candidates() -> None:
     assert classification_allows_append('product_candidate') is True
     assert classification_allows_append('amount_detail') is False
-    assert classification_allows_append('continuation') is False
+    assert classification_allows_append('continuation') is True
     assert classification_allows_append('metadata') is False
     assert classification_allows_append('footer_payment_tax') is False
     assert classification_allows_append('ignore') is False
@@ -51,16 +51,9 @@ def check_prijs_per_kg_is_supporting_detail_not_standalone_article() -> None:
     assert diagnosis['rule'] == 'GENERIC_SUPPORTING_AMOUNT_DETAIL_TOKEN'
 
 
-def check_prijs_per_kg_with_product_label_is_still_supporting_detail() -> None:
-    diagnosis = diagnose_article_line_classification(
-        'Prijs per kg KOMKOMMER 2,29',
-        store_name='Albert Heijn',
-        filename='AH foto 11.jpeg',
-        label_first_re=LABEL_FIRST_RE,
-    )
-
-    assert diagnosis['classification'] == 'amount_detail'
-    assert diagnosis['include_in_article_sum'] is False
+def check_prijs_per_kg_with_product_label_is_not_supporting_detail() -> None:
+    diagnosis = trace_receipt_text_line_classification('Prijs per kg KOMKOMMER 11,97 0,99')
+    assert diagnosis['classification'] != 'amount_detail'
 
 
 def check_statiegeld_value_line_remains_product_candidate_when_it_has_amount() -> None:
@@ -91,7 +84,7 @@ def run_checks() -> None:
     checks = [
         check_gateway_allows_only_standalone_product_candidates,
         check_prijs_per_kg_is_supporting_detail_not_standalone_article,
-        check_prijs_per_kg_with_product_label_is_still_supporting_detail,
+        check_prijs_per_kg_with_product_label_is_not_supporting_detail,
         check_statiegeld_value_line_remains_product_candidate_when_it_has_amount,
         check_koopzegels_value_line_remains_appendable_financial_line,
     ]

--- a/backend/tests/test_receipt_line_classifier_ssot.py
+++ b/backend/tests/test_receipt_line_classifier_ssot.py
@@ -1,0 +1,77 @@
+import re
+
+from app.receipt_ingestion.line_classifier import (
+    classification_allows_append,
+    diagnose_article_line_classification,
+    trace_receipt_text_line_classification,
+)
+
+
+LABEL_FIRST_RE = re.compile(
+    r'^(?P<label>(?=[A-Za-z0-9].*[A-Za-z])[A-Za-z0-9].*?)\s+'
+    r'(?:(?P<qty>\d+(?:[\.,]\d+)?(?:\s*kg)?)\s*[xX]\s+)?'
+    r'(?P<amount1>-?\d{1,6}(?:[\.,]\d{2}))'
+    r'(?:\s+(?P<amount2>-?\d{1,6}(?:[\.,]\d{2})))?'
+    r'(?:\s+(?:EUR|[A-Z]{1,3}))?$',
+    re.IGNORECASE,
+)
+
+
+def test_gateway_allows_only_standalone_product_candidates():
+    assert classification_allows_append('product_candidate') is True
+    assert classification_allows_append('amount_detail') is False
+    assert classification_allows_append('continuation') is False
+    assert classification_allows_append('metadata') is False
+    assert classification_allows_append('footer_payment_tax') is False
+    assert classification_allows_append('ignore') is False
+
+
+def test_prijs_per_kg_is_supporting_detail_not_standalone_article():
+    diagnosis = diagnose_article_line_classification(
+        'Prijs per kg 2,29',
+        store_name='Albert Heijn',
+        filename='AH foto 11.jpeg',
+        label_first_re=LABEL_FIRST_RE,
+    )
+
+    assert diagnosis['classification'] == 'amount_detail'
+    assert diagnosis['article_decision'] == 'ONDERSTEUNENDE_ARTIKELINFO'
+    assert diagnosis['include_in_article_sum'] is False
+    assert diagnosis['reason'] == 'supporting_amount_detail_not_standalone_article'
+    assert diagnosis['rule'] == 'GENERIC_SUPPORTING_AMOUNT_DETAIL_TOKEN'
+
+
+def test_prijs_per_kg_with_product_label_is_still_supporting_detail():
+    diagnosis = diagnose_article_line_classification(
+        'Prijs per kg KOMKOMMER 2,29',
+        store_name='Albert Heijn',
+        filename='AH foto 11.jpeg',
+        label_first_re=LABEL_FIRST_RE,
+    )
+
+    assert diagnosis['classification'] == 'amount_detail'
+    assert diagnosis['include_in_article_sum'] is False
+
+
+def test_statiegeld_value_line_remains_product_candidate_when_it_has_amount():
+    trace = trace_receipt_text_line_classification(
+        'STATIEGELD 0,60',
+        store_name='Albert Heijn',
+        filename='AH foto 11.jpeg',
+        label_first_re=LABEL_FIRST_RE,
+    )
+
+    assert trace['classification'] == 'product_candidate'
+    assert classification_allows_append(trace['classification']) is True
+
+
+def test_koopzegels_value_line_remains_appendable_financial_line():
+    trace = trace_receipt_text_line_classification(
+        '130 KOOPZEGELS PREMIUM 13,00',
+        store_name='Albert Heijn',
+        filename='AH foto 17.jpeg',
+        label_first_re=LABEL_FIRST_RE,
+    )
+
+    assert trace['classification'] == 'product_candidate'
+    assert classification_allows_append(trace['classification']) is True

--- a/backend/tests/test_receipt_price_per_kg_classifier_selftest.py
+++ b/backend/tests/test_receipt_price_per_kg_classifier_selftest.py
@@ -1,0 +1,18 @@
+﻿from app.receipt_ingestion.line_classifier import trace_receipt_text_line_classification
+
+
+def run_checks():
+    pure = trace_receipt_text_line_classification("Prijs per kg")
+    amount_only = trace_receipt_text_line_classification("Prijs per kg 2,29")
+    product = trace_receipt_text_line_classification("Prijs per kg KOMKOMMER 11,97 0,99")
+
+    assert pure["classification"] == "amount_detail", pure
+    assert amount_only["classification"] == "amount_detail", amount_only
+    assert product["classification"] != "amount_detail", product
+
+    print("PASS check_price_per_kg_product_suffix_is_not_amount_detail")
+    print("RESULT: 1 classifier price-per-kg product-suffix check passed")
+
+
+if __name__ == "__main__":
+    run_checks()

--- a/backend/tests/test_receipt_price_per_kg_gateway_selftest.py
+++ b/backend/tests/test_receipt_price_per_kg_gateway_selftest.py
@@ -1,0 +1,73 @@
+﻿from app.receipt_ingestion.line_classifier import trace_receipt_text_line_classification
+from app.receipt_ingestion.product_candidate_gateway import append_product_candidate
+
+
+def clean_label(value):
+    return str(value or "").strip()
+
+
+def parse_quantity(value):
+    if not value:
+        return None
+    return float(str(value).replace(",", "."))
+
+
+def parse_decimal(value):
+    if value is None or value == "":
+        return None
+    return float(str(value).replace(",", "."))
+
+
+def amount_to_float(value):
+    return None if value is None else float(value)
+
+
+def classify_line(line):
+    return trace_receipt_text_line_classification(line).get("classification")
+
+
+def trace_line(line):
+    return trace_receipt_text_line_classification(line)
+
+
+def check_prijs_per_kg_product_label_is_preserved_by_gateway():
+    extracted = []
+
+    idx = append_product_candidate(
+        extracted,
+        label="Prijs per kg KOMKOMMER",
+        qty_raw=None,
+        amount1_raw="11,97",
+        amount2_raw="0,99",
+        source_index=1,
+        raw_line="Prijs per kg KOMKOMMER 11,97 0,99",
+        normalized_line="Prijs per kg KOMKOMMER 11,97 0,99",
+        filename="AH foto 11.jpeg",
+        store_name="Albert Heijn",
+        function_name="_extract_ah_lines",
+        append_branch="label_first",
+        parser_path="ah_photo",
+        caller_line_hint="prijs_per_kg_product_label",
+        clean_label=clean_label,
+        parse_quantity=parse_quantity,
+        parse_decimal=parse_decimal,
+        amount_to_float=amount_to_float,
+        classify_line=classify_line,
+        trace_line=trace_line,
+    )
+
+    assert idx == 0
+    assert len(extracted) == 1
+    assert extracted[0]["normalized_label"] == "KOMKOMMER"
+    assert extracted[0]["line_total"] == 0.99
+    assert extracted[0]["producer_trace"]["supporting_amount_prefix_normalization_applied"] is True
+
+
+def run_checks():
+    check_prijs_per_kg_product_label_is_preserved_by_gateway()
+    print("PASS check_prijs_per_kg_product_label_is_preserved_by_gateway")
+    print("RESULT: 1 gateway price-per-kg product-label check passed")
+
+
+if __name__ == "__main__":
+    run_checks()


### PR DESCRIPTION
## Summary

M2C2i-127A updates receipt line classification for unit-price support lines.

Changes:
- Pure support lines are not stored as active receipt item lines.
- Support-prefix lines that also contain a product label are preserved as product lines.
- The gateway keeps continuation appendable for this parser context.
- Financial value lines for deposits and saving stamps remain appendable when recognized.

Validation performed:
- Backend compile checks passed.
- SSOT classifier selftest passed.
- Unit-price classifier selftest passed.
- Unit-price gateway selftest passed.
- Functional latest-only scan after reimport: 8 active receipts, 5 controlled and 3 requiring review.

Out of scope:
- Remaining OCR duplicate issue on receipt 10.
- Remaining total-source issue on receipt 12.
- Remaining discount/action issue on receipt 17.

Closes #127