### PR TITLE
M2C2i: define duplicate receipt visibility contract

### DIFF
--- a/docs/release/M2C2i_duplicate_visibility_contract.md
+++ b/docs/release/M2C2i_duplicate_visibility_contract.md
@@ -1,0 +1,45 @@
+# M2C2i duplicate visibility contract
+
+## Doel
+
+Wanneer een kassabon opnieuw wordt aangeboden en Rezzerv deze als duplicate herkent, moet de gebruiker kunnen zien welke bestaande bon daarbij hoort.
+
+## API-contract
+
+Een duplicate import-response moet deze informatie leveren:
+
+- `duplicate: true`
+- `raw_receipt_id`
+- `receipt_table_id`
+- `duplicate_message`
+- `existing_receipt.raw_receipt_id`
+- `existing_receipt.receipt_table_id`
+- `existing_receipt.original_filename`
+- `existing_receipt.store_name`
+- `existing_receipt.purchase_at`
+- `existing_receipt.total_amount`
+- `existing_receipt.parse_status`
+- `existing_receipt.po_norm_status_label`
+
+## UI-gedrag
+
+Bij een duplicate import:
+
+1. toon bestandsnaam, datum, totaal en status van de bestaande bon;
+2. open de bestaande bon op basis van `receipt_table_id`;
+3. focus de bestaande rij in de Kassa-inbox;
+4. voeg geen tweede zichtbare bon toe.
+
+## Afbakening
+
+- Geen wijziging aan SSOT-statuslogica.
+- Geen frontend statusfallback.
+- Geen parserwijziging.
+- Geen database-schema wijziging.
+- Geen productkennis of kassaboninhoud hardcoden.
+
+## Acceptatie
+
+- Tweede upload van een identieke bon opent of verwijst naar de bestaande zichtbare bon.
+- De API-response bevat bestaande bonmetadata.
+- De UI toont niet alleen dat de bon al eerder is toegevoegd, maar ook welke bon dat is.


### PR DESCRIPTION
## Doel

Leg vast wat API en UI moeten doen wanneer een kassabon opnieuw wordt aangeboden en als duplicate wordt herkend.

## Wijziging

- Documenteert het duplicate visibility contract.
- Bepaalt welke bestaande bonmetadata de API moet teruggeven.
- Bepaalt dat de UI de bestaande bon moet openen of focussen.

## Niet gewijzigd

- Geen parserwijziging.
- Geen SSOT-statuswijziging.
- Geen database-schemawijziging.
- Geen runtimewijziging in deze PR.

## Vervolg

De runtime-implementatie moet in een aparte patch op basis van dit contract worden gedaan.