### PR TITLE
M2C2i: open existing receipt on duplicate import

### DIFF
--- a/backend/app/services/receipt_service.py
+++ b/backend/app/services/receipt_service.py
@@ -104,6 +104,7 @@ from app.receipt_ingestion.service_parts.text_extraction import (
     _ocr_pdf_text_with_ocrmypdf,
     _preprocess_pdf_text,
 )
+from app.services.receipt_status_baseline_service import STATUS_LABELS
 from app.receipt_ingestion.service_parts.image_ocr_flow import (
     _ocr_image_text_with_paddle,
     _ocr_image_text_with_tesseract,
@@ -246,10 +247,14 @@ def find_existing_receipt_by_fingerprint(conn, household_id: str, fingerprint: s
             SELECT
                 rt.id AS receipt_table_id,
                 rr.id AS raw_receipt_id,
+                rr.original_filename,
+                rr.sha256_hash,
                 rt.store_name,
+                rt.store_branch,
                 rt.purchase_at,
                 rt.total_amount,
-                rt.parse_status
+                rt.parse_status,
+                rt.line_count
             FROM receipt_tables rt
             JOIN raw_receipts rr ON rr.id = rt.raw_receipt_id
             WHERE {' AND '.join(where_parts)}
@@ -1694,6 +1699,54 @@ def ensure_default_receipt_sources(engine, receipt_root: Path, household_id: str
     return defaults
 
 
+
+def _format_duplicate_amount(value: Any) -> str:
+    if value is None or value == '':
+        return 'onbekend bedrag'
+    try:
+        amount = Decimal(str(value)).quantize(Decimal('0.01'))
+        return f"€ {str(amount).replace('.', ',')}"
+    except Exception:
+        return str(value)
+
+
+def _po_norm_status_label_for_duplicate(parse_status: Any) -> str:
+    normalized = str(parse_status or '').strip()
+    return STATUS_LABELS.get(normalized, 'Controle nodig')
+
+
+def _build_duplicate_receipt_response(row: Any) -> dict[str, Any]:
+    data = dict(row or {})
+    raw_receipt_id = data.get('raw_receipt_id') or data.get('id')
+    receipt_table_id = data.get('receipt_table_id')
+    parse_status = data.get('parse_status') or data.get('raw_status')
+    filename = str(data.get('original_filename') or 'bestaande bon').strip() or 'bestaande bon'
+    purchase_at = data.get('purchase_at') or 'onbekende datum'
+    total_amount = data.get('total_amount')
+    status_label = _po_norm_status_label_for_duplicate(parse_status)
+    existing_receipt = {
+        'raw_receipt_id': raw_receipt_id,
+        'receipt_table_id': receipt_table_id,
+        'original_filename': filename,
+        'store_name': data.get('store_name'),
+        'store_branch': data.get('store_branch'),
+        'purchase_at': data.get('purchase_at'),
+        'total_amount': total_amount,
+        'parse_status': parse_status,
+        'line_count': data.get('line_count'),
+        'po_norm_status_label': status_label,
+    }
+    return {
+        'raw_receipt_id': raw_receipt_id,
+        'receipt_table_id': receipt_table_id,
+        'duplicate': True,
+        'duplicate_message': f"Deze bon is al ingelezen als {filename} op {purchase_at} totaal {_format_duplicate_amount(total_amount)}.",
+        'parse_status': parse_status,
+        'po_norm_status_label': status_label,
+        'existing_receipt': existing_receipt,
+    }
+
+
 def _store_raw_file(storage_root: Path, household_id: str, raw_receipt_id: str, filename: str, file_bytes: bytes) -> str:
     now = datetime.utcnow()
     target_dir = storage_root / str(household_id) / now.strftime('%Y') / now.strftime('%m')
@@ -1712,7 +1765,18 @@ def ingest_receipt(engine, receipt_storage_root: Path, household_id: str, filena
         duplicate = conn.execute(
             text(
                 '''
-                SELECT rr.id, rr.raw_status
+                SELECT
+                    rr.id AS raw_receipt_id,
+                    rr.raw_status,
+                    rr.original_filename,
+                    rr.sha256_hash,
+                    rt.id AS receipt_table_id,
+                    rt.store_name,
+                    rt.store_branch,
+                    rt.purchase_at,
+                    rt.total_amount,
+                    rt.parse_status,
+                    rt.line_count
                 FROM raw_receipts rr
                 LEFT JOIN receipt_tables rt ON rt.raw_receipt_id = rr.id
                 WHERE rr.household_id = :household_id
@@ -1725,17 +1789,7 @@ def ingest_receipt(engine, receipt_storage_root: Path, household_id: str, filena
             {'household_id': household_id, 'sha256_hash': digest},
         ).mappings().first()
         if duplicate:
-            existing_table = conn.execute(
-                text('SELECT id, parse_status FROM receipt_tables WHERE raw_receipt_id = :raw_receipt_id LIMIT 1'),
-                {'raw_receipt_id': duplicate['id']},
-            ).mappings().first()
-            return {
-                'raw_receipt_id': duplicate['id'],
-                'receipt_table_id': existing_table['id'] if existing_table else None,
-                'duplicate': True,
-                'duplicate_message': 'Deze kassabon is al eerder toegevoegd en is niet opnieuw geladen.',
-                'parse_status': existing_table['parse_status'] if existing_table else duplicate['raw_status'],
-            }
+            return _build_duplicate_receipt_response(duplicate)
 
     parse_result = parse_receipt_content(file_bytes, filename, detected_mime)
     if reject_non_receipt and not parse_result.is_receipt:
@@ -1745,13 +1799,7 @@ def ingest_receipt(engine, receipt_storage_root: Path, household_id: str, filena
         with engine.begin() as conn:
             existing_by_fingerprint = find_existing_receipt_by_fingerprint(conn, household_id, parse_fingerprint)
             if existing_by_fingerprint:
-                return {
-                    'raw_receipt_id': existing_by_fingerprint['raw_receipt_id'],
-                    'receipt_table_id': existing_by_fingerprint['receipt_table_id'],
-                    'duplicate': True,
-                    'duplicate_message': 'Deze kassabon is al eerder toegevoegd en is niet opnieuw geladen.',
-                    'parse_status': existing_by_fingerprint['parse_status'],
-                }
+                return _build_duplicate_receipt_response(existing_by_fingerprint)
     raw_receipt_id = uuid.uuid4().hex
     storage_path = _store_raw_file(receipt_storage_root, household_id, raw_receipt_id, filename, file_bytes)
 

--- a/frontend/src/features/receipts/KassaPage.jsx
+++ b/frontend/src/features/receipts/KassaPage.jsx
@@ -44,6 +44,27 @@ function formatMoney(value, currency = 'EUR') {
   }
 }
 
+
+function getDuplicateReceiptTableId(result) {
+  return String(result?.existing_receipt?.receipt_table_id || result?.receipt_table_id || result?.receiptTableId || '')
+}
+
+function formatDuplicateImportMessageV2(result) {
+  const existing = result?.existing_receipt || {}
+  if (result?.duplicate_message) return String(result.duplicate_message)
+  const filename = String(existing.original_filename || '').trim()
+  const purchaseAt = existing.purchase_at ? formatDateTime(existing.purchase_at) : ''
+  const total = existing.total_amount !== undefined && existing.total_amount !== null ? formatMoney(existing.total_amount, existing.currency || 'EUR') : ''
+  const statusLabel = String(existing.po_norm_status_label || '').trim()
+  const parts = ['Deze bon is al ingelezen']
+  if (filename) parts.push(`als ${filename}`)
+  if (purchaseAt) parts.push(`op ${purchaseAt}`)
+  if (total && total !== '-') parts.push(`totaal ${total}`)
+  if (statusLabel) parts.push(`status ${statusLabel}`)
+  return `${parts.join(' ')}.`
+}
+
+
 function emailPartLabel(value) {
   if (value === 'attachment') return 'Bijlage uit e-mail'
   if (value === 'html_body') return 'HTML-body van e-mail'
@@ -2162,7 +2183,7 @@ export default function KassaPage() {
         }
         if (sharedResult?.shareStatus === 'success') {
           if (sharedResult.duplicate) {
-            announceDuplicate(sharedResult)
+            await announceDuplicate(sharedResult, items)
           } else {
             setDuplicateNotice('')
             setStatus('Gedeelde bon ontvangen. De bon staat nu in de Kassa.')
@@ -2198,22 +2219,40 @@ export default function KassaPage() {
     return () => window.clearTimeout(timeoutId)
   }, [receiptInboxFocusId])
 
-  function announceDuplicate(result) {
-    const message = formatDuplicateImportMessage(result)
+  async function announceDuplicate(result, sourceItems = receipts) {
+    const message = formatDuplicateImportMessageV2(result)
+    const existingReceiptId = getDuplicateReceiptTableId(result)
     setError('')
     setStatus('')
     setDuplicateNotice(message)
     showKassaFeedback('warning', message, {
       title: 'Bon al ingelezen',
-      detail: 'Deze upload is niet opnieuw toegevoegd. De bestaande kassabon blijft ongewijzigd in Kassa.',
-      key: 'kassa-duplicate-receipt',
+      detail: existingReceiptId ? 'De bestaande kassabon is geopend in Kassa.' : 'Deze upload is niet opnieuw toegevoegd. De bestaande kassabon blijft ongewijzigd in Kassa.',
+      key: `kassa-duplicate-receipt-${existingReceiptId || 'unknown'}`,
       dedupeMs: 0,
       testId: 'kassa-duplicate-overlay',
     })
+
+    if (existingReceiptId) {
+      setFilters(DEFAULT_RECEIPT_FILTERS)
+      setReceiptInboxFocusId(existingReceiptId)
+      setSelectedReceiptIds([existingReceiptId])
+      const refreshedItems = await loadReceipts(householdId, {
+        preserveDuplicateNotice: true,
+        openReceiptId: existingReceiptId,
+      })
+      const itemsForOpen = Array.isArray(refreshedItems) && refreshedItems.length ? refreshedItems : sourceItems
+      await openReceiptDetail(existingReceiptId, itemsForOpen)
+      if (isAddReceiptRoute) navigate('/kassa')
+    }
+
     try {
       window.requestAnimationFrame(() => {
+        const targetRow = existingReceiptId
+          ? document.querySelector(`[data-testid="kassa-row-${existingReceiptId}"]`)
+          : null
         const feedback = document.querySelector('[data-testid="receipt-duplicate-feedback"]')
-        feedback?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        ;(targetRow || feedback)?.scrollIntoView({ behavior: 'smooth', block: 'center' })
       })
     } catch {
       // ignore scroll issues
@@ -2540,7 +2579,7 @@ export default function KassaPage() {
       const uploadedReceiptId = String(result?.receipt_table_id || '')
 
       if (result?.duplicate) {
-        announceDuplicate(result)
+        await announceDuplicate(result)
       } else {
         clearCameraDraft()
             setOpenedReceiptId('')
@@ -2640,7 +2679,7 @@ export default function KassaPage() {
       const uploadedReceiptId = String(result?.receipt_table_id || '')
 
       if (result?.duplicate) {
-        announceDuplicate(result)
+        await announceDuplicate(result)
       } else {
         setOpenedReceiptId('')
         setOpenedReceipt(null)
@@ -2719,7 +2758,7 @@ export default function KassaPage() {
       const isBatchImport = Boolean(result?.batch)
       let keepUploading = false
       if (result?.duplicate && !isBatchImport) {
-        announceDuplicate(result)
+        await announceDuplicate(result)
       } else if (isBatchImport && result?.async && result?.batch_id) {
         setOpenedReceiptId('')
         setOpenedReceipt(null)


### PR DESCRIPTION
## Doel

Duplicate kassabonuploads worden nu niet alleen als duplicate gemeld, maar verwijzen naar de bestaande kassabon en openen/focussen die in Kassa.

## Wijziging

- Backend duplicate-response uitgebreid met bestaande bonmetadata via `existing_receipt`.
- Duplicate-responses gebruiken nu bestandsnaam, aankoopmoment, totaalbedrag en statuslabel van de bestaande bon.
- Frontend duplicate-flow opent/focust de bestaande bon via `receipt_table_id`.
- Geen tweede zichtbare bon toevoegen bij duplicate.

## Niet gewijzigd

- Geen parserwijziging.
- Geen database-schemawijziging.
- Geen SSOT-statuswijziging.
- Geen productkennis in code.
- Geen wijziging aan foto 12 parser/OCR-status.

## Lokale validatie

Door PO bevestigd:

- duplicate-melding is beter toegelicht;
- gedrag is functioneel akkoord voor deze stap.

Nog te draaien voor merge:

```powershell
cd C:\Users\Gebruiker\Rezzerv_Github; docker compose down; docker compose up -d --build
Start-Sleep -Seconds 90; Invoke-RestMethod http://localhost:8011/api/health
```

Aanvullend aanbevolen:

```powershell
cd C:\Users\Gebruiker\Rezzerv_Github; .\scripts\run-frontend-regression-report.ps1 -SkipDockerBuild
```

## Risico

Middel: raakt backend import-response en frontend duplicate-flow. Geen schema-impact, maar wel UI-flow-impact op Kassa duplicate-upload.