### PR TITLE
fix(receipts): handle fuzzy totals and Lidl photo OCR tails

### DIFF
--- a/backend/app/receipt_ingestion/header_parser.py
+++ b/backend/app/receipt_ingestion/header_parser.py
@@ -24,6 +24,23 @@ from app.receipt_ingestion.fingerprints import (
     _is_plausible_total_amount,
 )
 
+
+def _looks_like_fuzzy_total_label(value: str | None) -> bool:
+    """Recognize OCR variants of receipt total labels across store profiles."""
+    candidate = re.sub(r'\s+', ' ', str(value or '')).strip(' .:-')
+    if not candidate:
+        return False
+    first_token = candidate.split()[0].lower()
+    normalized = (
+        first_token
+        .replace('0', 'o')
+        .replace('1', 'l')
+        .replace('i', 'l')
+        .replace('|', 'l')
+        .replace('!', 'l')
+    )
+    return normalized in {'totaal', 'totall', 'totaai'}
+
 KNOWN_STORES = [
     'Albert Heijn', 'AH', 'Jumbo', 'Lidl', 'Plus', 'ALDI', 'Aldi', 'Action',
     'Gamma', 'Hornbach', 'Picnic', 'Bol', 'bol.com', 'Coolblue', 'Karwei',
@@ -154,6 +171,16 @@ def _purchase_at_from_lines(lines: Iterable[str], filename: str) -> str | None:
     candidates: list[tuple[int, str]] = []
     for candidate in list(lines):
         normalized_candidate = str(candidate or '').strip()
+        normalized_candidate = re.sub(
+            r'\b(\d{1,2})\s+(\d{1,2}[/-]\d{4})\b',
+            r'\1-\2',
+            normalized_candidate,
+        )
+        normalized_candidate = re.sub(
+            r'\b(\d{1,2}[/-]\d{1,2}[/-]\d{4})-\s+(\d{1,2}:\d{2}(?::\d{2})?)\b',
+            r'\1 \2',
+            normalized_candidate,
+        )
         lowered = normalized_candidate.lower()
         for pattern in patterns:
             match = pattern.search(normalized_candidate)
@@ -252,14 +279,17 @@ def _total_amount_from_lines(lines: list[str], filename: str) -> tuple[Decimal |
         if any(token in lowered for token in ('voordeel', 'korting', 'waarvan', 'bonus box')):
             continue
 
-        explicit = bool(explicit_total_pattern.search(lowered))
+        explicit = bool(explicit_total_pattern.search(lowered) or _looks_like_fuzzy_total_label(lowered))
+        explicit_line_start = bool(_looks_like_fuzzy_total_label(lowered))
         payment = bool(payment_pattern.search(lowered))
         if not explicit and not payment:
             continue
 
         amount = parsed_matches[-1]
         score = 0
-        if explicit:
+        if explicit_line_start:
+            score += 120
+        elif explicit:
             score += 40
         if payment:
             score += 25

--- a/backend/app/services/receipt_service.py
+++ b/backend/app/services/receipt_service.py
@@ -698,8 +698,68 @@ def _extract_receipt_lines(lines: list[str], *, store_name: str | None = None, f
         r'(?:\s+(?P<amount2>-?\d{1,6}(?:[\.,]\d{2})))?(?:\s+(?:EUR|[A-Z]{1,3}))?$',
         re.IGNORECASE,
     )
+    amount_first_tail_re = re.compile(
+        r'^(?P<amount>-?(?:\d{1,6}|[QOqOo])[\.,]\s?\d{2})\s*(?P<vat>[A-Z8]{1,3})?\s+(?P<tail>(?=.*[A-Za-z]).+)$',
+        re.IGNORECASE,
+    )
+    amount_first_weight_re = re.compile(
+        r'^(?P<amount>-?(?:\d{1,6}|[QOqOo])[\.,]\s?[\dZSs]{2})\s*(?P<vat>[A-Z8]{1,3})?\s*'
+        r'(?P<qty>\d+(?:[\.,]\d+)?)\s*kg\s*x\s*(?P<unit_price>\d{1,6}(?:[\.,]\d{2}))',
+        re.IGNORECASE,
+    )
+
+    loose_weight_detail_re = re.compile(
+        r'^(?P<qty>\d+(?:[\.,]\d+)?)\s*kg\s*x\s*(?P<unit_price>\d{1,6}(?:[\.,]\d{2}))',
+        re.IGNORECASE,
+    )
+
     pending_label: str | None = None
     pending_line_index: int | None = None
+
+    def clean_tail_label(value: str | None) -> str | None:
+        tail = re.sub(r'\s+', ' ', str(value or '')).strip(' .:-')
+        tail = re.sub(r'^(?:[A-Z]{1,3}|8)\s+', '', tail, flags=re.IGNORECASE).strip(' .:-')
+        tail = re.sub(r'\s+(?:[A-Z]{1,3}|8)$', '', tail, flags=re.IGNORECASE).strip(' .:-')
+        if not tail or not _contains_letter(tail):
+            return None
+        if _looks_like_non_product_receipt_label(tail):
+            return None
+        return tail
+
+    def clean_ocr_amount(value: str | None) -> str | None:
+        token = re.sub(r'\s+', '', str(value or '').strip())
+        if not token:
+            return None
+        token = token.replace('−', '-')
+        token = re.sub(r'^[QOqOo](?=[\.,])', '0', token)
+        token = token.replace('Z', '7').replace('z', '7')
+        token = token.replace('S', '5').replace('s', '5')
+        token = re.sub(r'[^0-9,\.\-]', '', token)
+        return token
+
+
+    def split_pending_label_amount(value: str | None) -> tuple[str | None, str | None]:
+        candidate = re.sub(r'\s+', ' ', str(value or '')).strip()
+        if not candidate:
+            return None, None
+
+        # Generic OCR case:
+        # "<label> Q,5ZBL..." / "<label> 0,57B..." where the amount belongs
+        # to the previous line total and trailing VAT/noise got glued to label.
+        match = re.match(
+            r'^(?P<label>.*?[A-Za-zÀ-ÖØ-öø-ÿ][A-Za-zÀ-ÖØ-öø-ÿ0-9 .&''’/-]*?)\s+'
+            r'(?P<amount>[QOqOo0-9][\.,]\s?[0-9ZSsz]{2})(?P<tail>[A-Za-z8]{1,8}.*)?$',
+            candidate,
+            flags=re.IGNORECASE,
+        )
+        if not match:
+            return candidate, None
+
+        label = clean_tail_label(match.group('label')) or match.group('label').strip(' .:-')
+        amount = clean_ocr_amount(match.group('amount'))
+        if not label or not amount:
+            return candidate, None
+        return label, amount
 
     def append_line(label: str, qty_raw: str | None, amount1_raw: str | None, amount2_raw: str | None, *, source_index: int) -> int | None:
         return append_product_candidate(
@@ -754,6 +814,53 @@ def _extract_receipt_lines(lines: list[str], *, store_name: str | None = None, f
         normalized = re.sub(r'(?<=\d)/(?!/)(?=\d{2}\b)', ',', normalized)
         normalized = re.sub(r'^[^A-Za-z0-9]+', '', normalized).strip()
         normalized = re.sub(r'[^A-Za-z0-9]+$', '', normalized).strip()
+        normalized = re.sub(r'(?P<prefix>-?(?:\d{1,6}|[QOqOo])[\.,])\s+(?=\d{2}\b)', r'\g<prefix>', normalized)
+        normalized = re.sub(r'(?<=\d[\.,]\d{2})(?=[A-Z]{1,3}\b)', ' ', normalized)
+
+        loose_weight_detail_match = loose_weight_detail_re.match(normalized)
+        if pending_label and loose_weight_detail_match:
+            pending_clean_label, pending_amount = split_pending_label_amount(pending_label)
+            if pending_amount:
+                append_line(
+                    pending_clean_label or pending_label,
+                    f"{loose_weight_detail_match.group('qty')} kg",
+                    loose_weight_detail_match.group('unit_price'),
+                    pending_amount,
+                    source_index=source_index,
+                )
+                pending_label = None
+                pending_line_index = None
+                continue
+
+        amount_first_weight_match = amount_first_weight_re.match(normalized)
+        if pending_label and amount_first_weight_match:
+            append_line(
+                pending_label,
+                f"{amount_first_weight_match.group('qty')} kg",
+                amount_first_weight_match.group('unit_price'),
+                clean_ocr_amount(amount_first_weight_match.group('amount')),
+                source_index=source_index,
+            )
+            pending_label = None
+            pending_line_index = None
+            continue
+
+        amount_first_tail_match = amount_first_tail_re.match(normalized)
+        if amount_first_tail_match:
+            amount_raw = clean_ocr_amount(amount_first_tail_match.group('amount'))
+            tail_label = clean_tail_label(amount_first_tail_match.group('tail'))
+            if pending_label and amount_raw:
+                append_line(
+                    pending_label,
+                    None,
+                    amount_raw,
+                    None,
+                    source_index=source_index,
+                )
+            pending_label = tail_label
+            pending_line_index = None
+            continue
+
         classification = _classify_receipt_text_line(
             normalized,
             store_name=store_name,
@@ -774,7 +881,14 @@ def _extract_receipt_lines(lines: list[str], *, store_name: str | None = None, f
             pending_label = None
             continue
         if classification == 'amount_detail' and detail_match and pending_label:
-            append_line(pending_label, detail_match.group('qty'), detail_match.group('amount1'), detail_match.group('amount2'), source_index=source_index)
+            pending_clean_label, pending_amount = split_pending_label_amount(pending_label)
+            append_line(
+                pending_clean_label or pending_label,
+                detail_match.group('qty'),
+                detail_match.group('amount1'),
+                pending_amount or detail_match.group('amount2'),
+                source_index=source_index,
+            )
             pending_label = None
             pending_line_index = None
             continue

--- a/backend/app/services/receipt_service.py
+++ b/backend/app/services/receipt_service.py
@@ -200,9 +200,30 @@ IGNORED_LINE_MARKERS = {
     'kassa', 'kassabon', 'ticket', 'bonnr', 'filiaal', 'adres', 'datum', 'tijd', 'transactie'
 }
 
+
 LOGGER = logging.getLogger(__name__)
 _PADDLE_OCR_INSTANCE = None
 
+
+def _looks_like_fuzzy_total_label(value: str | None) -> bool:
+    """Recognize OCR variants of receipt total labels.
+
+    Generic across store profiles. This must not depend on filenames, receipt ids,
+    hashes, article names, or store-specific receipt examples.
+    """
+    candidate = re.sub(r'\s+', ' ', str(value or '')).strip(' .:-')
+    if not candidate:
+        return False
+    first_token = candidate.split()[0].lower()
+    normalized = (
+        first_token
+        .replace('0', 'o')
+        .replace('1', 'l')
+        .replace('i', 'l')
+        .replace('|', 'l')
+        .replace('!', 'l')
+    )
+    return normalized in {'totaal', 'totall', 'totaai'}
 
 
 def _column_exists(conn, table_name: str, column_name: str) -> bool:
@@ -553,7 +574,7 @@ def _should_skip_receipt_line(line: str, *, store_name: str | None = None, filen
         return True
     if lowered.startswith(('bonus ', 'bbox ', 'korting ', 'retour ', 'refund ')):
         return True
-    if 'totaal' in lowered:
+    if 'totaal' in lowered or _looks_like_fuzzy_total_label(lowered):
         return True
     if re.match(r'^(?:\d+%|%)\b', lowered):
         return True


### PR DESCRIPTION
## Samenvatting

Deze PR herstelt generieke OCR-afhandeling voor Lidl-foto’s zonder bestands-, bon-, hash-, artikel- of prijs-hardcoding.

Opgelost:
- Fuzzy totaalherkenning zoals `Totaai` naast `Totaal`.
- Totaalbedragselectie bij OCR-ruis rond betaalregels.
- OCR-datumruis zoals `30-01-2026- 14:24`.
- Amount-first regels waarbij bedragen en labels door OCR aan elkaar kleven.
- Losse weegdetailregels waarbij het bedrag in het pending label zat en de volgende regel alleen `kg x unit_price` bevatte.

## Bewijs

### Lidl foto 14

- Status: Gecontroleerd
- Totaal: 32.93
- Som regels: 32.93
- Datum/tijd: 2026-03-17T13:57:00
- Fuzzy totaalregel niet meer als artikel opgeslagen.

### Lidl foto 12

- Status: Gecontroleerd
- po_norm_status: controlled
- Totaal: 69.33
- Som regels: 69.33
- Net som regels: 69.33
- Aantal regels: 29
- Datum/tijd: 2026-01-30T14:24:00
- Peren-weegregel hersteld naar 0.444 kg x 1.29 = 0.57

## Testresultaten

Geslaagd:

```text
R9-38E10-ADMIN-SSOT-REGRESSION passed
R9-36N5 RELEASE QUALITY GATE PASSED
```

Niet uitvoerbaar in huidige container:

```text
python -m pytest ...
/usr/local/bin/python: No module named pytest
```

Dit is een ontbrekende testdependency in de backend-container, geen regressiefout in de code.

## Guardrails

- Geen hardcoding op bestandsnaam.
- Geen hardcoding op receipt id/hash.
- Geen hardcoding op artikelnamen.
- Geen hardcoding op specifieke prijzen.
- Oplossing gebruikt generieke OCR-patronen voor totalen, datums, amount-first tails en weegdetailregels.