### PR TITLE
fix(receipts): repair AH image balance from reliable OCR evidence

### DIFF
--- a/backend/app/receipt_ingestion/profiles/ah/corrections.py
+++ b/backend/app/receipt_ingestion/profiles/ah/corrections.py
@@ -343,3 +343,272 @@ def _ah_rebalance_after_footer_noise_filter(
         return correction if correction != Decimal("0.00") else None
 
     return discount_total
+
+def _ah_label_key(value: str | None) -> str:
+    return re.sub(r"[^A-Z0-9]+", " ", str(value or "").upper()).strip()
+
+
+def _ah_existing_label_keys(lines: list[dict[str, Any]] | None) -> set[str]:
+    keys: set[str] = set()
+    for line in lines or []:
+        if not isinstance(line, dict):
+            continue
+        label = (
+            line.get("raw_label")
+            or line.get("normalized_label")
+            or line.get("display_label")
+            or ""
+        )
+        key = _ah_label_key(str(label))
+        if key:
+            keys.add(key)
+    return keys
+
+
+def _ah_sum_lines_net(lines: list[dict[str, Any]] | None, discount_total: Decimal | None = None) -> Decimal:
+    line_sum = sum(
+        (_r9_38e1_decimal(line.get("line_total")) for line in (lines or []) if isinstance(line, dict)),
+        Decimal("0.00"),
+    )
+    line_discount_sum = sum(
+        (_r9_38e1_decimal(line.get("discount_amount")) for line in (lines or []) if isinstance(line, dict)),
+        Decimal("0.00"),
+    )
+    receipt_discount = _r9_38e1_decimal(discount_total)
+    return (line_sum + line_discount_sum + receipt_discount).quantize(Decimal("0.01"))
+
+
+def _ah_extract_weight_product_candidates_from_reliable_lines(reliable_lines: list[str] | None) -> list[dict[str, Any]]:
+    """Extract AH weighted article rows from a reliable OCR stream.
+
+    Example:
+    0,587K CONFERENCE 1,11
+    """
+    candidates: list[dict[str, Any]] = []
+
+    blocked_tokens = (
+        "subtotaal",
+        "totaal",
+        "bonus",
+        "voordeel",
+        "koopzegel",
+        "koopzegels",
+        "prijs per kg",
+        "pinnen",
+        "betaald",
+        "btw",
+    )
+
+    for index, raw in enumerate(reliable_lines or []):
+        line = re.sub(r"\s+", " ", str(raw or "")).strip()
+        low = line.lower()
+        if not line:
+            continue
+        if any(token in low for token in blocked_tokens):
+            continue
+
+        # AH OCR variants commonly read weight as 0,587K / 0,587k / 0,587 KG.
+        match = re.search(
+            r"(?<!\d)(\d+[,.]\d{3})\s*(?:k|kg)?\s+([A-Za-zÀ-ÖØ-öø-ÿ][A-Za-zÀ-ÖØ-öø-ÿ0-9 '\-]{2,}?)\s+(\d{1,5}[,.]\d{2})(?!\d)",
+            line,
+            re.I,
+        )
+        if not match:
+            continue
+
+        try:
+            quantity = Decimal(match.group(1).replace(",", ".")).quantize(Decimal("0.001"))
+        except Exception:
+            quantity = None
+        label = re.sub(r"\s+", " ", match.group(2)).strip(" .:-")
+        total = _parse_decimal(match.group(3))
+
+        if quantity is None or quantity <= Decimal("0.000"):
+            continue
+        if total is None or total <= Decimal("0.00"):
+            continue
+        if not re.search(r"[A-Za-zÀ-ÖØ-öø-ÿ]", label):
+            continue
+
+        unit = (total / quantity).quantize(Decimal("0.01"))
+
+        candidates.append({
+            "raw_label": label,
+            "normalized_label": label.upper(),
+            "quantity": float(quantity),
+            "unit_price": float(unit),
+            "line_total": float(total),
+            "discount_amount": None,
+            "include_in_receipt_total": True,
+            "exclude_from_inventory": False,
+            "source_index": index,
+            "producer_trace": {
+                "parser_path": "ah_image_balance_repair.weight_product_from_reliable_ocr",
+                "function_name": "_ah_repair_image_balance_from_reliable_lines",
+                "raw_line": line,
+                "source_index": index,
+                "classification": "product_candidate",
+                "append_allowed": True,
+            },
+        })
+
+    return candidates
+
+
+def _ah_extract_bonus_discount_from_reliable_lines(reliable_lines: list[str] | None) -> Decimal | None:
+    total = Decimal("0.00")
+
+    for raw in reliable_lines or []:
+        line = re.sub(r"\s+", " ", str(raw or "")).strip()
+        low = line.lower()
+        if "bonuskaart" in low or "bonus box premium" in low:
+            continue
+        if "bonus" not in low:
+            continue
+
+        for token in re.findall(r"(?<!\d)(-\s*\d{1,5}[,.]\d{2}|[=−]\s*\d{1,5}[,.]\d{2})(?!\d)", line):
+            normalized = token.replace(" ", "").replace("−", "-").replace("=", "-")
+            amount = _parse_decimal(normalized)
+            if amount is not None and amount < Decimal("0.00"):
+                total += amount
+
+    return total.quantize(Decimal("0.01")) if total != Decimal("0.00") else None
+
+
+def _ah_apply_discount_to_best_bonus_target(lines: list[dict[str, Any]], discount: Decimal) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    if not lines or discount == Decimal("0.00"):
+        return lines, None
+
+    refined = [dict(line) if isinstance(line, dict) else line for line in lines]
+
+    candidate_indices: list[int] = []
+    for index, line in enumerate(refined):
+        if not isinstance(line, dict):
+            continue
+        trace = line.get("producer_trace") or {}
+        raw = str(trace.get("raw_line") or line.get("raw_label") or "")
+        label = str(line.get("raw_label") or line.get("normalized_label") or "")
+
+        if "koopzegel" in label.lower():
+            continue
+        if re.search(r"\sB\s*$", raw, re.I):
+            candidate_indices.append(index)
+
+    if not candidate_indices:
+        for index, line in enumerate(refined):
+            if not isinstance(line, dict):
+                continue
+            label = str(line.get("raw_label") or line.get("normalized_label") or "")
+            if "koopzegel" in label.lower():
+                continue
+            if _r9_38e1_decimal(line.get("line_total")) > Decimal("0.00"):
+                candidate_indices.append(index)
+
+    if not candidate_indices:
+        return lines, None
+
+    target_index = max(
+        candidate_indices,
+        key=lambda idx: _r9_38e1_decimal(refined[idx].get("line_total")) if isinstance(refined[idx], dict) else Decimal("0.00"),
+    )
+
+    current = _r9_38e1_decimal(refined[target_index].get("discount_amount"))
+    refined[target_index]["discount_amount"] = float((current + discount).quantize(Decimal("0.01")))
+
+    return refined, {
+        "target_index": int(target_index),
+        "target_label": refined[target_index].get("raw_label"),
+        "discount_amount": float(discount),
+    }
+
+
+def _ah_repair_image_balance_from_reliable_lines(
+    *,
+    reliable_lines: list[str],
+    lines: list[dict[str, Any]],
+    store_name: str | None,
+    total_amount: Decimal | None,
+    discount_total: Decimal | None,
+) -> tuple[list[dict[str, Any]], Decimal | None, dict[str, Any] | None]:
+    """AH image OCR balance repair using reliable OCR financial/product evidence.
+
+    This is deliberately total-guarded:
+    no line, discount, or status is changed unless the resulting net sum exactly
+    matches the visible receipt total.
+    """
+    if not lines or total_amount is None:
+        return lines, discount_total, None
+    if not _is_ah_store_context(store_name, reliable_lines):
+        return lines, discount_total, None
+
+    total = _r9_38e1_decimal(total_amount)
+    before_net = _ah_sum_lines_net(lines, discount_total)
+    if before_net == total:
+        return lines, discount_total, None
+
+    existing_keys = _ah_existing_label_keys(lines)
+    weight_candidates = []
+    for candidate in _ah_extract_weight_product_candidates_from_reliable_lines(reliable_lines):
+        key = _ah_label_key(candidate.get("raw_label"))
+        if not key:
+            continue
+        if key in existing_keys:
+            continue
+        if any(key in existing or existing in key for existing in existing_keys if len(existing) >= 4 and len(key) >= 4):
+            continue
+        weight_candidates.append(candidate)
+
+    bonus_discount = _ah_extract_bonus_discount_from_reliable_lines(reliable_lines)
+
+    attempts: list[tuple[list[dict[str, Any]], Decimal | None, str]] = [
+        ([], None, "none"),
+    ]
+
+    for candidate in weight_candidates:
+        attempts.append(([candidate], None, "weight_only"))
+
+    if bonus_discount is not None:
+        attempts.append(([], bonus_discount, "bonus_only"))
+        for candidate in weight_candidates:
+            attempts.append(([candidate], bonus_discount, "weight_plus_bonus"))
+
+    for add_lines, discount, mode in attempts:
+        if mode == "none":
+            continue
+
+        candidate_lines = [dict(line) if isinstance(line, dict) else line for line in lines]
+        candidate_lines.extend(dict(line) for line in add_lines)
+
+        discount_application = None
+        candidate_discount_total = discount_total
+
+        if discount is not None:
+            candidate_lines, discount_application = _ah_apply_discount_to_best_bonus_target(candidate_lines, discount)
+
+        candidate_net = _ah_sum_lines_net(candidate_lines, candidate_discount_total)
+
+        if candidate_net == total:
+            return candidate_lines, candidate_discount_total, {
+                "r9_m2c2i128_ah_image_balance_repair": {
+                    "applied": True,
+                    "mode": mode,
+                    "before_net": float(before_net),
+                    "after_net": float(candidate_net),
+                    "total_amount": float(total),
+                    "added_lines": [
+                        {
+                            "raw_label": line.get("raw_label"),
+                            "quantity": line.get("quantity"),
+                            "line_total": line.get("line_total"),
+                            "source_index": line.get("source_index"),
+                        }
+                        for line in add_lines
+                    ],
+                    "bonus_discount": float(discount) if discount is not None else None,
+                    "discount_application": discount_application,
+                    "reason": "AH reliable OCR evidence closes receipt total exactly",
+                }
+            }
+
+    return lines, discount_total, None
+

--- a/backend/app/services/receipt_service.py
+++ b/backend/app/services/receipt_service.py
@@ -17,6 +17,7 @@ from app.receipt_ingestion.profiles.ah.corrections import (
     _ah_remove_duplicate_receipt_discount,
     _ah_fix_total_from_net_sum,
     _ah_filter_ocr_conflict_footer_noise_lines,
+    _ah_repair_image_balance_from_reliable_lines,
 )
 from app.receipt_ingestion.profiles.ah.reconstruction import (
     _r9_38e2_should_use_ah_paddle_reconstruction,
@@ -1536,6 +1537,16 @@ def parse_receipt_content(file_bytes: bytes, filename: str, mime_type: str) -> R
                     lines=image_result.lines or [],
                     store_name=image_result.store_name,
                 )
+
+                image_result.lines, image_result.discount_total, ah_balance_repair_diagnostics = _ah_repair_image_balance_from_reliable_lines(
+                    reliable_lines=paddle_lines or [],
+                    lines=image_result.lines or [],
+                    store_name=image_result.store_name,
+                    total_amount=image_result.total_amount,
+                    discount_total=image_result.discount_total,
+                )
+                if ah_balance_repair_diagnostics:
+                    diagnostics.update(ah_balance_repair_diagnostics)
 
                 image_result.total_amount = _ah_fix_total_from_net_sum(
                     text_lines=ah_source_lines_for_total,

--- a/backend/tests/test_receipt_ah_image_balance_repair_selftest.py
+++ b/backend/tests/test_receipt_ah_image_balance_repair_selftest.py
@@ -1,0 +1,54 @@
+from decimal import Decimal
+
+from app.receipt_ingestion.profiles.ah.corrections import _ah_repair_image_balance_from_reliable_lines
+
+
+def _net(lines, discount_total=None):
+    line_sum = sum(Decimal(str(line.get("line_total") or 0)) for line in lines)
+    line_discount_sum = sum(Decimal(str(line.get("discount_amount") or 0)) for line in lines)
+    receipt_discount = Decimal(str(discount_total or 0))
+    return (line_sum + line_discount_sum + receipt_discount).quantize(Decimal("0.01"))
+
+
+def test_ah10_image_balance_repair():
+    reliable_lines = [
+        "Albert Heijn Zielhorst",
+        "1 OLIJFOLIE 4.79 B 1,09",
+        "1 OLIJFOLIE AH BANANEN 1,45 4,79 B",
+        "0,587K CONFERENCE 1,11",
+        "Prijs per kg 1,89",
+        "5 SUBTOTAAL 13,23",
+        "BONUS AHEXCEVOOSMA -2,88",
+        "JOUW VOORDEEL 2,88",
+        "SUBTOTAAL 10,35",
+        "10 KOOPZEGELS 1,00",
+        "TOTAAL 11,35",
+    ]
+
+    lines = [
+        {"raw_label": "TIJGER MATS", "normalized_label": "TIJGER MATS", "line_total": 1.09, "discount_amount": None, "producer_trace": {"raw_line": "TIJGER MATS 1,09"}},
+        {"raw_label": "OLTJFOLTIE", "normalized_label": "OLTJFOLTIE", "line_total": 4.79, "discount_amount": None, "producer_trace": {"raw_line": "OLTJFOLTIE 4,79 B"}},
+        {"raw_label": "OLIJFOLIE", "normalized_label": "OLIJFOLIE", "line_total": 4.79, "discount_amount": None, "producer_trace": {"raw_line": "1 OLIJFOLIE 4,79 B"}},
+        {"raw_label": "AH BANANEN", "normalized_label": "AH BANANEN", "line_total": 1.45, "discount_amount": None, "producer_trace": {"raw_line": "1 AH BANANEN 1,45"}},
+        {"raw_label": "10 KOOPZEGELS 1,00", "normalized_label": "KOOPZEGELS", "line_total": 1.00, "discount_amount": None, "producer_trace": {"raw_line": "10 KOOPZEGELS 1,00"}},
+    ]
+
+    repaired, discount_total, diagnostics = _ah_repair_image_balance_from_reliable_lines(
+        reliable_lines=reliable_lines,
+        lines=lines,
+        store_name="Albert Heijn",
+        total_amount=Decimal("11.35"),
+        discount_total=None,
+    )
+
+    assert diagnostics is not None
+    assert diagnostics["r9_m2c2i128_ah_image_balance_repair"]["applied"] is True
+    assert any(line.get("raw_label") == "CONFERENCE" and Decimal(str(line.get("line_total"))) == Decimal("1.11") for line in repaired)
+    assert sum(Decimal(str(line.get("discount_amount") or 0)) for line in repaired).quantize(Decimal("0.01")) == Decimal("-2.88")
+    assert discount_total is None
+    assert _net(repaired, discount_total) == Decimal("11.35")
+
+
+if __name__ == "__main__":
+    test_ah10_image_balance_repair()
+    print("OK")


### PR DESCRIPTION
## Samenvatting
- Voegt een AH-specifieke, total-guarded image balance repair toe.
- Gebruikt betrouwbare Paddle OCR-regels aanvullend op gekozen Tesseract productregels.
- Herstelt AH foto 10 door ontbrekende gewichtsregel `CONFERENCE 1,11` toe te voegen en zichtbare `BONUS -2,88` toe te passen.
- Past de correctie alleen toe wanneer de netto som exact sluit op het zichtbare bon-totaal.

## Validatie
- `python -m py_compile app/receipt_ingestion/profiles/ah/corrections.py app/services/receipt_service.py tests/test_receipt_ah_image_balance_repair_selftest.py`
- `PYTHONPATH=/app python tests/test_receipt_ah_image_balance_repair_selftest.py`
- Directe parser-servicecheck AH foto 10: `parse_status: approved`, `line_sum: 14.23`, `line_discount_sum: -2.88`, `net_sum: 11.35`
- Reparse bestaande AH10 in DB: `parse_status: approved`, `line_count: 6`, `matches: True`

## Scope
- Geen bestandsnaam-hardcoding.
- Geen duplicate-filter op olijfolie.
- Frontend Playwright-output is niet meegenomen.