### PR TITLE
fix(plus): activate guarded structured bbox parsing

### DIFF
--- a/backend/app/receipt_ingestion/header_parser.py
+++ b/backend/app/receipt_ingestion/header_parser.py
@@ -25,21 +25,47 @@ from app.receipt_ingestion.fingerprints import (
 )
 
 
-def _looks_like_fuzzy_total_label(value: str | None) -> bool:
-    """Recognize OCR variants of receipt total labels across store profiles."""
-    candidate = re.sub(r'\s+', ' ', str(value or '')).strip(' .:-')
-    if not candidate:
-        return False
-    first_token = candidate.split()[0].lower()
-    normalized = (
-        first_token
+def _normalize_ocr_total_token(value: str | None) -> str:
+    token = str(value or '').strip().lower()
+    token = token.strip(' .:-;')
+    token = (
+        token
         .replace('0', 'o')
         .replace('1', 'l')
         .replace('i', 'l')
         .replace('|', 'l')
         .replace('!', 'l')
     )
-    return normalized in {'totaal', 'totall', 'totaai'}
+    return re.sub(r'[^a-z0-9]+', '', token)
+
+
+def _looks_like_fuzzy_total_label(value: str | None) -> bool:
+    """Recognize OCR variants of receipt total labels across store profiles.
+
+    OCR often fuses the total label with adjacent noise (for example
+    ``Totaaleodboowns``) or reads the leading ``T`` as ``l`` (``lotaal``).  This
+    helper intentionally only inspects the first token so normal product labels
+    containing a later word such as "totaal" are not promoted to totals.
+    """
+    candidate = re.sub(r'\s+', ' ', str(value or '')).strip(' .:-;')
+    if not candidate:
+        return False
+    first_token = candidate.split()[0]
+    normalized = _normalize_ocr_total_token(first_token)
+    if normalized in {'totaal', 'totall', 'totaai', 'lotaal', 'lotall', 'lotaai'}:
+        return True
+    return bool(re.fullmatch(r'(?:t|l)otaal[a-z0-9]{1,20}', normalized))
+
+
+def _looks_like_vat_total_line(value: str | None) -> bool:
+    """Return True for VAT/tax summary rows that must not become receipt totals."""
+    lowered = re.sub(r'\s+', ' ', str(value or '')).strip().lower()
+    if not lowered:
+        return False
+    if any(token in lowered for token in ('btw', 'vat', 'biw', 'bedr.excl', 'bedr.incl', 'bedrag excl', 'bedrag incl')):
+        return True
+    return False
+
 
 KNOWN_STORES = [
     'Albert Heijn', 'AH', 'Jumbo', 'Lidl', 'Plus', 'ALDI', 'Aldi', 'Action',
@@ -228,14 +254,13 @@ def _ah_final_total_after_savings(lines: list[str], filename: str) -> Decimal | 
         return None
     savings_seen = False
     amount_pattern = re.compile(r'(-?\d{1,6}(?:[\.,]\d{2}))')
-    total_pattern = re.compile(r'(?i)^\s*totaal\b')
     for raw_line in lines:
         normalized = re.sub(r'\s+', ' ', str(raw_line or '')).strip()
         lowered = normalized.lower()
         if any(token in lowered for token in ('koopzegel', 'koopzegels', 'pluspunten')) and amount_pattern.search(normalized):
             savings_seen = True
             continue
-        if savings_seen and total_pattern.search(normalized):
+        if savings_seen and _looks_like_fuzzy_total_label(normalized):
             matches = amount_pattern.findall(normalized)
             parsed = [_parse_decimal(item) for item in matches]
             parsed = [item for item in parsed if item is not None and _is_plausible_total_amount(item)]
@@ -257,18 +282,17 @@ def _total_amount_from_lines(lines: list[str], filename: str) -> tuple[Decimal |
     amount_pattern = re.compile(r'(-?\d{1,6}(?:[\.,]\d{2}))')
     explicit_total_pattern = re.compile(r'(?i)\b(totaal|te betalen|te voldoen|eindtotaal|total due|amount due)\b')
     subtotal_pattern = re.compile(r'(?i)\b(subtotaal|subtotal)\b')
-    payment_pattern = re.compile(r'(?i)\b(bankpas|pinnen|pin|betaald|betaling)\b')
-    vat_pattern = re.compile(r'(?i)\b(btw|bedr\.excl|bedr\.incl|bedrag excl|bedrag incl)\b')
+    payment_pattern = re.compile(r'(?i)\b(bankpas|pinnen|pin|betaald|betaling|contactloos|contactless|contactiess|tontactless)\b')
     refund_pattern = re.compile(r'(?i)\b(retour|refund|credit)\b')
     candidates: list[tuple[int, int, Decimal, bool]] = []
-    in_vat_block = False
 
     for index, line in enumerate(lines):
-        lowered = str(line or '').lower()
-        if vat_pattern.search(lowered) or lowered.startswith('%'):
-            in_vat_block = True
+        raw_line = str(line or '')
+        lowered = raw_line.lower()
+        if _looks_like_vat_total_line(lowered):
+            continue
 
-        matches = amount_pattern.findall(str(line or ''))
+        matches = amount_pattern.findall(raw_line)
         parsed_matches = [_parse_decimal(item) for item in matches]
         parsed_matches = [item for item in parsed_matches if item is not None]
 
@@ -295,8 +319,6 @@ def _total_amount_from_lines(lines: list[str], filename: str) -> tuple[Decimal |
             score += 25
         if 'eur' in lowered:
             score += 10
-        if in_vat_block or vat_pattern.search(lowered):
-            score -= 100
         if refund_pattern.search(lowered):
             score -= 60
         if len(parsed_matches) > 1:

--- a/backend/app/receipt_ingestion/line_classifier.py
+++ b/backend/app/receipt_ingestion/line_classifier.py
@@ -36,8 +36,9 @@ LegacyLineCheck = Callable[[str], bool]
 GENERIC_PAYMENT_TOKENS = (
     'te betalen', 'totaal te betalen', 'betaald', 'betaling', 'kaartbetaling',
     'pin', 'pinnen', 'bankpas', 'maestro', 'visa', 'mastercard', 'v pay', 'v-pay',
-    'contactloos', 'contant', 'wisselgeld', 'terminal', 'transactie', 'transactienr',
-    'autorisatie', 'akkoord', 'merchant', 'kopie kaarthouder', 'klantticket',
+    'contactloos', 'contactless', 'contactiess', 'tontactless', 'contant', 'wisselgeld',
+    'terminal', 'transactie', 'transactienr', 'autorisatie', 'akkoord', 'merchant',
+    'kopie kaarthouder', 'klantticket',
 )
 GENERIC_TOTAL_TOKENS = (
     'totaal', 'subtotaal', 'sub totaal', 'bedrag euro', 'bedrag = euro',
@@ -83,6 +84,34 @@ def _has_amount(value: str) -> bool:
     return bool(re.search(r'(?<!\d)-?\d+[\.,]\d{2}(?!\d)', value))
 
 
+def _normalize_ocr_total_token(value: str | None) -> str:
+    token = str(value or '').strip().lower().strip(' .:-;')
+    token = (
+        token
+        .replace('0', 'o')
+        .replace('1', 'l')
+        .replace('i', 'l')
+        .replace('|', 'l')
+        .replace('!', 'l')
+    )
+    return re.sub(r'[^a-z0-9]+', '', token)
+
+
+def _looks_like_fuzzy_total_label(value: str | None) -> bool:
+    candidate = re.sub(r'\s+', ' ', str(value or '')).strip(' .:-;')
+    if not candidate:
+        return False
+    normalized = _normalize_ocr_total_token(candidate.split()[0])
+    if normalized in {'totaal', 'totall', 'totaai', 'lotaal', 'lotall', 'lotaai'}:
+        return True
+    return bool(re.fullmatch(r'(?:t|l)otaal[a-z0-9]{1,20}', normalized))
+
+
+def _is_summary_discount_line(lowered: str) -> bool:
+    compact = re.sub(r'[^a-z0-9]+', '', str(lowered or '').lower())
+    return 'totalekortingis' in compact or 'detotalekortingis' in compact
+
+
 def _is_value_line_label_without_amount(lowered: str) -> bool:
     return matches_spaarzegels_value_label(lowered)
 
@@ -104,6 +133,10 @@ def _token_match(lowered: str, tokens: tuple[str, ...]) -> str | None:
 def _priced_article_value_token(lowered: str) -> str | None:
     if not _has_amount(lowered):
         return None
+    if _is_summary_discount_line(lowered):
+        return None
+    if _looks_like_fuzzy_total_label(lowered):
+        return None
     if _token_match(lowered, GENERIC_PAYMENT_TOKENS):
         return None
     if _token_match(lowered, GENERIC_TAX_TOKENS):
@@ -114,7 +147,7 @@ def _priced_article_value_token(lowered: str) -> str | None:
 
 
 def _footer_or_metadata(lowered: str) -> str:
-    if any(token in lowered for token in FOOTER_TOKENS):
+    if any(token in lowered for token in FOOTER_TOKENS) or _looks_like_fuzzy_total_label(lowered):
         return 'footer_payment_tax'
     return 'metadata'
 
@@ -152,6 +185,10 @@ def _generic_non_article_trace(line: str) -> dict[str, Any] | None:
         return _decision('footer_payment_tax', 'GENERIC_REGEX_PERCENT_LINE', normalized)
     if re.fullmatch(r'\d{1,4}[.]\d{2}', normalized) or re.fullmatch(r'\d{1,4},\d{2}', normalized):
         return _decision('footer_payment_tax', 'GENERIC_REGEX_STANDALONE_AMOUNT', normalized)
+    if _looks_like_fuzzy_total_label(normalized):
+        return _decision('footer_payment_tax', 'GENERIC_FUZZY_TOTAL_LABEL', normalized)
+    if _is_summary_discount_line(lowered):
+        return _decision('footer_payment_tax', 'GENERIC_SUMMARY_DISCOUNT_LINE', normalized)
     for tokens, classification, rule in (
         (GENERIC_PAYMENT_TOKENS, 'footer_payment_tax', 'GENERIC_PAYMENT_TOKENS'),
         (GENERIC_TAX_TOKENS, 'footer_payment_tax', 'GENERIC_TAX_TOKENS'),
@@ -193,12 +230,17 @@ def _store_specific_non_article_trace(line: str, store_name: str | None = None, 
     common_payment_footer_tokens = (
         'te betalen', 'totaal', 'subtotaal', 'totaal incl', 'btw', 'vat',
         'pin', 'bankpas', 'maestro', 'visa', 'mastercard', 'contactloos',
-        'terminal', 'transactie', 'transactienr', 'betaling', 'betaald',
-        'wisselgeld', 'kasbon', 'bonnr', 'bon nr', 'bonnummer', 'referentie',
+        'contactless', 'contactiess', 'tontactless', 'terminal', 'transactie',
+        'transactienr', 'betaling', 'betaald', 'wisselgeld', 'kasbon', 'bonnr',
+        'bon nr', 'bonnummer', 'referentie',
     )
     token = _token_match(lowered, common_payment_footer_tokens)
     if token:
         return _decision(_footer_or_metadata(lowered), 'STORE_COMMON_PAYMENT_FOOTER_TOKENS', token, stage='store_specific')
+    if _looks_like_fuzzy_total_label(normalized):
+        return _decision('footer_payment_tax', 'STORE_FUZZY_TOTAL_LABEL', normalized, stage='store_specific')
+    if _is_summary_discount_line(lowered):
+        return _decision('footer_payment_tax', 'STORE_SUMMARY_DISCOUNT_LINE', normalized, stage='store_specific')
     if re.fullmatch(r'(?:[a-z]\s*)?\d{1,2}[,.]\d{2}\s*%.*', lowered):
         return _decision('footer_payment_tax', 'STORE_REGEX_PERCENT_LINE', normalized, stage='store_specific')
     if re.fullmatch(r'\d{1,2}:\d{2}(?::\d{2})?', lowered):
@@ -215,6 +257,10 @@ def _store_specific_non_article_trace(line: str, store_name: str | None = None, 
         if token:
             return _decision('metadata', 'ALDI_METADATA_TOKENS', token, stage='store_specific')
     if 'plus' in store_key:
+        if _is_summary_discount_line(lowered):
+            return _decision('footer_payment_tax', 'PLUS_SUMMARY_DISCOUNT_LINE', normalized, stage='store_specific')
+        if _looks_like_fuzzy_total_label(normalized):
+            return _decision('footer_payment_tax', 'PLUS_FUZZY_TOTAL_LABEL', normalized, stage='store_specific')
         token = _priced_article_value_token(lowered)
         if token:
             return _decision('product_candidate', 'PLUS_PRICED_DISCOUNT_OR_SPAARZEGELS_LINE', token, stage='store_specific')
@@ -236,15 +282,15 @@ def _non_article_reason(classification: str | None, line: str) -> str:
     normalized = re.sub(r'\s+', ' ', str(line or '')).strip()
     lowered = normalized.lower()
     if classification == 'footer_payment_tax':
-        if any(token in lowered for token in ('totaal', 'subtotaal')):
+        if _looks_like_fuzzy_total_label(normalized) or any(token in lowered for token in ('totaal', 'subtotaal')):
             return 'total_or_subtotal_line'
         if any(token in lowered for token in ('btw', 'vat', 'biw', 'netto', 'bruto')):
             return 'vat_line'
-        if any(token in lowered for token in ('betaal', 'bankpas', 'pin', 'terminal', 'transactie', 'maestro', 'visa', 'mastercard')):
+        if any(token in lowered for token in ('betaal', 'bankpas', 'pin', 'terminal', 'transactie', 'maestro', 'visa', 'mastercard', 'contactless', 'contactloos')):
             return 'payment_line'
         if any(token in lowered for token in ('statiegeld retour', 'retour statiegeld', 'emballage retour')):
             return 'deposit_return_or_refund_line'
-        if any(token in lowered for token in ('korting', 'bonus', 'actie', 'prijsvoordeel', 'voordeel', 'coupon')):
+        if _is_summary_discount_line(lowered) or any(token in lowered for token in ('korting', 'bonus', 'actie', 'prijsvoordeel', 'voordeel', 'coupon')):
             return 'discount_or_promotion_line'
         if re.fullmatch(r'\d{1,4}[.,]\d{2}', normalized):
             return 'standalone_amount_line'

--- a/backend/app/receipt_ingestion/parsing/plus_article_block_recovery.py
+++ b/backend/app/receipt_ingestion/parsing/plus_article_block_recovery.py
@@ -1,0 +1,208 @@
+﻿"""PLUS article-block recovery diagnostics.
+
+Diagnose-only module for PLUS image receipts.
+
+Purpose:
+- inspect Paddle/raw OCR lines inside the PLUS article block;
+- compare those lines with currently parsed receipt lines;
+- report product-like OCR lines that were not converted into parser lines;
+- do not alter parser output.
+
+No hardcoded article names, receipt IDs, filenames or receipt-specific prices.
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from typing import Any
+
+
+_MONEY_RE = re.compile(r'(?<![A-Za-z0-9])[-€£CEe]?\s*\d{1,5}(?:[.,]\d{2})(?![A-Za-z0-9])')
+_LETTER_RE = re.compile(r'[A-Za-zÀ-ÖØ-öø-ÿ]')
+
+_ARTICLE_HEADER_RE = re.compile(
+    r'(?:omschrijving|onschrijving|dnschrijving|beschrijving).*(?:bedrag|p\.?\s*st|st/kg|p\s*st/kg)',
+    re.IGNORECASE,
+)
+
+_ARTICLE_BLOCK_END_RE = re.compile(
+    r'\b(?:subtotaal|subtotal|klantticket|terminal|merchant|transactie|autorisatie|betaling|contactless|contactiess|tontactless|leesmethode|wisselgeld|btw|kaart|pin)\b',
+    re.IGNORECASE,
+)
+
+_NON_ARTICLE_RE = re.compile(
+    r'\b(?:subtotaal|subtotal|totaal|totael|yotaal|lotaal|pluspunten|digitale\s+zegels|zegel|actie|korting|klantticket|terminal|merchant|transactie|betaling|contactless|contactiess|tontactless|leesmethode|wisselgeld|btw|kaart|pin|poi)\b',
+    re.IGNORECASE,
+)
+
+
+def _money(value: Any) -> Decimal:
+    if value is None or value == '':
+        return Decimal('0.00')
+    try:
+        return Decimal(str(value).replace(',', '.')).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+    except (InvalidOperation, ValueError):
+        return Decimal('0.00')
+
+
+def _parse_money_token(token: str) -> Decimal | None:
+    cleaned = str(token or '').strip()
+    cleaned = cleaned.replace('€', '').replace('£', '')
+    cleaned = re.sub(r'^[CEe]\s*', '', cleaned)
+    cleaned = cleaned.replace(' ', '').replace(',', '.')
+    try:
+        return Decimal(cleaned).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _amount_tokens(line: str) -> list[Decimal]:
+    values: list[Decimal] = []
+    for match in _MONEY_RE.finditer(str(line or '')):
+        value = _parse_money_token(match.group(0))
+        if value is not None:
+            values.append(value)
+    return values
+
+
+def _normalize_text(value: Any) -> str:
+    return re.sub(r'\s+', ' ', str(value or '')).strip().lower()
+
+
+def _source_indexes(lines: list[dict[str, Any]] | None) -> set[int]:
+    indexes: set[int] = set()
+    for line in lines or []:
+        trace = line.get('producer_trace') if isinstance(line, dict) else None
+        if not isinstance(trace, dict):
+            continue
+        try:
+            indexes.add(int(trace.get('source_index')))
+        except Exception:
+            continue
+    return indexes
+
+
+def _article_block_bounds(text_lines: list[str] | None) -> tuple[int, int]:
+    lines = list(text_lines or [])
+    start = 0
+
+    for idx, raw in enumerate(lines):
+        if _ARTICLE_HEADER_RE.search(str(raw or '')):
+            start = idx + 1
+            break
+
+    end = len(lines)
+    for idx in range(start, len(lines)):
+        raw = str(lines[idx] or '')
+        if _ARTICLE_BLOCK_END_RE.search(raw):
+            end = idx
+            break
+
+    return start, end
+
+
+def _is_product_like_article_block_line(raw: str) -> bool:
+    value = str(raw or '').strip()
+    normalized = _normalize_text(value)
+
+    if not value:
+        return False
+    if not _LETTER_RE.search(value):
+        return False
+    if _NON_ARTICLE_RE.search(normalized):
+        return False
+
+    amounts = _amount_tokens(value)
+    if not amounts:
+        return False
+
+    # Product-like lines should have text before the final amount.
+    last_amount_match = list(_MONEY_RE.finditer(value))[-1]
+    prefix = value[:last_amount_match.start()]
+    if not _LETTER_RE.search(prefix):
+        return False
+
+    return True
+
+
+def diagnose_plus_article_block_recovery(
+    *,
+    text_lines: list[str] | None,
+    current_lines: list[dict[str, Any]] | None,
+    total_amount: Any = None,
+    discount_total: Any = None,
+) -> dict[str, Any]:
+    """Return PLUS raw-OCR article-block diagnostics without changing output."""
+
+    lines = list(text_lines or [])
+    start, end = _article_block_bounds(lines)
+    parsed_source_indexes = _source_indexes(current_lines)
+
+    current_line_sum = sum((_money(line.get('line_total')) for line in (current_lines or [])), Decimal('0.00'))
+    current_line_discount_sum = sum((_money(line.get('discount_amount')) for line in (current_lines or [])), Decimal('0.00'))
+    current_discount_total = _money(discount_total)
+    current_total = _money(total_amount) if total_amount is not None else None
+    current_net = (current_line_sum + current_line_discount_sum + current_discount_total).quantize(Decimal('0.01'))
+
+    if current_total is None:
+        current_diff = None
+    else:
+        current_diff = (current_net - current_total).quantize(Decimal('0.01'))
+
+    candidates: list[dict[str, Any]] = []
+    article_block_lines: list[dict[str, Any]] = []
+
+    for idx in range(start, end):
+        raw = str(lines[idx] or '')
+        amounts = _amount_tokens(raw)
+        product_like = _is_product_like_article_block_line(raw)
+        already_parsed = idx in parsed_source_indexes
+
+        item = {
+            'source_index': idx,
+            'raw_line': raw,
+            'amounts': [float(value) for value in amounts],
+            'last_amount': float(amounts[-1]) if amounts else None,
+            'product_like': product_like,
+            'already_parsed': already_parsed,
+        }
+        article_block_lines.append(item)
+
+        if not product_like or already_parsed or not amounts:
+            continue
+
+        last_amount = amounts[-1]
+        net_if_added = (current_net + last_amount).quantize(Decimal('0.01'))
+        diff_if_added = None if current_total is None else (net_if_added - current_total).quantize(Decimal('0.01'))
+
+        candidates.append({
+            'source_index': idx,
+            'raw_line': raw,
+            'candidate_line_total': float(last_amount),
+            'amounts': [float(value) for value in amounts],
+            'current_diff': float(current_diff) if current_diff is not None else None,
+            'diff_if_added_last_amount': float(diff_if_added) if diff_if_added is not None else None,
+            'reason': 'unparsed_product_like_line_in_plus_article_block',
+        })
+
+    return {
+        'scope': 'PLUS profile image receipts only',
+        'mode': 'diagnose_only',
+        'article_block_start_index': start,
+        'article_block_end_index': end,
+        'article_block_line_count': max(0, end - start),
+        'current_line_count': len(current_lines or []),
+        'current_line_sum': float(current_line_sum),
+        'current_line_discount_sum': float(current_line_discount_sum),
+        'current_discount_total': float(current_discount_total),
+        'current_net': float(current_net),
+        'current_total': float(current_total) if current_total is not None else None,
+        'current_diff': float(current_diff) if current_diff is not None else None,
+        'article_block_lines': article_block_lines,
+        'unparsed_product_like_candidates': candidates,
+        'candidate_count': len(candidates),
+    }
+
+
+__all__ = ['diagnose_plus_article_block_recovery']

--- a/backend/app/receipt_ingestion/parsing/plus_bbox_activation_readiness.py
+++ b/backend/app/receipt_ingestion/parsing/plus_bbox_activation_readiness.py
@@ -1,0 +1,162 @@
+﻿"""PLUS bbox activation readiness diagnostics.
+
+Diagnose-only module.
+
+Purpose:
+- decide whether PLUS bbox reconstruction is safe enough for possible guarded runtime activation;
+- require exact financial closure;
+- block footer/payment/tax contamination in reconstructed article rows;
+- block missing subtotal/total;
+- block suspicious unused fragments unless they are harmless noise;
+- do not alter parser output or database state.
+
+No hardcoded article names, receipt IDs, filenames or receipt-specific prices.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from app.receipt_ingestion.parsing.plus_non_article_financial_corrections import (
+    diagnose_plus_non_article_financial_corrections,
+)
+
+
+_BLOCKED_ARTICLE_TEXT_RE = re.compile(
+    r'\b(?:'
+    r'pin|btw|contactless|contactiess|klantticket|terminal|merchant|poi|'
+    r'transactie|autorisatie|kaart|kaartserienummer|betaling|wisselgeld|'
+    r'leesmethode|maestro|v[\-\s]?pay|par:|eur|incl\.?|btw\s+groep|'
+    r'openingstijden|prettige|bonnr|www\.|u\s+bent\s+geholpen'
+    r')\b',
+    re.IGNORECASE,
+)
+
+_ALLOWED_UNUSED_NOISE_RE = re.compile(
+    r'^(?:'
+    r'[*.=\-\s]+|'
+    r'assa|'
+    r'.{0,2}|'
+    r'.*\b(?:inclusief\s+korting|spaarkaart|geregistreerd)\b.*'
+    r')$',
+    re.IGNORECASE,
+)
+
+_SUSPICIOUS_UNUSED_RE = re.compile(
+    r'[A-Za-zÀ-ÖØ-öø-ÿ]{3,}',
+    re.IGNORECASE,
+)
+
+
+def _normalize(value: Any) -> str:
+    return re.sub(r'\s+', ' ', str(value or '')).strip()
+
+
+def _article_blocker_reasons(article_rows: list[dict[str, Any]]) -> list[str]:
+    reasons: list[str] = []
+
+    for index, row in enumerate(article_rows, start=1):
+        line = _normalize(row.get('reconstructed_line'))
+        if not line:
+            reasons.append(f'article_row_{index}_empty')
+            continue
+
+        if _BLOCKED_ARTICLE_TEXT_RE.search(line):
+            reasons.append(f'article_row_{index}_contains_footer_payment_or_tax_text:{line}')
+
+    return reasons
+
+
+def _unused_fragment_reasons(unused_fragments: list[dict[str, Any]]) -> list[str]:
+    reasons: list[str] = []
+
+    for fragment in unused_fragments or []:
+        text = _normalize(fragment.get('text'))
+        if not text:
+            continue
+
+        if _ALLOWED_UNUSED_NOISE_RE.match(text):
+            continue
+
+        if _SUSPICIOUS_UNUSED_RE.search(text):
+            reasons.append(f'suspicious_unused_text:{text}')
+
+    return reasons
+
+
+def diagnose_plus_bbox_activation_readiness(
+    texts: list[Any],
+    boxes: list[Any],
+    runtime_lines: list[str],
+) -> dict[str, Any]:
+    diag = diagnose_plus_non_article_financial_corrections(texts, boxes, runtime_lines)
+
+    reasons: list[str] = []
+
+    article_rows = list(diag.get('article_rows') or [])
+    unused_text_fragments = list(diag.get('unused_text_fragments') or [])
+    unused_unit_fragments = list(diag.get('unused_unit_fragments') or [])
+
+    if not diag.get('exact_subtotal_match'):
+        reasons.append(f"subtotal_not_exact:diff={diag.get('diff_to_subtotal')}")
+
+    if not diag.get('exact_total_match'):
+        reasons.append(f"total_not_exact:diff={diag.get('diff_to_total')}")
+
+    if diag.get('subtotal_amount') is None:
+        reasons.append('subtotal_missing')
+
+    if diag.get('total_amount') is None:
+        reasons.append('total_missing')
+
+    if len(article_rows) <= 0:
+        reasons.append('no_article_rows')
+
+    reasons.extend(_article_blocker_reasons(article_rows))
+    reasons.extend(_unused_fragment_reasons(unused_text_fragments))
+
+    if unused_unit_fragments:
+        reasons.append(f'unused_unit_fragments_present:{len(unused_unit_fragments)}')
+
+    ready = len(reasons) == 0
+
+    return {
+        'mode': 'diagnose_only',
+        'version': 'PLUS-01K',
+        'ready_for_activation': ready,
+        'readiness_reasons': reasons,
+        'financial': {
+            'article_total': diag.get('article_total'),
+            'non_article_financial_total': diag.get('non_article_financial_total'),
+            'pre_discount_total': diag.get('pre_discount_total'),
+            'subtotal_amount': diag.get('subtotal_amount'),
+            'diff_to_subtotal': diag.get('diff_to_subtotal'),
+            'exact_subtotal_match': diag.get('exact_subtotal_match'),
+            'discount_total': diag.get('discount_total'),
+            'net_total': diag.get('net_total'),
+            'total_amount': diag.get('total_amount'),
+            'diff_to_total': diag.get('diff_to_total'),
+            'exact_total_match': diag.get('exact_total_match'),
+            'total_discount_control': diag.get('total_discount_control'),
+        },
+        'counts': {
+            'article_rows': len(article_rows),
+            'bbox_non_article_financial_rows': len(diag.get('bbox_non_article_financial_rows') or []),
+            'extra_runtime_non_article_financial_rows': len(diag.get('extra_runtime_non_article_financial_rows') or []),
+            'used_discount_rows': len([row for row in diag.get('discount_rows') or [] if row.get('used_in_total')]),
+            'unused_text_fragments': len(unused_text_fragments),
+            'unused_unit_fragments': len(unused_unit_fragments),
+        },
+        'article_rows': article_rows,
+        'bbox_non_article_financial_rows': diag.get('bbox_non_article_financial_rows') or [],
+        'extra_runtime_non_article_financial_rows': diag.get('extra_runtime_non_article_financial_rows') or [],
+        'discount_rows': diag.get('discount_rows') or [],
+        'unused_text_fragments': unused_text_fragments,
+        'unused_unit_fragments': unused_unit_fragments,
+        'chosen_total_candidate': diag.get('chosen_total_candidate'),
+        'total_candidates': diag.get('total_candidates') or [],
+    }
+
+
+__all__ = ['diagnose_plus_bbox_activation_readiness']

--- a/backend/app/receipt_ingestion/parsing/plus_bbox_activation_readiness.py
+++ b/backend/app/receipt_ingestion/parsing/plus_bbox_activation_readiness.py
@@ -7,7 +7,8 @@ Purpose:
 - require exact financial closure;
 - block footer/payment/tax contamination in reconstructed article rows;
 - block missing subtotal/total;
-- block suspicious unused fragments unless they are harmless noise;
+- block suspicious unused fragments unless they are harmless noise or already consumed financial labels;
+- document that any future activation is scoped to current, non-deleted, non-archived receipts only;
 - do not alter parser output or database state.
 
 No hardcoded article names, receipt IDs, filenames or receipt-specific prices.
@@ -48,6 +49,8 @@ _SUSPICIOUS_UNUSED_RE = re.compile(
     re.IGNORECASE,
 )
 
+_STATIEGELD_RE = re.compile(r'\bstatiegeld\b', re.IGNORECASE)
+
 
 def _normalize(value: Any) -> str:
     return re.sub(r'\s+', ' ', str(value or '')).strip()
@@ -68,8 +71,21 @@ def _article_blocker_reasons(article_rows: list[dict[str, Any]]) -> list[str]:
     return reasons
 
 
-def _unused_fragment_reasons(unused_fragments: list[dict[str, Any]]) -> list[str]:
+def _has_consumed_statiegeld(diag: dict[str, Any]) -> bool:
+    bbox_rows = list(diag.get('bbox_non_article_financial_rows') or [])
+    extra_rows = list(diag.get('extra_runtime_non_article_financial_rows') or [])
+
+    for row in bbox_rows + extra_rows:
+        raw = _normalize(row.get('reconstructed_line') or row.get('raw_line'))
+        if _STATIEGELD_RE.search(raw):
+            return True
+
+    return False
+
+
+def _unused_fragment_reasons(unused_fragments: list[dict[str, Any]], diag: dict[str, Any]) -> list[str]:
     reasons: list[str] = []
+    consumed_statiegeld = _has_consumed_statiegeld(diag)
 
     for fragment in unused_fragments or []:
         text = _normalize(fragment.get('text'))
@@ -77,6 +93,12 @@ def _unused_fragment_reasons(unused_fragments: list[dict[str, Any]]) -> list[str
             continue
 
         if _ALLOWED_UNUSED_NOISE_RE.match(text):
+            continue
+
+        # PLUS-01K-a:
+        # A leftover standalone "Statiegeld" label is harmless when a statiegeld
+        # financial row has already been consumed and the receipt is financially exact.
+        if consumed_statiegeld and _STATIEGELD_RE.fullmatch(text):
             continue
 
         if _SUSPICIOUS_UNUSED_RE.search(text):
@@ -114,7 +136,7 @@ def diagnose_plus_bbox_activation_readiness(
         reasons.append('no_article_rows')
 
     reasons.extend(_article_blocker_reasons(article_rows))
-    reasons.extend(_unused_fragment_reasons(unused_text_fragments))
+    reasons.extend(_unused_fragment_reasons(unused_text_fragments, diag))
 
     if unused_unit_fragments:
         reasons.append(f'unused_unit_fragments_present:{len(unused_unit_fragments)}')
@@ -123,7 +145,13 @@ def diagnose_plus_bbox_activation_readiness(
 
     return {
         'mode': 'diagnose_only',
-        'version': 'PLUS-01K',
+        'version': 'PLUS-01K-a',
+        'scope': {
+            'current_receipts_only': True,
+            'excludes_deleted': True,
+            'excludes_archived': True,
+            'no_bulk_backfill_without_explicit_instruction': True,
+        },
         'ready_for_activation': ready,
         'readiness_reasons': reasons,
         'financial': {

--- a/backend/app/receipt_ingestion/parsing/plus_bbox_line_reconstruction.py
+++ b/backend/app/receipt_ingestion/parsing/plus_bbox_line_reconstruction.py
@@ -1,0 +1,516 @@
+﻿"""PLUS bounding-box article-line reconstruction diagnostics.
+
+Diagnose-only module.
+
+Purpose:
+- reconstruct PLUS article lines from Paddle OCR fragments and bounding boxes;
+- use the right amount column as row anchor;
+- prevent reuse of labels and unit prices across neighbouring rows;
+- avoid bundling closely stacked receipt rows through broad y-grouping;
+- keep statiegeld as non-article financial row;
+- do not alter parser output or database state.
+
+No hardcoded article names, receipt IDs, filenames or receipt-specific prices.
+"""
+
+from __future__ import annotations
+
+import re
+from statistics import median
+from typing import Any
+
+
+_MONEY_RE = re.compile(r'[-€£CEe]?\s*\d{1,6}(?:[.,]\s?\d{2})')
+_SPLIT_DECIMAL_HEAD_RE = re.compile(r'^\s*[-€£CEe]?\s*\d+[.,]\s*$')
+_SPLIT_DECIMAL_TAIL_RE = re.compile(r'^\s*\d{2}\s*$')
+_LETTER_RE = re.compile(r'[A-Za-zÀ-ÖØ-öø-ÿ]')
+_WORD_RE = re.compile(r'[A-Za-zÀ-ÖØ-öø-ÿ]{3,}')
+_HEADER_RE = re.compile(
+    r'(?:omschrijving|onschrijving|dnschrijving|beschrijving).*(?:bedrag|p\.?\s*st|st/kg|p\s*st/kg)',
+    re.IGNORECASE,
+)
+_SUBTOTAL_RE = re.compile(r'\bsubtotaal\b', re.IGNORECASE)
+_TOTAL_RE = re.compile(r'\b(?:totaal|totael|yotaal|lotaal)\b', re.IGNORECASE)
+_ARTICLE_BLOCK_NOISE_RE = re.compile(
+    r'\b(?:klant|spaarkaart|geregistreerd)\b|^[*.=\-\s]+$',
+    re.IGNORECASE,
+)
+_NON_ARTICLE_FINANCIAL_RE = re.compile(
+    r'\b(?:statiegeld|pluspunten|digitale\s+zegels|zegel|zegels|mepal|buitenservies|buitensservies)\b',
+    re.IGNORECASE,
+)
+_UNIT_ONLY_RE = re.compile(
+    r'^\s*[-€£CEe]?\s*\d{1,6}(?:[.,]\s?\d{2})\s*(?:e\s*/?\s*kg|c\s*/?\s*kg|€/kg|kg|p\.?\s*st)?\s*$',
+    re.IGNORECASE,
+)
+
+
+def _normalize(value: Any) -> str:
+    return re.sub(r'\s+', ' ', str(value or '')).strip()
+
+
+def _bbox_rect(box: Any) -> tuple[float, float, float, float] | None:
+    try:
+        if isinstance(box, (list, tuple)) and len(box) == 4 and not isinstance(box[0], (list, tuple)):
+            x1, y1, x2, y2 = [float(v) for v in box]
+            return x1, y1, x2, y2
+
+        points: list[tuple[float, float]] = []
+        for point in box:
+            if isinstance(point, (list, tuple)) and len(point) >= 2:
+                points.append((float(point[0]), float(point[1])))
+
+        if not points:
+            return None
+
+        xs = [point[0] for point in points]
+        ys = [point[1] for point in points]
+        return min(xs), min(ys), max(xs), max(ys)
+    except Exception:
+        return None
+
+
+def _fragment_from_text_box(index: int, text: Any, box: Any) -> dict[str, Any] | None:
+    value = _normalize(text)
+    if not value:
+        return None
+
+    rect = _bbox_rect(box)
+    if rect is None:
+        x1 = float(index)
+        y1 = float(index * 20)
+        x2 = x1 + 1.0
+        y2 = y1 + 10.0
+    else:
+        x1, y1, x2, y2 = rect
+
+    height = max(1.0, y2 - y1)
+
+    return {
+        'idx': index,
+        'text': value,
+        'x1': x1,
+        'y1': y1,
+        'x2': x2,
+        'y2': y2,
+        'cx': (x1 + x2) / 2.0,
+        'cy': (y1 + y2) / 2.0,
+        'height': height,
+        'amounts': _MONEY_RE.findall(value),
+        'has_letters': bool(_LETTER_RE.search(value)),
+    }
+
+
+def _merge_split_decimal_fragments(fragments: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    ordered = sorted(fragments, key=lambda item: (item['cy'], item['x1']))
+    used: set[int] = set()
+    merged: list[dict[str, Any]] = []
+
+    for pos, current in enumerate(ordered):
+        if pos in used:
+            continue
+
+        text = current['text']
+        if not _SPLIT_DECIMAL_HEAD_RE.match(text):
+            merged.append(current)
+            continue
+
+        best_next_pos = None
+        best_score = None
+
+        for next_pos in range(pos + 1, min(pos + 5, len(ordered))):
+            candidate = ordered[next_pos]
+            if next_pos in used:
+                continue
+            if not _SPLIT_DECIMAL_TAIL_RE.match(candidate['text']):
+                continue
+
+            y_gap = abs(candidate['cy'] - current['cy'])
+            x_gap = abs(candidate['x1'] - current['x2'])
+            if y_gap > max(12.0, current['height'] * 1.2):
+                continue
+            if x_gap > 18.0:
+                continue
+
+            score = y_gap + x_gap
+            if best_score is None or score < best_score:
+                best_score = score
+                best_next_pos = next_pos
+
+        if best_next_pos is None:
+            merged.append(current)
+            continue
+
+        nxt = ordered[best_next_pos]
+        used.add(best_next_pos)
+
+        combined = dict(current)
+        combined['text'] = f"{current['text'].strip()}{nxt['text'].strip()}"
+        combined['x1'] = min(current['x1'], nxt['x1'])
+        combined['y1'] = min(current['y1'], nxt['y1'])
+        combined['x2'] = max(current['x2'], nxt['x2'])
+        combined['y2'] = max(current['y2'], nxt['y2'])
+        combined['cx'] = (combined['x1'] + combined['x2']) / 2.0
+        combined['cy'] = (combined['y1'] + combined['y2']) / 2.0
+        combined['height'] = max(1.0, combined['y2'] - combined['y1'])
+        combined['amounts'] = _MONEY_RE.findall(combined['text'])
+        combined['has_letters'] = bool(_LETTER_RE.search(combined['text']))
+        combined['idx'] = current['idx']
+        merged.append(combined)
+
+    return sorted(merged, key=lambda item: (item['cy'], item['x1']))
+
+
+def _group_for_bounds(fragments: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not fragments:
+        return []
+
+    heights = [fragment['height'] for fragment in fragments if fragment.get('height')]
+    threshold = max(12.0, (median(heights) if heights else 12.0) * 0.7)
+
+    ordered = sorted(fragments, key=lambda item: (item['cy'], item['x1']))
+    groups: list[list[dict[str, Any]]] = []
+
+    for fragment in ordered:
+        if not groups:
+            groups.append([fragment])
+            continue
+
+        current_group = groups[-1]
+        current_y = sum(part['cy'] for part in current_group) / len(current_group)
+
+        if abs(fragment['cy'] - current_y) <= threshold:
+            current_group.append(fragment)
+        else:
+            groups.append([fragment])
+
+    result: list[dict[str, Any]] = []
+    for index, group in enumerate(groups):
+        group = sorted(group, key=lambda item: item['x1'])
+        text = _normalize(' '.join(part['text'] for part in group))
+        result.append({
+            'index': index,
+            'text': text,
+            'cy_min': min(part['cy'] for part in group),
+            'cy_max': max(part['cy'] for part in group),
+            'y1_min': min(part['y1'] for part in group),
+            'y2_max': max(part['y2'] for part in group),
+            'fragments': group,
+        })
+
+    return result
+
+
+def _find_article_y_bounds(fragments: list[dict[str, Any]]) -> tuple[float, float, dict[str, Any]]:
+    groups = _group_for_bounds(fragments)
+
+    start_y = min((fragment['y1'] for fragment in fragments), default=0.0)
+    end_y = max((fragment['y2'] for fragment in fragments), default=0.0)
+
+    header_group = None
+    subtotal_group = None
+
+    for group in groups:
+        if _HEADER_RE.search(group['text']):
+            header_group = group
+            start_y = group['y2_max'] + 1.0
+            break
+
+    for group in groups:
+        if group['y1_min'] <= start_y:
+            continue
+        if _SUBTOTAL_RE.search(group['text']):
+            subtotal_group = group
+            end_y = group['y1_min'] - 1.0
+            break
+
+    return start_y, end_y, {
+        'header_text': header_group['text'] if header_group else None,
+        'subtotal_text': subtotal_group['text'] if subtotal_group else None,
+        'header_y': header_group['y2_max'] if header_group else None,
+        'subtotal_y': subtotal_group['y1_min'] if subtotal_group else None,
+    }
+
+
+def _is_noise_text(value: str) -> bool:
+    text = _normalize(value)
+    if not text:
+        return True
+    if _ARTICLE_BLOCK_NOISE_RE.search(text):
+        return True
+    if _HEADER_RE.search(text) or _SUBTOTAL_RE.search(text) or _TOTAL_RE.search(text):
+        return True
+    return False
+
+
+def _is_pure_amount_fragment(fragment: dict[str, Any]) -> bool:
+    text = fragment['text'].strip()
+    return bool(_MONEY_RE.fullmatch(text)) and not fragment['has_letters']
+
+
+def _is_unit_only_fragment(fragment: dict[str, Any]) -> bool:
+    text = _normalize(fragment.get('text'))
+    if not text:
+        return False
+    return bool(_UNIT_ONLY_RE.match(text))
+
+
+def _is_label_candidate(fragment: dict[str, Any]) -> bool:
+    text = _normalize(fragment.get('text'))
+    if _is_noise_text(text):
+        return False
+    if not fragment.get('has_letters'):
+        return False
+
+    if _is_unit_only_fragment(fragment):
+        return False
+
+    words = _WORD_RE.findall(text)
+    if len(words) >= 1:
+        return True
+
+    return False
+
+
+def _clean_label_text(value: str) -> str:
+    text = _normalize(value)
+    text = re.sub(r'\s+', ' ', text)
+    return text.strip(' .:-')
+
+
+def _last_amount_text(value: str) -> str | None:
+    matches = list(_MONEY_RE.finditer(value or ''))
+    if not matches:
+        return None
+    return matches[-1].group(0).strip()
+
+
+def _choose_right_amount_anchors(article_fragments: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    amount_fragments = [
+        fragment for fragment in article_fragments
+        if _is_pure_amount_fragment(fragment)
+    ]
+
+    if not amount_fragments:
+        return []
+
+    max_cx = max(fragment['cx'] for fragment in amount_fragments)
+    right_threshold = max_cx - 45.0
+
+    anchors = [
+        fragment for fragment in amount_fragments
+        if fragment['cx'] >= right_threshold
+    ]
+
+    return sorted(anchors, key=lambda item: (item['cy'], item['x1']))
+
+
+def _score_label_for_anchor(
+    anchor: dict[str, Any],
+    label: dict[str, Any],
+    used_label_indexes: set[int],
+) -> float | None:
+    if label['idx'] in used_label_indexes:
+        return None
+
+    if label['x1'] >= anchor['x1'] - 8.0:
+        return None
+
+    row_tolerance = max(9.0, anchor['height'] * 0.75)
+    y_distance = abs(label['cy'] - anchor['cy'])
+
+    if y_distance > row_tolerance:
+        return None
+
+    x_distance = max(0.0, anchor['x1'] - label['x2'])
+
+    # Small penalty for labels much farther left, but y-position dominates.
+    return (y_distance * 10.0) + (x_distance * 0.03)
+
+
+def _nearest_label_fragment(
+    anchor: dict[str, Any],
+    article_fragments: list[dict[str, Any]],
+    used_label_indexes: set[int],
+) -> dict[str, Any] | None:
+    candidates: list[tuple[float, dict[str, Any]]] = []
+
+    for fragment in article_fragments:
+        if fragment is anchor:
+            continue
+        if not _is_label_candidate(fragment):
+            continue
+
+        score = _score_label_for_anchor(anchor, fragment, used_label_indexes)
+        if score is None:
+            continue
+
+        candidates.append((score, fragment))
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda item: item[0])
+    return candidates[0][1]
+
+
+def _nearest_unit_fragment(
+    anchor: dict[str, Any],
+    label: dict[str, Any] | None,
+    article_fragments: list[dict[str, Any]],
+    anchor_indexes: set[int],
+    used_unit_indexes: set[int],
+) -> dict[str, Any] | None:
+    if label is None:
+        return None
+
+    candidates: list[tuple[float, float, dict[str, Any]]] = []
+
+    # Stricter than label matching to avoid borrowing the unit price from a row above/below.
+    unit_row_tolerance = max(7.0, anchor['height'] * 0.45)
+    label_x2 = label['x2']
+
+    for fragment in article_fragments:
+        if fragment is anchor or fragment is label:
+            continue
+        if fragment['idx'] in used_unit_indexes:
+            continue
+        if fragment['idx'] in anchor_indexes:
+            continue
+        if not fragment.get('amounts'):
+            continue
+        if not _is_unit_only_fragment(fragment):
+            continue
+
+        if fragment['x1'] < label_x2 - 5.0:
+            continue
+        if fragment['x2'] >= anchor['x1'] + 5.0:
+            continue
+
+        y_distance = abs(fragment['cy'] - anchor['cy'])
+        if y_distance > unit_row_tolerance:
+            continue
+
+        x_distance = max(0.0, anchor['x1'] - fragment['x2'])
+        candidates.append((y_distance, x_distance, fragment))
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda item: (item[0], item[1]))
+    return candidates[0][2]
+
+
+def diagnose_plus_bbox_article_reconstruction(
+    texts: list[Any],
+    boxes: list[Any],
+) -> dict[str, Any]:
+    raw_fragments: list[dict[str, Any]] = []
+
+    for index, text in enumerate(texts or []):
+        box = boxes[index] if boxes is not None and index < len(boxes) else None
+        fragment = _fragment_from_text_box(index, text, box)
+        if fragment is not None:
+            raw_fragments.append(fragment)
+
+    fragments = _merge_split_decimal_fragments(raw_fragments)
+    start_y, end_y, bounds = _find_article_y_bounds(fragments)
+
+    article_fragments = [
+        fragment for fragment in fragments
+        if fragment['cy'] >= start_y and fragment['cy'] <= end_y
+    ]
+
+    anchors = _choose_right_amount_anchors(article_fragments)
+    anchor_indexes = {anchor['idx'] for anchor in anchors}
+
+    rows: list[dict[str, Any]] = []
+    used_label_indexes: set[int] = set()
+    used_unit_indexes: set[int] = set()
+
+    for anchor in anchors:
+        label = _nearest_label_fragment(anchor, article_fragments, used_label_indexes)
+        unit = _nearest_unit_fragment(anchor, label, article_fragments, anchor_indexes, used_unit_indexes)
+
+        if label is None:
+            continue
+
+        label_text = _clean_label_text(label['text'])
+        unit_text = _clean_label_text(unit['text']) if unit is not None else ''
+        amount_text = _last_amount_text(anchor['text']) or anchor['text']
+
+        if not label_text:
+            continue
+
+        classification = 'non_article_financial' if _NON_ARTICLE_FINANCIAL_RE.search(label_text) else 'article_candidate'
+
+        reconstructed_parts = [label_text]
+        if unit_text and unit_text not in label_text:
+            reconstructed_parts.append(unit_text)
+        reconstructed_parts.append(amount_text)
+
+        rows.append({
+            'classification': classification,
+            'reconstructed_line': _normalize(' '.join(reconstructed_parts)),
+            'label': label_text,
+            'unit_or_weight': unit_text or None,
+            'amount': amount_text,
+            'anchor_idx': anchor['idx'],
+            'label_idx': label['idx'],
+            'unit_idx': unit['idx'] if unit is not None else None,
+            'anchor_y': round(anchor['cy'], 1),
+            'label_y': round(label['cy'], 1),
+            'unit_y': round(unit['cy'], 1) if unit is not None else None,
+            'y_delta_label': round(abs(label['cy'] - anchor['cy']), 1),
+            'source_fragments': {
+                'label': label['text'],
+                'unit_or_weight': unit['text'] if unit is not None else None,
+                'amount': anchor['text'],
+            },
+        })
+
+        used_label_indexes.add(label['idx'])
+        if unit is not None:
+            used_unit_indexes.add(unit['idx'])
+
+    unused_text_fragments = [
+        {
+            'idx': fragment['idx'],
+            'text': fragment['text'],
+            'x1': round(fragment['x1'], 1),
+            'x2': round(fragment['x2'], 1),
+            'cy': round(fragment['cy'], 1),
+        }
+        for fragment in article_fragments
+        if _is_label_candidate(fragment)
+        and fragment['idx'] not in used_label_indexes
+    ]
+
+    unused_unit_fragments = [
+        {
+            'idx': fragment['idx'],
+            'text': fragment['text'],
+            'x1': round(fragment['x1'], 1),
+            'x2': round(fragment['x2'], 1),
+            'cy': round(fragment['cy'], 1),
+        }
+        for fragment in article_fragments
+        if _is_unit_only_fragment(fragment)
+        and fragment['idx'] not in used_unit_indexes
+        and fragment['idx'] not in anchor_indexes
+    ]
+
+    return {
+        'mode': 'diagnose_only',
+        'version': 'PLUS-01G',
+        'bounds': bounds,
+        'fragment_count': len(fragments),
+        'article_fragment_count': len(article_fragments),
+        'right_amount_anchor_count': len(anchors),
+        'rows': rows,
+        'unused_text_fragments': unused_text_fragments,
+        'unused_unit_fragments': unused_unit_fragments,
+    }
+
+
+__all__ = ['diagnose_plus_bbox_article_reconstruction']

--- a/backend/app/receipt_ingestion/parsing/plus_correction_runtime.py
+++ b/backend/app/receipt_ingestion/parsing/plus_correction_runtime.py
@@ -13,6 +13,7 @@ Technical Design Reference:
 
 from __future__ import annotations
 
+import re
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Any
 
@@ -23,6 +24,8 @@ from typing import Any
 
 from app.receipt_ingestion.profiles.plus.corrections import apply_plus_runtime_corrections as _base_apply_plus_runtime_corrections
 
+_SUMMARY_AMOUNT_RE = re.compile(r'[€£CE]?-?\d{1,6}(?:[\.,]\d{2})', re.IGNORECASE)
+
 
 def _money(value: Any) -> Decimal:
     if value is None or value == '':
@@ -31,6 +34,28 @@ def _money(value: Any) -> Decimal:
         return Decimal(str(value)).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
     except Exception:
         return Decimal('0.00')
+
+
+def _parse_summary_amount_token(value: str) -> Decimal | None:
+    raw = str(value or '').upper().replace('€', '').replace('£', '').strip()
+    raw = raw.replace('C', '').replace('E', '').replace(',', '.')
+    try:
+        return Decimal(raw).copy_abs().quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+    except Exception:
+        return None
+
+
+def _summary_discount_amounts(text_lines: list[str] | None) -> set[Decimal]:
+    amounts: set[Decimal] = set()
+    for raw_line in text_lines or []:
+        compact = re.sub(r'[^a-z0-9]+', '', str(raw_line or '').lower())
+        if 'totalekortingis' not in compact and 'detotalekortingis' not in compact:
+            continue
+        for token in _SUMMARY_AMOUNT_RE.findall(str(raw_line or '')):
+            parsed = _parse_summary_amount_token(token)
+            if parsed is not None and parsed > Decimal('0.00'):
+                amounts.add(parsed)
+    return amounts
 
 
 def _sanitize_implausible_plus_line_discounts(lines: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
@@ -61,14 +86,47 @@ def _sanitize_implausible_plus_line_discounts(lines: list[dict[str, Any]]) -> tu
     return sanitized, removed
 
 
+def _sanitize_summary_plus_line_discounts(lines: list[dict[str, Any]], summary_amounts: set[Decimal]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    if not summary_amounts:
+        return lines, []
+    sanitized: list[dict[str, Any]] = []
+    removed: list[dict[str, Any]] = []
+    for line in lines:
+        adjusted = dict(line)
+        discount = _money(adjusted.get('discount_amount'))
+        if discount < Decimal('0.00') and abs(discount) in summary_amounts:
+            removed.append({
+                'target_label': adjusted.get('raw_label') or adjusted.get('normalized_label'),
+                'removed_discount_amount': float(discount),
+                'reason': 'discount_equals_summary_discount_total',
+            })
+            adjusted['discount_amount'] = None
+            trace = dict(adjusted.get('producer_trace') or {})
+            trace['plus_summary_discount_removed'] = {
+                'applied': True,
+                'removed_discount_amount': float(discount),
+                'reason': 'discount_equals_summary_discount_total',
+                'source': 'PLUS_summary_discount_guardrail',
+            }
+            adjusted['producer_trace'] = trace
+        sanitized.append(adjusted)
+    return sanitized, removed
+
+
 def apply_plus_runtime_corrections(**kwargs: Any):
     lines, discount_total, diagnostics = _base_apply_plus_runtime_corrections(**kwargs)
-    sanitized_lines, removed = _sanitize_implausible_plus_line_discounts(lines)
-    if removed:
+    sanitized_lines, removed_implausible = _sanitize_implausible_plus_line_discounts(lines)
+    summary_amounts = _summary_discount_amounts(kwargs.get('text_lines'))
+    sanitized_lines, removed_summary = _sanitize_summary_plus_line_discounts(sanitized_lines, summary_amounts)
+    if removed_implausible or removed_summary:
         diagnostics = dict(diagnostics or {})
         plus_diag = dict(diagnostics.get('r9_38c3a_plus_subtotal_correction_recovery') or {})
-        plus_diag['implausible_line_discount_guardrail_applied'] = True
-        plus_diag['removed_implausible_line_discounts'] = removed
+        if removed_implausible:
+            plus_diag['implausible_line_discount_guardrail_applied'] = True
+            plus_diag['removed_implausible_line_discounts'] = removed_implausible
+        if removed_summary:
+            plus_diag['summary_line_discount_guardrail_applied'] = True
+            plus_diag['removed_summary_line_discounts'] = removed_summary
         diagnostics['r9_38c3a_plus_subtotal_correction_recovery'] = plus_diag
     return sanitized_lines, discount_total, diagnostics
 

--- a/backend/app/receipt_ingestion/parsing/plus_correction_runtime.py
+++ b/backend/app/receipt_ingestion/parsing/plus_correction_runtime.py
@@ -13,11 +13,64 @@ Technical Design Reference:
 
 from __future__ import annotations
 
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any
+
 # R9-38C1a:
 # Backwards-compatible wrapper. PLUS-specific runtime correction logic has moved
 # to app.receipt_ingestion.profiles.plus.corrections.
 # Remove this wrapper after receipt_service.py imports the PLUS profile directly.
 
-from app.receipt_ingestion.profiles.plus.corrections import apply_plus_runtime_corrections
+from app.receipt_ingestion.profiles.plus.corrections import apply_plus_runtime_corrections as _base_apply_plus_runtime_corrections
+
+
+def _money(value: Any) -> Decimal:
+    if value is None or value == '':
+        return Decimal('0.00')
+    try:
+        return Decimal(str(value)).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+    except Exception:
+        return Decimal('0.00')
+
+
+def _sanitize_implausible_plus_line_discounts(lines: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    sanitized: list[dict[str, Any]] = []
+    removed: list[dict[str, Any]] = []
+    for line in lines:
+        adjusted = dict(line)
+        line_total = abs(_money(adjusted.get('line_total')))
+        discount = _money(adjusted.get('discount_amount'))
+        if discount < Decimal('0.00') and line_total > Decimal('0.00') and abs(discount) > line_total + Decimal('0.02'):
+            removed.append({
+                'target_label': adjusted.get('raw_label') or adjusted.get('normalized_label'),
+                'line_total': float(line_total),
+                'removed_discount_amount': float(discount),
+                'reason': 'discount_exceeds_line_total',
+            })
+            adjusted['discount_amount'] = None
+            trace = dict(adjusted.get('producer_trace') or {})
+            trace['plus_implausible_discount_removed'] = {
+                'applied': True,
+                'line_total': float(line_total),
+                'removed_discount_amount': float(discount),
+                'reason': 'discount_exceeds_line_total',
+                'source': 'PLUS_runtime_guardrail',
+            }
+            adjusted['producer_trace'] = trace
+        sanitized.append(adjusted)
+    return sanitized, removed
+
+
+def apply_plus_runtime_corrections(**kwargs: Any):
+    lines, discount_total, diagnostics = _base_apply_plus_runtime_corrections(**kwargs)
+    sanitized_lines, removed = _sanitize_implausible_plus_line_discounts(lines)
+    if removed:
+        diagnostics = dict(diagnostics or {})
+        plus_diag = dict(diagnostics.get('r9_38c3a_plus_subtotal_correction_recovery') or {})
+        plus_diag['implausible_line_discount_guardrail_applied'] = True
+        plus_diag['removed_implausible_line_discounts'] = removed
+        diagnostics['r9_38c3a_plus_subtotal_correction_recovery'] = plus_diag
+    return sanitized_lines, discount_total, diagnostics
+
 
 __all__ = ["apply_plus_runtime_corrections"]

--- a/backend/app/receipt_ingestion/parsing/plus_non_article_financial_corrections.py
+++ b/backend/app/receipt_ingestion/parsing/plus_non_article_financial_corrections.py
@@ -1,0 +1,445 @@
+﻿"""PLUS non-article financial correction diagnostics.
+
+Diagnose-only module.
+
+Purpose:
+- financially validate PLUS bbox reconstructed article rows;
+- include non-article financial corrections:
+  - statiegeld in the article block;
+  - PLUSpunten / digital points;
+  - zegel / spaaraction lines;
+  - action discounts between Subtotaal and Totaal;
+- keep "DE TOTALE KORTING IS" as control-only;
+- do not alter parser output or database state.
+
+No hardcoded article names, receipt IDs, filenames or receipt-specific prices.
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from typing import Any
+
+from app.receipt_ingestion.parsing.plus_bbox_line_reconstruction import (
+    diagnose_plus_bbox_article_reconstruction,
+)
+
+
+_MONEY_RE = re.compile(r'[-€£CEe]?\s*\d{1,6}(?:[.,]\s?\d{2})')
+_SUBTOTAL_RE = re.compile(r'\bsubtotaal\b', re.IGNORECASE)
+_TOTAL_RE = re.compile(r'\b(?:totaal|totael|yotaal|lotaal)\b', re.IGNORECASE)
+_TOTAL_DISCOUNT_RE = re.compile(r'\b(?:totale\s+korting|de\s+totale\s+korting)\b', re.IGNORECASE)
+_DISCOUNT_RE = re.compile(r'\b(?:actie|aktie|korting|voordeel)\b', re.IGNORECASE)
+_PLUSPOINTS_RE = re.compile(r'\b(?:pluspunten|pluspunten digitaal|piuspunten)\b', re.IGNORECASE)
+_STAMPS_RE = re.compile(r'\b(?:zegel|zegels|mepal|buitenservies|buitensservies|buitens ervies)\b', re.IGNORECASE)
+_STATIEGELD_RE = re.compile(r'\bstatiegeld\b', re.IGNORECASE)
+_NON_ARTICLE_FINANCIAL_RE = re.compile(
+    r'\b(?:statiegeld|pluspunten|piuspunten|digitale\s+zegels|zegel|zegels|mepal|buitenservies|buitensservies|buitens ervies)\b',
+    re.IGNORECASE,
+)
+_PAYMENT_OR_FOOTER_RE = re.compile(
+    r'\b(?:klantticket|terminal|merchant|transactie|autorisatie|betaling|contactless|contactiess|leesmethode|wisselgeld|btw|kaart|pin|poi|par:|openingstijden|prettige|bonnr|www\.)\b',
+    re.IGNORECASE,
+)
+
+
+def _normalize(value: Any) -> str:
+    return re.sub(r'\s+', ' ', str(value or '')).strip()
+
+
+def _to_decimal(value: Any) -> Decimal:
+    cleaned = str(value or '').strip()
+    cleaned = cleaned.replace('€', '').replace('£', '')
+    cleaned = re.sub(r'^[CEe]\s*', '', cleaned)
+    cleaned = re.sub(r'\s+', '', cleaned)
+    cleaned = cleaned.replace(',', '.')
+    try:
+        return Decimal(cleaned).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+    except (InvalidOperation, ValueError):
+        return Decimal('0.00')
+
+
+def _amount_tokens(raw: str) -> list[Decimal]:
+    return [_to_decimal(match.group(0)) for match in _MONEY_RE.finditer(str(raw or ''))]
+
+
+def _signed_amounts_from_line(raw: str) -> list[Decimal]:
+    text = _normalize(raw)
+    lowered = text.lower()
+    signed: list[Decimal] = []
+
+    for match in _MONEY_RE.finditer(text):
+        token = match.group(0)
+        amount = _to_decimal(token)
+        prefix = text[max(0, match.start() - 5):match.start()]
+
+        if '-' in token or '-' in prefix:
+            amount = -abs(amount)
+        elif _DISCOUNT_RE.search(lowered):
+            amount = -abs(amount)
+
+        signed.append(amount.quantize(Decimal('0.01')))
+
+    return signed
+
+
+def _find_subtotal_index(lines: list[str]) -> int | None:
+    for index, line in enumerate(lines):
+        if _SUBTOTAL_RE.search(line or ''):
+            return index
+    return None
+
+
+def _find_footer_index(lines: list[str], start_index: int | None) -> int:
+    start = 0 if start_index is None else start_index + 1
+    for index in range(start, len(lines)):
+        if _PAYMENT_OR_FOOTER_RE.search(lines[index] or ''):
+            return index
+    return len(lines)
+
+
+def _extract_subtotal(lines: list[str], subtotal_index: int | None) -> Decimal | None:
+    if subtotal_index is None or subtotal_index >= len(lines):
+        return None
+
+    amounts = _amount_tokens(lines[subtotal_index])
+    return amounts[-1] if amounts else None
+
+
+def _find_total_candidates(lines: list[str], subtotal_index: int | None) -> list[dict[str, Any]]:
+    if subtotal_index is None:
+        return []
+
+    footer_index = _find_footer_index(lines, subtotal_index)
+    candidates: list[dict[str, Any]] = []
+
+    for index in range(subtotal_index + 1, footer_index):
+        raw = lines[index] or ''
+        text = _normalize(raw)
+        if not text:
+            continue
+        if _TOTAL_DISCOUNT_RE.search(text):
+            continue
+
+        amounts = _amount_tokens(text)
+        if not amounts:
+            continue
+
+        if _TOTAL_RE.search(text):
+            candidates.append({
+                'source_index': index,
+                'raw_line': text,
+                'amount': amounts[-1],
+                'reason': 'explicit_total_label',
+            })
+            continue
+
+        if len(amounts) == 1 and not _DISCOUNT_RE.search(text) and not _NON_ARTICLE_FINANCIAL_RE.search(text):
+            # PLUS photo OCR can return the total as a bare amount line, e.g. "E45,14".
+            if re.fullmatch(r'[€£CEe]?\s*\d{1,6}(?:[.,]\s?\d{2})', text):
+                candidates.append({
+                    'source_index': index,
+                    'raw_line': text,
+                    'amount': amounts[-1],
+                    'reason': 'bare_amount_total_candidate',
+                })
+
+    return candidates
+
+
+def _choose_total_amount(
+    candidates: list[dict[str, Any]],
+    expected_net: Decimal | None,
+) -> tuple[Decimal | None, dict[str, Any] | None]:
+    if not candidates:
+        return None, None
+
+    explicit = [candidate for candidate in candidates if candidate.get('reason') == 'explicit_total_label']
+    pool = explicit if explicit else candidates
+
+    if expected_net is None:
+        chosen = pool[0]
+        return chosen['amount'], chosen
+
+    chosen = min(pool, key=lambda candidate: abs(candidate['amount'] - expected_net))
+    return chosen['amount'], chosen
+
+
+def _runtime_article_block(lines: list[str]) -> list[tuple[int, str]]:
+    start = None
+    end = None
+
+    for index, line in enumerate(lines):
+        low = (line or '').lower()
+        if ('omschrijving' in low or 'onschrijving' in low or 'dnschrijving' in low) and 'bedrag' in low:
+            start = index + 1
+            break
+
+    if start is None:
+        return []
+
+    for index in range(start, len(lines)):
+        if _SUBTOTAL_RE.search(lines[index] or ''):
+            end = index
+            break
+
+    if end is None:
+        end = len(lines)
+
+    return [(index, lines[index]) for index in range(start, end)]
+
+
+def _collect_extra_statiegeld_from_runtime(
+    runtime_lines: list[str],
+    already_used_amounts: list[Decimal],
+) -> tuple[list[dict[str, Any]], Decimal]:
+    rows: list[dict[str, Any]] = []
+    total = Decimal('0.00')
+    remaining_used = list(already_used_amounts)
+
+    for source_index, raw in _runtime_article_block(runtime_lines):
+        text = _normalize(raw)
+        if not _STATIEGELD_RE.search(text):
+            continue
+
+        # Only standalone statiegeld lines are added here.
+        # Mixed article+statiegeld rows are handled by bbox rows if they were paired.
+        if not text.lower().startswith('statiegeld'):
+            continue
+
+        amounts = _amount_tokens(text)
+        if not amounts:
+            continue
+
+        amount = amounts[-1]
+
+        # Avoid double counting values that bbox already used as non-article financial.
+        matched_existing = False
+        for idx, used in enumerate(remaining_used):
+            if used == amount:
+                matched_existing = True
+                remaining_used.pop(idx)
+                break
+
+        if matched_existing:
+            continue
+
+        rows.append({
+            'source_index': source_index,
+            'classification': 'runtime_article_block_statiegeld',
+            'raw_line': text,
+            'amount': float(amount),
+            'used_in_financial_total': True,
+        })
+        total += amount
+
+    return rows, total.quantize(Decimal('0.01'))
+
+
+def _collect_discount_block(
+    lines: list[str],
+    subtotal_index: int | None,
+) -> tuple[list[dict[str, Any]], Decimal, Decimal | None]:
+    if subtotal_index is None:
+        return [], Decimal('0.00'), None
+
+    footer_index = _find_footer_index(lines, subtotal_index)
+    rows: list[dict[str, Any]] = []
+    discount_total = Decimal('0.00')
+    total_discount_control: Decimal | None = None
+
+    for index in range(subtotal_index + 1, footer_index):
+        raw = lines[index] or ''
+        text = _normalize(raw)
+
+        if not text:
+            continue
+
+        signed_amounts = _signed_amounts_from_line(text)
+        plain_amounts = _amount_tokens(text)
+
+        if not plain_amounts:
+            continue
+
+        if _TOTAL_DISCOUNT_RE.search(text):
+            total_discount_control = abs(signed_amounts[-1]) if signed_amounts else abs(plain_amounts[-1])
+            rows.append({
+                'source_index': index,
+                'classification': 'total_discount_control_only',
+                'raw_line': text,
+                'amounts': [float(amount) for amount in signed_amounts],
+                'line_total': 0.0,
+                'used_in_total': False,
+            })
+            continue
+
+        if _PLUSPOINTS_RE.search(text):
+            # Generic PLUS interpretation:
+            # - one amount on PLUSpunten line => positive financial correction;
+            # - multiple amounts => first is promo/action value, last is points/stamps correction.
+            if len(plain_amounts) == 1:
+                line_total = abs(plain_amounts[-1])
+                used_amounts = [line_total]
+            else:
+                discount_part = -abs(plain_amounts[0])
+                correction_part = abs(plain_amounts[-1])
+                line_total = (discount_part + correction_part).quantize(Decimal('0.01'))
+                used_amounts = [discount_part, correction_part]
+
+            discount_total += line_total
+            rows.append({
+                'source_index': index,
+                'classification': 'pluspoints_financial_correction',
+                'raw_line': text,
+                'amounts': [float(amount) for amount in used_amounts],
+                'line_total': float(line_total),
+                'used_in_total': True,
+            })
+            continue
+
+        if _DISCOUNT_RE.search(text):
+            used_amounts = [amount for amount in signed_amounts if amount < Decimal('0.00')]
+            if not used_amounts:
+                used_amounts = [-abs(plain_amounts[-1])]
+
+            line_total = sum(used_amounts, Decimal('0.00')).quantize(Decimal('0.01'))
+            discount_total += line_total
+
+            rows.append({
+                'source_index': index,
+                'classification': 'discount',
+                'raw_line': text,
+                'amounts': [float(amount) for amount in used_amounts],
+                'line_total': float(line_total),
+                'used_in_total': True,
+            })
+            continue
+
+        if _STAMPS_RE.search(text) or _NON_ARTICLE_FINANCIAL_RE.search(text):
+            negative_amounts = [amount for amount in signed_amounts if amount < Decimal('0.00')]
+            positive_amounts = [abs(amount) for amount in signed_amounts if amount > Decimal('0.00')]
+
+            if negative_amounts:
+                used_amounts = negative_amounts
+            elif positive_amounts and len(positive_amounts) == 1:
+                used_amounts = positive_amounts
+            else:
+                used_amounts = []
+
+            line_total = sum(used_amounts, Decimal('0.00')).quantize(Decimal('0.01'))
+            if line_total != Decimal('0.00'):
+                discount_total += line_total
+
+            rows.append({
+                'source_index': index,
+                'classification': 'non_article_financial_correction',
+                'raw_line': text,
+                'amounts': [float(amount) for amount in used_amounts],
+                'line_total': float(line_total),
+                'used_in_total': line_total != Decimal('0.00'),
+            })
+
+    return rows, discount_total.quantize(Decimal('0.01')), total_discount_control
+
+
+def _row_amount(row: dict[str, Any]) -> Decimal:
+    return _to_decimal(row.get('amount'))
+
+
+def diagnose_plus_non_article_financial_corrections(
+    texts: list[Any],
+    boxes: list[Any],
+    runtime_lines: list[str],
+) -> dict[str, Any]:
+    bbox_diag = diagnose_plus_bbox_article_reconstruction(texts, boxes)
+
+    article_rows: list[dict[str, Any]] = []
+    non_article_rows: list[dict[str, Any]] = []
+
+    for row in bbox_diag.get('rows') or []:
+        amount = _row_amount(row)
+        normalized = dict(row)
+        normalized['amount_decimal'] = amount
+
+        if row.get('classification') == 'non_article_financial':
+            non_article_rows.append(normalized)
+        else:
+            article_rows.append(normalized)
+
+    article_total = sum((row['amount_decimal'] for row in article_rows), Decimal('0.00')).quantize(Decimal('0.01'))
+    bbox_non_article_total = sum((row['amount_decimal'] for row in non_article_rows), Decimal('0.00')).quantize(Decimal('0.01'))
+
+    extra_statiegeld_rows, extra_statiegeld_total = _collect_extra_statiegeld_from_runtime(
+        runtime_lines=runtime_lines,
+        already_used_amounts=[row['amount_decimal'] for row in non_article_rows],
+    )
+
+    non_article_financial_total = (bbox_non_article_total + extra_statiegeld_total).quantize(Decimal('0.01'))
+
+    lines = list(runtime_lines or [])
+    subtotal_index = _find_subtotal_index(lines)
+    subtotal_amount = _extract_subtotal(lines, subtotal_index)
+
+    discount_rows, discount_total, total_discount_control = _collect_discount_block(lines, subtotal_index)
+
+    pre_discount_total = (article_total + non_article_financial_total).quantize(Decimal('0.01'))
+    net_total = (pre_discount_total + discount_total).quantize(Decimal('0.01'))
+
+    total_candidates = _find_total_candidates(lines, subtotal_index)
+    total_amount, chosen_total = _choose_total_amount(total_candidates, net_total)
+
+    diff_to_subtotal = None
+    if subtotal_amount is not None:
+        diff_to_subtotal = (pre_discount_total - subtotal_amount).quantize(Decimal('0.01'))
+
+    diff_to_total = None
+    if total_amount is not None:
+        diff_to_total = (net_total - total_amount).quantize(Decimal('0.01'))
+
+    return {
+        'mode': 'diagnose_only',
+        'version': 'PLUS-01I',
+        'bbox_version': bbox_diag.get('version'),
+        'bounds': bbox_diag.get('bounds'),
+        'article_rows': [
+            {k: v for k, v in row.items() if k != 'amount_decimal'}
+            for row in article_rows
+        ],
+        'bbox_non_article_financial_rows': [
+            {k: v for k, v in row.items() if k != 'amount_decimal'}
+            for row in non_article_rows
+        ],
+        'extra_runtime_non_article_financial_rows': extra_statiegeld_rows,
+        'discount_rows': discount_rows,
+        'article_total': float(article_total),
+        'bbox_non_article_financial_total': float(bbox_non_article_total),
+        'extra_runtime_non_article_financial_total': float(extra_statiegeld_total),
+        'non_article_financial_total': float(non_article_financial_total),
+        'pre_discount_total': float(pre_discount_total),
+        'discount_total': float(discount_total),
+        'net_total': float(net_total),
+        'subtotal_amount': float(subtotal_amount) if subtotal_amount is not None else None,
+        'total_amount': float(total_amount) if total_amount is not None else None,
+        'chosen_total_candidate': {
+            **chosen_total,
+            'amount': float(chosen_total['amount']),
+        } if chosen_total is not None else None,
+        'total_candidates': [
+            {
+                **candidate,
+                'amount': float(candidate['amount']),
+            }
+            for candidate in total_candidates
+        ],
+        'total_discount_control': float(total_discount_control) if total_discount_control is not None else None,
+        'diff_to_subtotal': float(diff_to_subtotal) if diff_to_subtotal is not None else None,
+        'diff_to_total': float(diff_to_total) if diff_to_total is not None else None,
+        'exact_subtotal_match': diff_to_subtotal == Decimal('0.00') if diff_to_subtotal is not None else False,
+        'exact_total_match': diff_to_total == Decimal('0.00') if diff_to_total is not None else False,
+        'unused_text_fragments': bbox_diag.get('unused_text_fragments') or [],
+        'unused_unit_fragments': bbox_diag.get('unused_unit_fragments') or [],
+    }
+
+
+__all__ = ['diagnose_plus_non_article_financial_corrections']

--- a/backend/app/receipt_ingestion/service_parts/image_ocr_flow.py
+++ b/backend/app/receipt_ingestion/service_parts/image_ocr_flow.py
@@ -40,6 +40,20 @@ except Exception:  # pragma: no cover
 
 LOGGER = logging.getLogger(__name__)
 _PADDLE_OCR_INSTANCE = None
+_LAST_PADDLE_BBOX_PAYLOAD: dict[str, dict[str, Any]] = {}
+
+
+def get_last_paddle_bbox_payload(filename: str | None) -> dict[str, Any] | None:
+    """Return last Paddle OCR texts/boxes captured for this filename.
+
+    Runtime Type: internal cache.
+    This does not run OCR and does not modify parser decisions.
+    """
+    if not filename:
+        return None
+    return _LAST_PADDLE_BBOX_PAYLOAD.get(str(filename))
+
+
 _PLUS_IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.webp', '.bmp', '.tif', '.tiff'}
 _PLUS_ROW_STOP_TOKENS = ('subtotaal', 'totaal', 'btw', 'pin', 'contactless', 'contactiess', 'transactie', 'wisselgeld')
 _PLUS_ROW_DISCOUNT_TOKENS = ('actie', 'korting', 'voordeel', 'plus geeft')
@@ -313,6 +327,14 @@ def _ocr_image_text_with_paddle(file_bytes: bytes, filename: str) -> tuple[list[
             except (TypeError, ValueError):
                 continue
         boxes.extend(current_boxes[: len(normalized_texts)])
+
+    # PLUS-01L-c bbox payload cache:
+    # Store Paddle texts/boxes so receipt_service can build a structured PLUS result
+    # without running OCR again and without forcing bbox rows through text parsing.
+    _LAST_PADDLE_BBOX_PAYLOAD[str(filename)] = {
+        'texts': list(texts),
+        'boxes': list(boxes),
+    }
 
     line_candidates = _group_paddle_texts_to_lines(texts, boxes if boxes else None)
     line_candidates = _apply_plus_merged_text_line_split(filename, line_candidates)

--- a/backend/app/receipt_ingestion/service_parts/image_ocr_flow.py
+++ b/backend/app/receipt_ingestion/service_parts/image_ocr_flow.py
@@ -40,6 +40,11 @@ except Exception:  # pragma: no cover
 
 LOGGER = logging.getLogger(__name__)
 _PADDLE_OCR_INSTANCE = None
+_PLUS_IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.webp', '.bmp', '.tif', '.tiff'}
+_PLUS_ROW_STOP_TOKENS = ('subtotaal', 'totaal', 'btw', 'pin', 'contactless', 'contactiess', 'transactie', 'wisselgeld')
+_PLUS_ROW_DISCOUNT_TOKENS = ('actie', 'korting', 'voordeel', 'plus geeft')
+_PLUS_AMOUNT_TOKEN_RE = re.compile(r'(?<!\d)(?:[€CE£]?-?\d{1,6}(?:[\.,]\s?\d{2})|0[\.,]\s?25)(?!\d)', re.IGNORECASE)
+_PLUS_QTY_TOKEN_RE = re.compile(r'(?<![A-Za-z0-9])\d{1,3}\s*[xX]\b')
 
 
 def _get_paddle_ocr():
@@ -185,6 +190,92 @@ def _normalize_paddle_collection(value: Any) -> list[Any]:
         return [value]
 
 
+def _is_plus_image_line_set(filename: str, lines: list[str]) -> bool:
+    suffix = Path(filename or '').suffix.lower()
+    if suffix not in _PLUS_IMAGE_EXTENSIONS:
+        return False
+    head = ' '.join(str(line or '').lower() for line in lines[:20])
+    return 'plus' in head or 'pluspunten' in head or 'piuspunten' in head
+
+
+def _clean_plus_amount_token(value: str) -> str:
+    token = re.sub(r'\s+', '', str(value or '').strip())
+    token = token.replace('£', '€')
+    token = re.sub(r'^(?=[0-9])', '', token)
+    return token
+
+
+def _split_plus_parallel_qty_line(line: str) -> list[str] | None:
+    normalized = re.sub(r'\b0[\.,]\s+25\b', '0,25', re.sub(r'\s+', ' ', str(line or '')).strip())
+    lowered = normalized.lower()
+    if any(token in lowered for token in _PLUS_ROW_STOP_TOKENS + _PLUS_ROW_DISCOUNT_TOKENS):
+        return None
+    amount_matches = list(_PLUS_AMOUNT_TOKEN_RE.finditer(normalized))
+    if len(amount_matches) < 4:
+        return None
+    first_amount = amount_matches[0]
+    label_part = normalized[:first_amount.start()].strip(' .:-')
+    qty_matches = list(_PLUS_QTY_TOKEN_RE.finditer(label_part))
+    if len(qty_matches) < 2:
+        return None
+    labels: list[str] = []
+    for index, qty_match in enumerate(qty_matches):
+        start = qty_match.start()
+        end = qty_matches[index + 1].start() if index + 1 < len(qty_matches) else len(label_part)
+        label = re.sub(r'\s+', ' ', label_part[start:end]).strip(' .:-')
+        if label:
+            labels.append(label)
+    if len(labels) < 2:
+        return None
+    if len(amount_matches) < len(labels) * 2:
+        return None
+    amounts = [_clean_plus_amount_token(match.group(0)) for match in amount_matches]
+    rows: list[str] = []
+    for index, label in enumerate(labels):
+        unit = amounts[index]
+        total = amounts[index + len(labels)]
+        rows.append(f'{label} {unit} {total}')
+    return rows if len(rows) >= 2 else None
+
+
+def _split_plus_statiegeld_line(line: str) -> list[str] | None:
+    normalized = re.sub(r'\b0[\.,]\s+25\b', '0,25', re.sub(r'\s+', ' ', str(line or '')).strip())
+    if 'statiegeld' not in normalized.lower():
+        return None
+    match = re.match(
+        r'^(?P<label>.*?\b\d{1,3}\s*[xX]\b.*?)\s+'
+        r'(?P<unit>[€CE£]?\d{1,6}[\.,]\d{2})\s+'
+        r'Statiegeld\s+'
+        r'(?P<total>[€CE£]?\d{1,6}[\.,]\d{2})\s+'
+        r'(?P<deposit>[€CE£]?0[\.,]\d{2})$',
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        return None
+    label = re.sub(r'\s+', ' ', match.group('label')).strip(' .:-')
+    if not label:
+        return None
+    return [
+        f"{label} {_clean_plus_amount_token(match.group('unit'))} {_clean_plus_amount_token(match.group('total'))}",
+        f"Statiegeld {_clean_plus_amount_token(match.group('deposit'))}",
+    ]
+
+
+def _apply_plus_merged_text_line_split(filename: str, lines: list[str]) -> list[str]:
+    if not lines or not _is_plus_image_line_set(filename, lines):
+        return lines
+    expanded: list[str] = []
+    changed = False
+    for line in lines:
+        split_rows = _split_plus_statiegeld_line(line) or _split_plus_parallel_qty_line(line)
+        if split_rows:
+            expanded.extend(split_rows)
+            changed = True
+        else:
+            expanded.append(line)
+    return expanded if changed else lines
+
 
 def _ocr_image_text_with_paddle(file_bytes: bytes, filename: str) -> tuple[list[str], float | None]:
     model = _get_paddle_ocr()
@@ -224,6 +315,7 @@ def _ocr_image_text_with_paddle(file_bytes: bytes, filename: str) -> tuple[list[
         boxes.extend(current_boxes[: len(normalized_texts)])
 
     line_candidates = _group_paddle_texts_to_lines(texts, boxes if boxes else None)
+    line_candidates = _apply_plus_merged_text_line_split(filename, line_candidates)
     plus_fallback_lines = apply_plus_photo_line_grouping_fallback(
         filename=filename,
         texts=texts,
@@ -259,42 +351,76 @@ def _ocr_image_text_with_paddle(file_bytes: bytes, filename: str) -> tuple[list[
     return line_candidates, confidence
 
 
-def warm_receipt_ocr_runtime() -> dict[str, Any]:
-    """Warm OCR dependencies before the first user upload."""
-    result: dict[str, Any] = {"warmup": "receipt_ocr_runtime"}
-    if str(os.getenv("REZZERV_RECEIPT_STARTUP_OCR_WARMUP", "false") or "false").strip().lower() not in {"1", "true", "yes", "on"}:
-        result["paddle"] = "skipped"
-        result["reason"] = "startup_ocr_warmup_disabled"
-        return result
-    try:
-        if Image is None:
-            result["paddle"] = "pillow_unavailable"
-            return result
-        sample = Image.new("RGB", (320, 220), "white")
-        buffer = io.BytesIO()
-        sample.save(buffer, format="PNG")
-        paddle_lines, _ = _ocr_image_text_with_paddle(buffer.getvalue(), "warmup.png")
-        result["paddle"] = "ok" if paddle_lines is not None else "no_lines"
-    except Exception as exc:
-        result["paddle"] = f"failed:{type(exc).__name__}"
-    return result
-
-
 def _ocr_image_text_with_tesseract(file_bytes: bytes, filename: str) -> tuple[list[str], float | None]:
-    suffix = Path(filename).suffix.lower() or '.png'
-    language = 'nld+eng'
-    try:
-        with tempfile.TemporaryDirectory(prefix='rezzerv-tesseract-') as temp_dir:
-            image_path = Path(temp_dir) / f'image{suffix}'
-            image_path.write_bytes(file_bytes)
-            command = ['tesseract', str(image_path), 'stdout', '-l', language, '--psm', '6']
-            completed = subprocess.run(command, capture_output=True, text=True, check=False, timeout=90)
-            if completed.returncode != 0:
-                LOGGER.warning('Tesseract verwerking mislukt voor %s: %s', filename, (completed.stderr or '').strip())
-                return [], None
-            text_output = completed.stdout or ''
-            return _normalize_text_lines(text_output), None
-    except Exception as exc:  # pragma: no cover - runtime dependency
-        LOGGER.warning('Tesseract fallback mislukt voor %s: %s', exc)
+    if Image is None:
         return [], None
+    try:
+        image = Image.open(io.BytesIO(file_bytes))
+    except Exception:
+        return [], None
+    with tempfile.TemporaryDirectory(prefix='rezzerv-tesseract-') as temp_dir:
+        image_path = Path(temp_dir) / 'receipt.png'
+        image.save(image_path)
+        base_path = Path(temp_dir) / 'out'
+        cmd = [
+            'tesseract',
+            str(image_path),
+            str(base_path),
+            '-l',
+            os.getenv('TESSERACT_LANG', 'nld+eng'),
+            '--psm',
+            '6',
+            'tsv',
+        ]
+        try:
+            subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=20)
+        except Exception:
+            return [], None
+        tsv_path = base_path.with_suffix('.tsv')
+        if not tsv_path.exists():
+            return [], None
+        rows = tsv_path.read_text(encoding='utf-8', errors='ignore').splitlines()
 
+    grouped: dict[tuple[str, str, str], list[tuple[int, str]]] = {}
+    confidences: list[float] = []
+    for raw in rows[1:]:
+        parts = raw.split('\t')
+        if len(parts) < 12:
+            continue
+        conf_raw = parts[10]
+        text = parts[11].strip()
+        if not text:
+            continue
+        try:
+            conf = float(conf_raw)
+            if conf >= 0:
+                confidences.append(conf / 100.0)
+        except ValueError:
+            pass
+        key = (parts[1], parts[2], parts[4])
+        try:
+            left = int(parts[6])
+        except ValueError:
+            left = len(grouped.get(key, []))
+        grouped.setdefault(key, []).append((left, text))
+
+    lines: list[str] = []
+    for key in sorted(grouped.keys(), key=lambda item: tuple(int(x) if str(x).isdigit() else 0 for x in item)):
+        words = [text for _, text in sorted(grouped[key], key=lambda item: item[0])]
+        line = re.sub(r'\s+', ' ', ' '.join(words)).strip()
+        if line:
+            lines.append(line)
+    return lines, round(sum(confidences) / len(confidences), 4) if confidences else None
+
+
+def warm_receipt_ocr_runtime() -> dict[str, bool]:
+    """Best-effort warm-up for heavy OCR runtimes after backend startup.
+
+    Keeps the existing lazy path intact: failures are reported but never block
+    application startup.
+    """
+    paddle_ready = _get_paddle_ocr() is not None
+    return {
+        'paddle_ready': bool(paddle_ready),
+        'tesseract_ready': Image is not None,
+    }

--- a/backend/app/receipt_ingestion/service_parts/plus_bbox_structured_result.py
+++ b/backend/app/receipt_ingestion/service_parts/plus_bbox_structured_result.py
@@ -1,0 +1,252 @@
+﻿"""Guarded structured PLUS bbox result builder.
+
+Runtime Type: production, guarded.
+
+Purpose:
+- convert PLUS-01K-a readiness diagnostics into structured receipt lines;
+- only return a result when readiness is exact and financial closure is exact;
+- avoid routing reconstructed PLUS bbox rows through the generic text parser;
+- keep non-ready PLUS receipts on the existing parser path.
+
+No database writes happen in this module.
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from pathlib import Path
+from typing import Any
+
+from app.receipt_ingestion.parsing.plus_bbox_activation_readiness import (
+    diagnose_plus_bbox_activation_readiness,
+)
+from app.receipt_ingestion.service_parts.receipt_result_helpers import ReceiptParseResult
+
+
+_IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.webp', '.bmp', '.tif', '.tiff'}
+_PLUS_RE = re.compile(r'\bplus\b', re.IGNORECASE)
+_AMOUNT_RE = re.compile(r'(?<!\d)[€CE£]?-?\d{1,6}(?:[\.,]\d{2})(?!\d)', re.IGNORECASE)
+_QTY_RE = re.compile(r'^\s*[+*]?\s*(?P<qty>\d+(?:[\.,]\d+)?)\s*[xX]\b\s*(?P<label>.+)$', re.IGNORECASE)
+
+
+def _normalize(value: Any) -> str:
+    return re.sub(r'\s+', ' ', str(value or '')).strip()
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    cleaned = str(value).strip()
+    cleaned = cleaned.replace('€', '').replace('£', '')
+    cleaned = re.sub(r'^[CEe]\s*', '', cleaned)
+    cleaned = re.sub(r'\s+', '', cleaned)
+    cleaned = cleaned.replace(',', '.')
+    try:
+        return Decimal(cleaned).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _float(value: Any) -> float | None:
+    amount = _decimal(value)
+    return float(amount) if amount is not None else None
+
+
+def _is_plus_image_context(filename: str | None, runtime_lines: list[str]) -> bool:
+    suffix = Path(str(filename or '')).suffix.lower()
+    if suffix and suffix not in _IMAGE_EXTENSIONS:
+        return False
+    haystack = ' '.join([str(filename or '')] + [str(line or '') for line in runtime_lines[:16]])
+    return bool(_PLUS_RE.search(haystack))
+
+
+def _row_text(row: dict[str, Any]) -> str:
+    for key in ('reconstructed_line', 'raw_line', 'line'):
+        value = _normalize(row.get(key))
+        if value:
+            return value
+    return ''
+
+
+def _clean_amount_token(token: str) -> str:
+    value = str(token or '').strip()
+    value = value.replace('€', '').replace('£', '')
+    value = re.sub(r'^[CEe]\s*', '', value)
+    value = value.replace('.', ',')
+    return value
+
+
+def _parse_structured_article_row(row: dict[str, Any], *, source_index: int, filename: str | None) -> dict[str, Any] | None:
+    raw_line = _row_text(row)
+    if not raw_line:
+        return None
+
+    matches = list(_AMOUNT_RE.finditer(raw_line))
+    if not matches:
+        return None
+
+    total_token = matches[-1].group(0)
+    total_amount = _decimal(total_token)
+    if total_amount is None:
+        return None
+
+    unit_price = total_amount
+    if len(matches) >= 2:
+        unit_candidate = _decimal(matches[-2].group(0))
+        if unit_candidate is not None:
+            unit_price = unit_candidate
+
+    label_part = raw_line[:matches[0].start()].strip(' .:-+*')
+    quantity = None
+
+    qty_match = _QTY_RE.match(label_part)
+    if qty_match:
+        quantity = _float(qty_match.group('qty'))
+        label_part = qty_match.group('label').strip(' .:-+*')
+
+    label = _normalize(label_part)
+    if not label:
+        return None
+
+    return {
+        'raw_label': label,
+        'normalized_label': label,
+        'quantity': quantity,
+        'unit': None,
+        'unit_price': float(unit_price),
+        'line_total': float(total_amount),
+        'discount_amount': None,
+        'barcode': None,
+        'confidence_score': 0.91,
+        'source_index': source_index,
+        'producer_trace': {
+            'source': 'PLUS-01L-c_structured_bbox_result',
+            'filename': filename,
+            'raw_line': raw_line,
+            'financially_guarded': True,
+            'parser_path': 'plus_bbox_structured_result',
+        },
+    }
+
+
+def _build_structured_lines(diag: dict[str, Any], *, filename: str | None) -> list[dict[str, Any]]:
+    structured: list[dict[str, Any]] = []
+    source_index = 0
+
+    for row in diag.get('article_rows') or []:
+        parsed = _parse_structured_article_row(row, source_index=source_index, filename=filename)
+        source_index += 1
+        if parsed is not None:
+            structured.append(parsed)
+
+    for group_name in ('bbox_non_article_financial_rows', 'extra_runtime_non_article_financial_rows'):
+        for row in diag.get(group_name) or []:
+            parsed = _parse_structured_article_row(row, source_index=source_index, filename=filename)
+            source_index += 1
+            if parsed is not None:
+                parsed['producer_trace'] = {
+                    **(parsed.get('producer_trace') or {}),
+                    'non_article_financial_row': True,
+                    'non_article_financial_group': group_name,
+                }
+                structured.append(parsed)
+
+    return structured
+
+
+def _line_total_sum(lines: list[dict[str, Any]]) -> Decimal:
+    total = Decimal('0.00')
+    for line in lines:
+        value = _decimal(line.get('line_total'))
+        if value is not None:
+            total += value
+        discount = _decimal(line.get('discount_amount'))
+        if discount is not None:
+            total += discount
+    return total.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+
+
+def build_plus_bbox_structured_result(
+    *,
+    filename: str | None,
+    runtime_lines: list[str],
+    texts: list[Any],
+    boxes: list[Any],
+    confidence_score: float | None = None,
+    current_receipt_only: bool = True,
+    excludes_deleted: bool = True,
+    excludes_archived: bool = True,
+) -> ReceiptParseResult | None:
+    """Build a guarded structured ReceiptParseResult for ready PLUS image receipts."""
+
+    original_lines = list(runtime_lines or [])
+
+    if not current_receipt_only or not excludes_deleted or not excludes_archived:
+        return None
+
+    if not _is_plus_image_context(filename, original_lines):
+        return None
+
+    if not texts or not boxes:
+        return None
+
+    diag = diagnose_plus_bbox_activation_readiness(texts, boxes, original_lines)
+    if not diag.get('ready_for_activation'):
+        return None
+
+    financial = diag.get('financial') or {}
+    if not financial.get('exact_subtotal_match') or not financial.get('exact_total_match'):
+        return None
+
+    total_amount = _decimal(financial.get('total_amount'))
+    discount_total = _decimal(financial.get('discount_total')) or Decimal('0.00')
+    expected_pre_discount = _decimal(financial.get('pre_discount_total'))
+    expected_net = _decimal(financial.get('net_total'))
+
+    if total_amount is None or expected_pre_discount is None or expected_net is None:
+        return None
+
+    structured_lines = _build_structured_lines(diag, filename=filename)
+    if not structured_lines:
+        return None
+
+    line_sum = _line_total_sum(structured_lines)
+    if line_sum != expected_pre_discount:
+        return None
+
+    if (line_sum + discount_total).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP) != total_amount:
+        return None
+
+    return ReceiptParseResult(
+        is_receipt=True,
+        parse_status='parsed',
+        confidence_score=round(float(confidence_score or 0.91), 4),
+        store_name='Plus',
+        purchase_at=None,
+        total_amount=total_amount,
+        discount_total=discount_total,
+        currency='EUR',
+        lines=structured_lines,
+        store_branch=None,
+        parser_diagnostics={
+            'plus_01l_c_structured_bbox_result': {
+                'applied': True,
+                'version': 'PLUS-01L-c',
+                'scope': diag.get('scope') or {
+                    'current_receipts_only': True,
+                    'excludes_deleted': True,
+                    'excludes_archived': True,
+                    'no_bulk_backfill_without_explicit_instruction': True,
+                },
+                'financial': financial,
+                'counts': diag.get('counts') or {},
+                'line_sum': float(line_sum),
+                'discount_total': float(discount_total),
+                'net_total': float((line_sum + discount_total).quantize(Decimal('0.01'))),
+            }
+        },
+    )
+
+
+__all__ = ['build_plus_bbox_structured_result']

--- a/backend/app/services/receipt_service.py
+++ b/backend/app/services/receipt_service.py
@@ -89,6 +89,7 @@ from app.receipt_ingestion.service_parts.source_detection import (
     sanitize_filename,
     sha256_hex,
 )
+from app.receipt_ingestion.service_parts.plus_bbox_structured_result import build_plus_bbox_structured_result
 from app.receipt_ingestion.service_parts.receipt_result_helpers import (
     ReceiptParseResult,
     _choose_better_receipt_result,
@@ -107,6 +108,7 @@ from app.receipt_ingestion.service_parts.text_extraction import (
 from app.services.receipt_status_baseline_service import STATUS_LABELS
 from app.receipt_ingestion.service_parts.image_ocr_flow import (
     _ocr_image_text_with_paddle,
+    get_last_paddle_bbox_payload,
     _ocr_image_text_with_tesseract,
     warm_receipt_ocr_runtime,
 )
@@ -1440,6 +1442,23 @@ def parse_receipt_content(file_bytes: bytes, filename: str, mime_type: str) -> R
             ocr_filename = filename
 
         paddle_lines, paddle_confidence = _ocr_image_text_with_paddle(ocr_file_bytes, ocr_filename)
+        # PLUS-01L-c guarded structured result injection:
+        # If PLUS bbox readiness is exact, bypass weak text-line parsing and return
+        # a structured ReceiptParseResult. Non-ready receipts remain on the existing path.
+        plus_bbox_payload = get_last_paddle_bbox_payload(ocr_filename) or {}
+        plus_structured_result = build_plus_bbox_structured_result(
+            filename=ocr_filename,
+            runtime_lines=paddle_lines or [],
+            texts=plus_bbox_payload.get('texts') or [],
+            boxes=plus_bbox_payload.get('boxes') or [],
+            confidence_score=paddle_confidence,
+            current_receipt_only=True,
+            excludes_deleted=True,
+            excludes_archived=True,
+        )
+        if plus_structured_result is not None:
+            return plus_structured_result
+
         tesseract_lines, tesseract_confidence = _ocr_image_text_with_tesseract(ocr_file_bytes, ocr_filename)
 
         paddle_result = _parse_result_from_text_lines(
@@ -1640,6 +1659,23 @@ def parse_receipt_content(file_bytes: bytes, filename: str, mime_type: str) -> R
 
         if ocr_file_bytes != file_bytes:
             original_paddle_lines, original_paddle_confidence = _ocr_image_text_with_paddle(file_bytes, filename)
+            # PLUS-01L-c2 guarded structured result injection on active image branch:
+            # The primary image path uses original_paddle_lines. If PLUS bbox readiness
+            # is exact, return the structured result before generic text parsing.
+            plus_bbox_payload = get_last_paddle_bbox_payload(filename) or {}
+            plus_structured_result = build_plus_bbox_structured_result(
+                filename=filename,
+                runtime_lines=original_paddle_lines or [],
+                texts=plus_bbox_payload.get('texts') or [],
+                boxes=plus_bbox_payload.get('boxes') or [],
+                confidence_score=original_paddle_confidence,
+                current_receipt_only=True,
+                excludes_deleted=True,
+                excludes_archived=True,
+            )
+            if plus_structured_result is not None:
+                return plus_structured_result
+
             original_tesseract_lines, original_tesseract_confidence = _ocr_image_text_with_tesseract(file_bytes, filename)
             original_paddle_result = _parse_result_from_text_lines(
                 original_paddle_lines,
@@ -2173,6 +2209,34 @@ def reparse_receipt(engine, receipt_storage_root: Path, receipt_table_id: str) -
     if not file_path.exists():
         raise FileNotFoundError(f'Ruwe bon ontbreekt op {file_path}')
     file_bytes = file_path.read_bytes()
+    # PLUS-01L-c current-receipt-only safety:
+    # Reparse may never modify soft-deleted / archived receipts.
+    with engine.begin() as conn:
+        active_state = conn.execute(
+            text(
+                '''
+                SELECT rt.deleted_at AS receipt_deleted_at,
+                       rr.deleted_at AS raw_deleted_at
+                FROM receipt_tables rt
+                JOIN raw_receipts rr ON rr.id = rt.raw_receipt_id
+                WHERE rt.id = :receipt_table_id
+                LIMIT 1
+                '''
+            ),
+            {'receipt_table_id': receipt_table_id},
+        ).mappings().first()
+    if active_state and (active_state.get('receipt_deleted_at') or active_state.get('raw_deleted_at')):
+        return {
+            'receipt_table_id': receipt_table_id,
+            'parse_status': 'skipped_deleted_or_archived',
+            'line_count': 0,
+            'deleted': True,
+            'plus_bbox_structured_result': {
+                'applied': False,
+                'reason': 'deleted_or_archived_receipt',
+            },
+        }
+
     parse_bytes, parse_filename, parse_mime_type = _resolve_reparse_source_payload(dict(record), file_bytes)
     parse_result = parse_receipt_content(parse_bytes, parse_filename, parse_mime_type)
     with engine.begin() as conn:

--- a/backend/app/services/receipt_service.py
+++ b/backend/app/services/receipt_service.py
@@ -1267,8 +1267,20 @@ def _parse_result_from_text_lines(
     totals_match = _totals_match_receipt_lines(total_amount, lines, discount_total)
     zero_discount_case = _discount_or_free_total_zero_case(total_amount, lines, discount_total)
 
+    is_plus_store = str(store_name or '').strip().lower() == 'plus'
+    balanced_plus_receipt = (
+        is_plus_store
+        and total_amount is not None
+        and bool(lines)
+        and totals_match
+        and bool(store_name)
+    )
+
     if lines:
-        if total_amount is not None and totals_match and len(lines) >= 2 and (store_name or purchase_at):
+        if balanced_plus_receipt:
+            confidence = rich_confidence if explicit_total_found else partial_confidence
+            parse_status = 'parsed' if explicit_total_found else 'partial'
+        elif total_amount is not None and totals_match and len(lines) >= 2 and (store_name or purchase_at):
             confidence = rich_confidence if (explicit_total_found and store_name) else partial_confidence
             parse_status = 'parsed' if explicit_total_found and (store_name or purchase_at) else 'partial'
         elif total_amount is not None and zero_discount_case and (store_name or purchase_at):
@@ -1284,7 +1296,7 @@ def _parse_result_from_text_lines(
         confidence = review_confidence
         parse_status = 'review_needed'
 
-    if suspicious_single_line or suspicious_filename_signal or not purchase_at:
+    if suspicious_filename_signal or ((suspicious_single_line or not purchase_at) and not balanced_plus_receipt):
         confidence = min(confidence, review_confidence)
         parse_status = 'review_needed'
 


### PR DESCRIPTION
## Summary

This PR activates guarded structured bbox parsing for PLUS image receipts.

The structured route only applies when PLUS readiness is exact:
- PLUS context
- bbox OCR payload available
- exact subtotal match
- exact total match
- active/current receipt scope
- deleted/archived receipts excluded

## Evidence

- Commit: `ddb348f1 fix(plus): activate guarded structured bbox parsing`
- READY PLUS sentinels: 8/8 parsed, exact, structured
- BLOCKED PLUS sentinels: 13/13 did not activate structured parsing
- Active DB scope after archive purge:
  - receipt_tables_active: 12
  - deleted/archived: 0
  - plus_active: 7
- Active PLUS final state:
  - parsed: 4
  - approved: 3
  - review_needed: 0
  - all active PLUS receipts financially exact
- Non-PLUS review_needed receipts remain out of scope:
  - Albert Heijn: 4
  - Lidl: 1

## Scope guard

No bulk backfill.
No deleted/archived receipts.
No generic raw-file sweep as standard regression.
No non-PLUS activation.

## Notes

This PR changes production parser behavior only through guarded PLUS structured bbox activation. The later database correction was local test-data cleanup only and is not part of the source-code diff.