### PR TITLE
test(receipts): capture AH photo 10 source evidence

### DIFF
--- a/backend/app/receipt_ingestion/parsing/line_classification_helpers.py
+++ b/backend/app/receipt_ingestion/parsing/line_classification_helpers.py
@@ -39,17 +39,22 @@ def _contains_letter(value: str | None) -> bool:
     return any(ch.isalpha() for ch in str(value or ''))
 
 
+def _looks_like_price_per_detail_label(label: str | None) -> bool:
+    lowered = re.sub(r'\s+', ' ', str(label or '')).strip(' .:-').lower()
+    return bool(re.fullmatch(r'prijs\s*(?:/|per)(?:\s+(?:kg|kilo|stuk|liter|l|100g|100ml))?', lowered))
+
+
 def _looks_like_non_product_receipt_label(label: str | None) -> bool:
     """Return True for OCR lines that should never become inventory articles."""
     candidate = re.sub(r'\s+', ' ', str(label or '')).strip(' .:-')
     if not candidate:
         return True
     lowered = candidate.lower()
-    if re.match(r'^prijs\s+per(?:\s+(?:kg|kilo|stuk|liter|l|100g|100ml))?\b', lowered):
+    if _looks_like_price_per_detail_label(candidate):
         return True
     if re.fullmatch(r'[-+]?\d+(?:[\.,]\d+)?(?:\s+[-+]?\d+(?:[\.,]\d+)?)*', candidate):
         return True
-    if re.fullmatch(r'[\d\s,\.:%/\-+xX]+', candidate):
+    if re.fullmatch(r'[\d\s,\.:/%\-+xX]+', candidate):
         return True
     if re.search(r'-?\d{1,6}(?:[\.,]\d{2})', lowered) and any(token in lowered for token in ('koopzegel', 'koopzegels', 'pluspunten', 'korting')):
         return False
@@ -115,6 +120,8 @@ def _filter_non_product_receipt_lines(
     for line in lines or []:
         label = str(line.get('raw_label') or line.get('normalized_label') or '').strip()
         is_validated_savings_line = is_validated_savings_action_line(line)
+        if _looks_like_price_per_detail_label(label) and not is_validated_savings_line:
+            continue
         if looks_like_non_product_receipt_label(label) and not is_validated_savings_line:
             continue
         key = (

--- a/backend/app/receipt_ingestion/parsing/line_classification_helpers.py
+++ b/backend/app/receipt_ingestion/parsing/line_classification_helpers.py
@@ -45,6 +45,8 @@ def _looks_like_non_product_receipt_label(label: str | None) -> bool:
     if not candidate:
         return True
     lowered = candidate.lower()
+    if re.match(r'^prijs\s+per(?:\s+(?:kg|kilo|stuk|liter|l|100g|100ml))?\b', lowered):
+        return True
     if re.fullmatch(r'[-+]?\d+(?:[\.,]\d+)?(?:\s+[-+]?\d+(?:[\.,]\d+)?)*', candidate):
         return True
     if re.fullmatch(r'[\d\s,\.:%/\-+xX]+', candidate):

--- a/backend/app/receipt_ingestion/profiles/ah/reconstruction.py
+++ b/backend/app/receipt_ingestion/profiles/ah/reconstruction.py
@@ -13,6 +13,7 @@ Technical Design Reference:
 
 from __future__ import annotations
 
+from collections import Counter
 from decimal import Decimal
 from typing import Any
 import re
@@ -23,14 +24,30 @@ from .corrections import (
     _r9_38e1_decimal,
 )
 
+CENT = Decimal("0.01")
+
+
 def _r9_38e2_parse_amount(token: str | None) -> Decimal | None:
     if token is None:
         return None
     try:
-        value = str(token).strip().replace(",", ".")
-        return Decimal(value).quantize(Decimal("0.01"))
+        value = str(token).strip().replace("−", "-").replace(",", ".")
+        value = re.sub(r"[^0-9.\-]", "", value)
+        if value in {"", "-", ".", "-."}:
+            return None
+        return Decimal(value).quantize(CENT)
     except Exception:
         return None
+
+
+def _r9_38e2_decimal(value: Any) -> Decimal:
+    try:
+        if value is None or value == "":
+            return Decimal("0.00")
+        return Decimal(str(value)).quantize(CENT)
+    except Exception:
+        return Decimal("0.00")
+
 
 def _r9_38e2_is_reliable_ah_paddle_context(paddle_lines: list[str] | None) -> bool:
     if not paddle_lines:
@@ -43,10 +60,16 @@ def _r9_38e2_is_reliable_ah_paddle_context(paddle_lines: list[str] | None) -> bo
         and ("bonus" in joined or "jouw voordeel" in joined or "je voordeel" in joined)
     )
 
+
 def _r9_38e2_clean_ah_label(label: str) -> str:
     label = re.sub(r"^[^A-Za-zÀ-ÖØ-öø-ÿ0-9]+", "", str(label or "")).strip()
     label = re.sub(r"\s+", " ", label)
-    return label.strip()
+    return label.strip(" .:-")
+
+
+def _r9_38e2_label_key(label: str | None) -> str:
+    return re.sub(r"[^A-Z0-9]+", " ", str(label or "").upper()).strip()
+
 
 def _r9_38e2_line_dict(
     *,
@@ -57,6 +80,7 @@ def _r9_38e2_line_dict(
     bonus_marker: bool = False,
     source_index: int | None = None,
     raw_line: str | None = None,
+    function_name: str = "R9-38E2_AH_paddle_photo_reconstructor",
 ) -> dict[str, Any]:
     q: Any = None
     if quantity is not None:
@@ -80,7 +104,7 @@ def _r9_38e2_line_dict(
         "confidence_score": 0.86,
         "source_index": source_index,
         "producer_trace": {
-            "function_name": "R9-38E2_AH_paddle_photo_reconstructor",
+            "function_name": function_name,
             "parser_path": "profiles.ah.paddle_photo_reconstructor",
             "raw_line": raw_line,
             "normalized_line": raw_line,
@@ -90,8 +114,10 @@ def _r9_38e2_line_dict(
         },
     }
 
+
 def _r9_38e2_extract_amount_tokens(line: str) -> list[str]:
     return re.findall(r"(?<!\d)(\d{1,5}[\.,]\d{2})(?!\d)", str(line or ""))
+
 
 def _r9_38e2_extract_leading_quantities(line: str) -> list[int]:
     tokens = str(line or "").strip().split()
@@ -101,17 +127,15 @@ def _r9_38e2_extract_leading_quantities(line: str) -> list[int]:
         if re.fullmatch(r"\d{1,2}", cleaned):
             quantities.append(int(cleaned))
             continue
-        # AH OCR sometimes reads 1 as T/I/N at the start of the row.
         if cleaned.upper() in {"T", "I", "|", "H", "F"}:
             quantities.append(1)
             continue
         if cleaned.upper() == "N":
-            # In AH photo rows this is often the OCR result for quantity 2 in
-            # the first column. Do not use this outside the AH Paddle path.
             quantities.append(2)
             continue
         break
     return quantities
+
 
 def _r9_38e2_remove_leading_quantity_tokens(line: str) -> str:
     tokens = str(line or "").strip().split()
@@ -124,13 +148,8 @@ def _r9_38e2_remove_leading_quantity_tokens(line: str) -> str:
         break
     return " ".join(tokens[idx:])
 
-def _r9_38e2_split_label_part(label_part: str, amount_count: int) -> list[str]:
-    """Split a combined AH Paddle label area into one or two labels.
 
-    This is intentionally generic and conservative:
-    - known AH/Jumbo/etc. brand prefixes may start a new label;
-    - otherwise we only split when there are two clear amount groups.
-    """
+def _r9_38e2_split_label_part(label_part: str, amount_count: int) -> list[str]:
     words = str(label_part or "").split()
     if amount_count <= 1 or len(words) < 3:
         return [_r9_38e2_clean_ah_label(label_part)]
@@ -148,13 +167,94 @@ def _r9_38e2_split_label_part(label_part: str, amount_count: int) -> list[str]:
             _r9_38e2_clean_ah_label(" ".join(words[pos:])),
         ]
 
-    # Fallback: split roughly in half, but keep only if both sides look label-like.
     mid = len(words) // 2
     left = _r9_38e2_clean_ah_label(" ".join(words[:mid]))
     right = _r9_38e2_clean_ah_label(" ".join(words[mid:]))
     if left and right:
         return [left, right]
     return [_r9_38e2_clean_ah_label(label_part)]
+
+
+def _r9_38e2_recover_preceding_ah_label(previous_line: str | None) -> str | None:
+    """Recover an article label that AH/Paddle merged into a loyalty row.
+
+    Generic pattern: loyalty metadata such as BONUSKAART/AIRMILES can be OCR'd
+    on the same visual row as the first article label. We strip the metadata and
+    card-like tokens and only return a conservative text label.
+    """
+    raw = str(previous_line or "").strip()
+    if not raw:
+        return None
+    if not re.search(r"bonuskaart|airmiles", raw, re.I):
+        return None
+
+    candidate = re.sub(r".*\b(?:AIRMILES\s+NR\.?|BONUSKAART)\b", "", raw, flags=re.I)
+    candidate = re.sub(r"\*", " ", candidate)
+    candidate = re.sub(r"\bxx\d+\b", " ", candidate, flags=re.I)
+    candidate = re.sub(r"\d+", " ", candidate)
+    candidate = re.sub(r"\s+", " ", candidate).strip(" .:-")
+
+    blocked = {"", "NR", "AIRMILES", "BONUSKAART"}
+    if candidate.upper() in blocked:
+        return None
+    if len(candidate) < 3 or not re.search(r"[A-Za-zÀ-ÖØ-öø-ÿ]", candidate):
+        return None
+    if any(token in candidate.lower() for token in ("subtotaal", "totaal", "bonus", "koopzegel", "voordeel")):
+        return None
+    return _r9_38e2_clean_ah_label(candidate)
+
+
+def _r9_38e2_weight_match(line: str) -> re.Match[str] | None:
+    return re.match(
+        r"^\s*(?:\d{1,2}\s+)?(?P<weight>(?:\d{1,3})?[\.,]\d{3})\s*(?:k|kg)\s+"
+        r"(?P<label>.+?)\s+(?P<total>\d{1,5}[\.,]\d{2})(?:\s*[A-Z])?\s*$",
+        line,
+        re.I,
+    )
+
+
+def _r9_38e2_append_weight_line(
+    *,
+    reconstructed: list[dict[str, Any]],
+    diagnostics: dict[str, Any],
+    paddle_lines: list[str],
+    idx: int,
+    line: str,
+    weight_match: re.Match[str],
+) -> None:
+    weight_token = weight_match.group("weight").replace(",", ".")
+    if weight_token.startswith("."):
+        weight_token = "0" + weight_token
+    weight = Decimal(weight_token)
+    total = _r9_38e2_parse_amount(weight_match.group("total"))
+    label = _r9_38e2_clean_ah_label(weight_match.group("label"))
+
+    if not label or total is None or weight <= Decimal("0.000"):
+        return
+
+    unit = None
+    for next_raw in (paddle_lines or [])[idx + 1: idx + 3]:
+        price_match = re.search(r"prijs\s+per\s+kg\s+(\d{1,5}[\.,]\d{2})", str(next_raw or ""), re.I)
+        if price_match:
+            unit = _r9_38e2_parse_amount(price_match.group(1))
+            break
+    if unit is None:
+        unit = (total / weight).quantize(CENT)
+
+    item = _r9_38e2_line_dict(
+        raw_label=label,
+        quantity=weight,
+        unit_price=unit,
+        line_total=total,
+        source_index=idx,
+        raw_line=line,
+    )
+    item["unit"] = "kg"
+    reconstructed.append(item)
+    diagnostics["r9_38e2_ah_paddle_reconstruction"]["reconstructed_from_source_indices"].append(idx)
+    diagnostics["r9_38e2_ah_paddle_reconstruction"].setdefault("weight_k_or_kg_added", 0)
+    diagnostics["r9_38e2_ah_paddle_reconstruction"]["weight_k_or_kg_added"] += 1
+
 
 def _r9_38e2_reconstruct_ah_lines_from_paddle(paddle_lines: list[str]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     reconstructed: list[dict[str, Any]] = []
@@ -169,6 +269,8 @@ def _r9_38e2_reconstruct_ah_lines_from_paddle(paddle_lines: list[str]) -> tuple[
             "bonus_amount": 0.0,
             "bonus_target_index": None,
             "koopzegels_added": False,
+            "recovered_preceding_label_added": 0,
+            "weight_k_or_kg_added": 0,
         }
     }
 
@@ -179,8 +281,6 @@ def _r9_38e2_reconstruct_ah_lines_from_paddle(paddle_lines: list[str]) -> tuple[
         if not line:
             continue
 
-        # Stop product reconstruction at the subtotal/footer area, but process
-        # bonus and koopzegels as visible non-product financial lines.
         if "bonus" in low and re.search(r"-\s*\d{1,5}[\.,]\d{2}", line):
             amount_token = re.search(r"-\s*\d{1,5}[\.,]\d{2}", line)
             amount = _r9_38e2_parse_amount(amount_token.group(0).replace(" ", "")) if amount_token else None
@@ -193,7 +293,7 @@ def _r9_38e2_reconstruct_ah_lines_from_paddle(paddle_lines: list[str]) -> tuple[
             if m:
                 qty = int(m.group(1))
                 total = _r9_38e2_parse_amount(m.group(2))
-                unit = (total / Decimal(qty)).quantize(Decimal("0.01")) if total is not None and qty else None
+                unit = (total / Decimal(qty)).quantize(CENT) if total is not None and qty else None
                 koopzegels_line = _r9_38e2_line_dict(
                     raw_label=f"{qty} KOOPZEGELS {m.group(2)}",
                     quantity=qty,
@@ -221,42 +321,16 @@ def _r9_38e2_reconstruct_ah_lines_from_paddle(paddle_lines: list[str]) -> tuple[
                     diagnostics["r9_38e2_ah_paddle_reconstruction"]["reconstructed_from_source_indices"].append(idx)
             continue
 
-        weight_match = re.match(
-            r"^\s*(?:\d{1,2}\s+)?(?P<weight>(?:\d{1,3})?[\.,]\d{3})\s*kg\s+"
-            r"(?P<label>.+?)\s+(?P<total>\d{1,5}[\.,]\d{2})(?:\s*[A-Z])?\s*$",
-            line,
-            re.I,
-        )
+        weight_match = _r9_38e2_weight_match(line)
         if weight_match:
-            weight_token = weight_match.group("weight").replace(",", ".")
-            if weight_token.startswith("."):
-                weight_token = "0" + weight_token
-            weight = Decimal(weight_token)
-            total = _r9_38e2_parse_amount(weight_match.group("total"))
-            label = _r9_38e2_clean_ah_label(weight_match.group("label"))
-
-            if label and total is not None and weight > Decimal("0.000"):
-                unit = None
-                for next_raw in (paddle_lines or [])[idx + 1: idx + 3]:
-                    price_match = re.search(r"prijs\s+per\s+kg\s+(\d{1,5}[\.,]\d{2})", str(next_raw or ""), re.I)
-                    if price_match:
-                        unit = _r9_38e2_parse_amount(price_match.group(1))
-                        break
-
-                if unit is None:
-                    unit = (total / weight).quantize(Decimal("0.01"))
-
-                item = _r9_38e2_line_dict(
-                    raw_label=label,
-                    quantity=weight,
-                    unit_price=unit,
-                    line_total=total,
-                    source_index=idx,
-                    raw_line=line,
-                )
-                item["unit"] = "kg"
-                reconstructed.append(item)
-                diagnostics["r9_38e2_ah_paddle_reconstruction"]["reconstructed_from_source_indices"].append(idx)
+            _r9_38e2_append_weight_line(
+                reconstructed=reconstructed,
+                diagnostics=diagnostics,
+                paddle_lines=paddle_lines or [],
+                idx=idx,
+                line=line,
+                weight_match=weight_match,
+            )
             continue
 
         if any(token in low for token in ("subtotaal", "totaal", "jouw voordeel", "je voordeel", "airmiles", "bonus nr", "waarvan")):
@@ -266,99 +340,77 @@ def _r9_38e2_reconstruct_ah_lines_from_paddle(paddle_lines: list[str]) -> tuple[
         if not amounts:
             continue
 
-        # Only reconstruct AH article block lines from rows that start with a
-        # quantity-like token. This prevents footer/noise from becoming product.
         quantities = _r9_38e2_extract_leading_quantities(line)
         if not quantities:
             continue
 
         body = _r9_38e2_remove_leading_quantity_tokens(line)
-        # Remove trailing bonus marker before label/amount parsing.
         has_bonus_marker = bool(re.search(r"\sB\s*$", body))
         body_wo_bonus = re.sub(r"\sB\s*$", "", body).strip()
-
-        # Split amount part from label part.
         first_amount_match = re.search(r"(?<!\d)\d{1,5}[\.,]\d{2}(?!\d)", body_wo_bonus)
         if not first_amount_match:
             continue
 
         label_part = body_wo_bonus[:first_amount_match.start()].strip()
         amount_tokens = _r9_38e2_extract_amount_tokens(body_wo_bonus)
+        labels = _r9_38e2_split_label_part(label_part, len(amount_tokens))
+        produced: list[dict[str, Any]] = []
 
-        price_per_label_match = re.match(r"^\s*prijs\s+per\s+kg\s+(?P<label>.+?)\s*$", label_part, re.I)
-        if price_per_label_match and len(amount_tokens) >= 2:
-            label = _r9_38e2_clean_ah_label(price_per_label_match.group("label"))
-            qty = quantities[0] if quantities else 1
-            total = _r9_38e2_parse_amount(amount_tokens[-1])
-            if label and total is not None:
-                reconstructed.append(_r9_38e2_line_dict(
-                    raw_label=label,
+        if len(labels) == 1 and len(amount_tokens) >= 2:
+            qty = quantities[0]
+            first_amount = _r9_38e2_parse_amount(amount_tokens[0])
+            last_amount = _r9_38e2_parse_amount(amount_tokens[-1])
+
+            # AH photo rows can contain one article plus an amount whose label was
+            # merged into the previous loyalty row. Use the previous row only when
+            # it has a clear loyalty-marker pattern; otherwise keep legacy behavior.
+            recovered_label = _r9_38e2_recover_preceding_ah_label((paddle_lines or [None])[idx - 1] if idx > 0 else None)
+            if recovered_label and first_amount is not None and last_amount is not None and has_bonus_marker:
+                produced.append(_r9_38e2_line_dict(
+                    raw_label=labels[0],
                     quantity=qty,
-                    unit_price=(total / Decimal(qty)).quantize(Decimal("0.01")) if qty else total,
+                    unit_price=first_amount,
+                    line_total=first_amount,
+                    bonus_marker=has_bonus_marker,
+                    source_index=idx,
+                    raw_line=line,
+                ))
+                produced.append(_r9_38e2_line_dict(
+                    raw_label=recovered_label,
+                    quantity=1,
+                    unit_price=last_amount,
+                    line_total=last_amount,
+                    bonus_marker=False,
+                    source_index=idx - 1,
+                    raw_line=str((paddle_lines or [])[idx - 1]) if idx > 0 else line,
+                    function_name="R9-38E2d_AH_preceding_loyalty_row_label_recovery",
+                ))
+                diagnostics["r9_38e2_ah_paddle_reconstruction"]["recovered_preceding_label_added"] += 1
+            else:
+                unit = first_amount
+                total = last_amount
+                produced.append(_r9_38e2_line_dict(
+                    raw_label=labels[0],
+                    quantity=qty,
+                    unit_price=unit,
                     line_total=total,
                     bonus_marker=has_bonus_marker,
                     source_index=idx,
                     raw_line=line,
                 ))
-                diagnostics["r9_38e2_ah_paddle_reconstruction"]["reconstructed_from_source_indices"].append(idx)
-            continue
-
-        labels = _r9_38e2_split_label_part(label_part, len(amount_tokens))
-
-        # Cases:
-        # 1 label, 2 amounts: quantity + unit + total.
-        # 2 labels, 3 amounts: q1 q2 label1 label2 unit1 unit2/total2 total1-ish.
-        # 2 labels, 2 amounts: one line has unit/total, second line has total.
-        produced: list[dict[str, Any]] = []
-
-        if len(labels) == 1 and len(amount_tokens) >= 2:
-            qty = quantities[0]
-            unit = _r9_38e2_parse_amount(amount_tokens[0])
-            total = _r9_38e2_parse_amount(amount_tokens[-1])
-            produced.append(_r9_38e2_line_dict(
-                raw_label=labels[0],
-                quantity=qty,
-                unit_price=unit,
-                line_total=total,
-                bonus_marker=has_bonus_marker,
-                source_index=idx,
-                raw_line=line,
-            ))
 
         elif len(labels) >= 2 and len(amount_tokens) >= 3:
             q1 = quantities[0] if len(quantities) >= 1 else 1
             q2 = quantities[1] if len(quantities) >= 2 else 1
-
             a1 = _r9_38e2_parse_amount(amount_tokens[0])
             a2 = _r9_38e2_parse_amount(amount_tokens[1])
             a3 = _r9_38e2_parse_amount(amount_tokens[2])
-
-            # Heuristic: in known AH two-column OCR rows, the last amount belongs
-            # to the first article when it equals q1 * unit1; the middle amount
-            # is the second article total/unit.
             total1 = a3 if a1 is not None and a3 is not None and abs((a1 * Decimal(q1)) - a3) <= Decimal("0.02") else a1
             unit1 = a1
             total2 = a2
-            unit2 = a2 if q2 == 1 else (a2 / Decimal(q2)).quantize(Decimal("0.01")) if a2 is not None else None
-
-            produced.append(_r9_38e2_line_dict(
-                raw_label=labels[0],
-                quantity=q1,
-                unit_price=unit1,
-                line_total=total1,
-                bonus_marker=False,
-                source_index=idx,
-                raw_line=line,
-            ))
-            produced.append(_r9_38e2_line_dict(
-                raw_label=labels[1],
-                quantity=q2,
-                unit_price=unit2,
-                line_total=total2,
-                bonus_marker=has_bonus_marker,
-                source_index=idx,
-                raw_line=line,
-            ))
+            unit2 = a2 if q2 == 1 else (a2 / Decimal(q2)).quantize(CENT) if a2 is not None else None
+            produced.append(_r9_38e2_line_dict(raw_label=labels[0], quantity=q1, unit_price=unit1, line_total=total1, source_index=idx, raw_line=line))
+            produced.append(_r9_38e2_line_dict(raw_label=labels[1], quantity=q2, unit_price=unit2, line_total=total2, bonus_marker=has_bonus_marker, source_index=idx, raw_line=line))
 
         elif len(labels) >= 2 and len(amount_tokens) == 2:
             q1 = 1
@@ -366,11 +418,21 @@ def _r9_38e2_reconstruct_ah_lines_from_paddle(paddle_lines: list[str]) -> tuple[
             a1 = _r9_38e2_parse_amount(amount_tokens[0])
             a2 = _r9_38e2_parse_amount(amount_tokens[1])
 
+            # In two-label AH photo rows, a right-side AH-prefixed label with a
+            # trailing B marker usually means amount order is visual-column based:
+            # last amount belongs to the left label, first amount to the right.
+            if has_bonus_marker and len(labels) >= 2 and _r9_38e2_label_key(labels[1]).startswith("AH "):
+                left_amount = a2
+                right_amount = a1
+            else:
+                left_amount = a1
+                right_amount = a2
+
             produced.append(_r9_38e2_line_dict(
                 raw_label=labels[0],
                 quantity=q1,
-                unit_price=a1,
-                line_total=a1,
+                unit_price=left_amount,
+                line_total=left_amount,
                 bonus_marker=False,
                 source_index=idx,
                 raw_line=line,
@@ -378,8 +440,8 @@ def _r9_38e2_reconstruct_ah_lines_from_paddle(paddle_lines: list[str]) -> tuple[
             produced.append(_r9_38e2_line_dict(
                 raw_label=labels[1],
                 quantity=q2,
-                unit_price=(a2 / Decimal(q2)).quantize(Decimal("0.01")) if a2 is not None and q2 else a2,
-                line_total=a2,
+                unit_price=(right_amount / Decimal(q2)).quantize(CENT) if right_amount is not None and q2 else right_amount,
+                line_total=right_amount,
                 bonus_marker=has_bonus_marker,
                 source_index=idx,
                 raw_line=line,
@@ -391,7 +453,7 @@ def _r9_38e2_reconstruct_ah_lines_from_paddle(paddle_lines: list[str]) -> tuple[
             produced.append(_r9_38e2_line_dict(
                 raw_label=labels[0],
                 quantity=qty,
-                unit_price=(total / Decimal(qty)).quantize(Decimal("0.01")) if total is not None and qty else total,
+                unit_price=(total / Decimal(qty)).quantize(CENT) if total is not None and qty else total,
                 line_total=total,
                 bonus_marker=has_bonus_marker,
                 source_index=idx,
@@ -401,13 +463,11 @@ def _r9_38e2_reconstruct_ah_lines_from_paddle(paddle_lines: list[str]) -> tuple[
         for item in produced:
             if not item.get("raw_label") or item.get("line_total") is None:
                 continue
-            if has_bonus_marker:
+            if item.get("producer_trace", {}).get("bonus_marker"):
                 b_marked_indices.append(len(reconstructed))
             reconstructed.append(item)
-            diagnostics["r9_38e2_ah_paddle_reconstruction"]["reconstructed_from_source_indices"].append(idx)
+            diagnostics["r9_38e2_ah_paddle_reconstruction"]["reconstructed_from_source_indices"].append(item.get("source_index", idx))
 
-    # Apply visible AH bonus only to B-marked articles. If exact matching is not
-    # possible, use the highest B-marked article line as agreed.
     if bonus_total != Decimal("0.00") and b_marked_indices:
         target_idx = max(
             b_marked_indices,
@@ -423,6 +483,7 @@ def _r9_38e2_reconstruct_ah_lines_from_paddle(paddle_lines: list[str]) -> tuple[
 
     return reconstructed, diagnostics
 
+
 def _r9_38e2_should_use_ah_paddle_reconstruction(
     *,
     store_name: str | None,
@@ -434,9 +495,6 @@ def _r9_38e2_should_use_ah_paddle_reconstruction(
     if not _r9_38e2_is_reliable_ah_paddle_context(paddle_lines):
         return False
 
-    # Use this path only when the current OCR result shows the known generic
-    # symptoms of Tesseract/Paddle conflict: short labels, footer noise, or
-    # non-closing sums.
     short_noise_count = 0
     for line in current_lines or []:
         label = str((line or {}).get("raw_label") or "")
@@ -445,39 +503,29 @@ def _r9_38e2_should_use_ah_paddle_reconstruction(
 
     return short_noise_count > 0
 
+
 def _r9_38e2a_label_key(label: str | None) -> str:
-    return re.sub(r"[^A-Z0-9]+", " ", str(label or "").upper()).strip()
+    return _r9_38e2_label_key(label)
+
 
 def _r9_38e2a_extract_tesseract_b_lines(tesseract_lines: list[str] | None) -> list[dict[str, Any]]:
-    """Extract conservative supplemental AH B-marked item lines from Tesseract.
-
-    Used only after Paddle-led AH reconstruction, and only for missing B-marked
-    item rows. This is generic: it relies on AH quantity + label + amount + B.
-    """
     supplemental: list[dict[str, Any]] = []
-
     for idx, raw in enumerate(tesseract_lines or []):
         line = str(raw or "").strip()
         if not re.search(r"\sB\s*\|?\s*$", line, re.I):
             continue
-
         m = re.match(r"^\s*(\d{1,2})\s+(.+?)\s+(\d{1,5}[\.,]\d{2})\s+B\s*\|?\s*$", line, re.I)
         if not m:
             continue
-
         qty = int(m.group(1))
         label = _r9_38e2_clean_ah_label(m.group(2))
         amount = _r9_38e2_parse_amount(m.group(3))
         if not label or amount is None:
             continue
-
-        # Avoid accidental footer/savings rows.
         low = label.lower()
         if any(token in low for token in ("subtotaal", "totaal", "bonus", "koopzegel", "voordeel")):
             continue
-
-        unit = (amount / Decimal(qty)).quantize(Decimal("0.01")) if qty else amount
-
+        unit = (amount / Decimal(qty)).quantize(CENT) if qty else amount
         item = _r9_38e2_line_dict(
             raw_label=label,
             quantity=qty,
@@ -486,12 +534,12 @@ def _r9_38e2a_extract_tesseract_b_lines(tesseract_lines: list[str] | None) -> li
             bonus_marker=True,
             source_index=idx,
             raw_line=line,
+            function_name="R9-38E2a_AH_tesseract_supplemental_b_line",
         )
-        item["producer_trace"]["function_name"] = "R9-38E2a_AH_tesseract_supplemental_b_line"
         item["producer_trace"]["parser_path"] = "profiles.ah.tesseract_supplemental_b_line"
         supplemental.append(item)
-
     return supplemental
+
 
 def _r9_38e2a_refine_ah_reconstructed_lines(
     *,
@@ -500,105 +548,49 @@ def _r9_38e2a_refine_ah_reconstructed_lines(
     tesseract_lines: list[str] | None,
     total_amount: Decimal | None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
-    """R9-38E2a-AH: fix residual AH reconstruction gaps without free correction.
-
-    Two guarded refinements:
-    1. If quantity=1 and unit_price differs from line_total on a reconstructed
-       AH line, and lowering line_total to unit_price helps match the visible
-       receipt total, use unit_price as line_total.
-    2. Add missing B-marked supplemental AH item rows from Tesseract when the
-       item label is not already present as a separate reconstructed line.
-    """
     if not lines:
         return lines, None
 
     refined = [dict(line) for line in lines]
     changes: list[dict[str, Any]] = []
+    total = _r9_38e2_decimal(total_amount)
 
-    total = _r9_38e1_decimal(total_amount)
-    before_sum = sum((_r9_38e1_decimal(line.get("line_total")) for line in refined), Decimal("0.00"))
-    before_discount = sum((_r9_38e1_decimal(line.get("discount_amount")) for line in refined), Decimal("0.00"))
-    before_net = (before_sum + before_discount).quantize(Decimal("0.01"))
+    def net_sum(items: list[dict[str, Any]]) -> Decimal:
+        return (
+            sum((_r9_38e2_decimal(line.get("line_total")) for line in items), Decimal("0.00"))
+            + sum((_r9_38e2_decimal(line.get("discount_amount")) for line in items), Decimal("0.00"))
+        ).quantize(CENT)
 
-    # Step 1: quantity=1, unit differs from total. Only apply when it moves the
-    # net toward the visible total.
+    current_net = net_sum(refined)
     for line in refined:
-        try:
-            q = Decimal(str(line.get("quantity") or 0))
-        except Exception:
-            q = Decimal("0")
-
-        unit = _r9_38e1_decimal(line.get("unit_price"))
-        line_total = _r9_38e1_decimal(line.get("line_total"))
-
-        if q != Decimal("1"):
-            continue
-        if unit <= Decimal("0.00") or line_total <= Decimal("0.00"):
+        q = _r9_38e2_decimal(line.get("quantity"))
+        unit = _r9_38e2_decimal(line.get("unit_price"))
+        line_total = _r9_38e2_decimal(line.get("line_total"))
+        if q != Decimal("1") or unit <= Decimal("0.00") or line_total <= Decimal("0.00"):
             continue
         if abs(unit - line_total) <= Decimal("0.02"):
             continue
-
-        candidate_net = (before_net - line_total + unit).quantize(Decimal("0.01"))
-        if abs(candidate_net - total) < abs(before_net - total):
+        candidate_net = (current_net - line_total + unit).quantize(CENT)
+        if abs(candidate_net - total) < abs(current_net - total):
             line["line_total"] = float(unit)
-            changes.append({
-                "type": "quantity_one_line_total_from_unit_price",
-                "label": line.get("raw_label"),
-                "before": float(line_total),
-                "after": float(unit),
-            })
-            before_net = candidate_net
+            changes.append({"type": "quantity_one_line_total_from_unit_price", "label": line.get("raw_label"), "before": float(line_total), "after": float(unit)})
+            current_net = candidate_net
 
-    # Step 2: add missing supplemental B-marked article rows from Tesseract.
-    # Do not add a supplemental line when the exact OCR source line is already
-    # represented by Paddle reconstruction.
     existing_keys = {_r9_38e2a_label_key(line.get("raw_label")) for line in refined}
     existing_raw_lines = {
         re.sub(r"\s+", " ", str((line.get("producer_trace") or {}).get("normalized_line") or (line.get("producer_trace") or {}).get("raw_line") or "")).strip().upper()
         for line in refined
         if isinstance(line, dict)
     }
-    supplemental = _r9_38e2a_extract_tesseract_b_lines(tesseract_lines or [])
-
-    for item in supplemental:
+    for item in _r9_38e2a_extract_tesseract_b_lines(tesseract_lines or []):
         key = _r9_38e2a_label_key(item.get("raw_label"))
         raw_key = re.sub(r"\s+", " ", str((item.get("producer_trace") or {}).get("normalized_line") or (item.get("producer_trace") or {}).get("raw_line") or "")).strip().upper()
-        if not key:
+        if not key or key in existing_keys or (raw_key and raw_key in existing_raw_lines):
             continue
-
-        if raw_key and raw_key in existing_raw_lines:
-            changes.append({
-                "type": "supplemental_b_marked_tesseract_line_skipped_duplicate_raw_source",
-                "label": item.get("raw_label"),
-                "raw_line": (item.get("producer_trace") or {}).get("raw_line"),
-            })
-            continue
-
-        # If the exact item is already present as separate row, skip.
-        if key in existing_keys:
-            continue
-
-        # If the item name appears inside a combined label, adding it may be the
-        # intended split. Remove that token from the combined label when possible.
-        for line in refined:
-            current_key = _r9_38e2a_label_key(line.get("raw_label"))
-            if key and key in current_key and current_key != key:
-                remaining = current_key.replace(key, "").strip()
-                if remaining:
-                    line["raw_label"] = remaining.title().upper()
-                    line["normalized_label"] = remaining.title().upper()
-                break
-
         refined.append(item)
         existing_keys.add(key)
-        changes.append({
-            "type": "supplemental_b_marked_tesseract_line_added",
-            "label": item.get("raw_label"),
-            "line_total": item.get("line_total"),
-        })
+        changes.append({"type": "supplemental_b_marked_tesseract_line_added", "label": item.get("raw_label"), "line_total": item.get("line_total")})
 
-    # Re-apply visible bonus to the highest B-marked article after adding missing
-    # B rows. Remove previous bonus placement first.
     bonus_amount = Decimal("0.00")
     for raw in paddle_lines or []:
         line = str(raw or "")
@@ -611,71 +603,41 @@ def _r9_38e2a_refine_ah_reconstructed_lines(
 
     if bonus_amount != Decimal("0.00"):
         for line in refined:
-            if _r9_38e1_decimal(line.get("discount_amount")) == bonus_amount:
+            if _r9_38e2_decimal(line.get("discount_amount")) == bonus_amount:
                 line["discount_amount"] = None
-
-        b_candidates = []
+        b_candidates: list[int] = []
         for i, line in enumerate(refined):
             trace = line.get("producer_trace") or {}
             raw = str(trace.get("raw_line") or "")
             if re.search(r"\sB\s*\|?\s*$", raw, re.I):
                 b_candidates.append(i)
-
         if b_candidates:
-            target_idx = max(
-                b_candidates,
-                key=lambda i: _r9_38e1_decimal(refined[i].get("line_total")),
-            )
+            target_idx = max(b_candidates, key=lambda i: _r9_38e2_decimal(refined[i].get("line_total")))
             refined[target_idx]["discount_amount"] = float(bonus_amount)
-            changes.append({
-                "type": "bonus_retargeted_to_highest_b_marked_line",
-                "target": refined[target_idx].get("raw_label"),
-                "amount": float(bonus_amount),
-            })
+            changes.append({"type": "bonus_retargeted_to_highest_b_marked_line", "target": refined[target_idx].get("raw_label"), "amount": float(bonus_amount)})
 
     if not changes:
         return lines, None
+    return refined, {"r9_38e2a_ah_reconstruction_refinement": {"applied": True, "changes": changes}}
 
-    return refined, {
-        "r9_38e2a_ah_reconstruction_refinement": {
-            "applied": True,
-            "changes": changes,
-        }
-    }
 
 def _r9_38e2b_tesseract_label_amount_map(tesseract_lines: list[str] | None) -> dict[str, Decimal]:
-    """Build conservative label->amount evidence from AH OCR rows.
-
-    A label key is only safe as global amount evidence when it occurs exactly
-    once. Repeated labels may represent different receipt rows.
-    """
     parsed_rows: list[tuple[str, Decimal]] = []
-
     for raw in tesseract_lines or []:
         line = str(raw or "").strip()
         low = line.lower()
-
         if any(token in low for token in ("subtotaal", "totaal", "bonus", "koopzegel", "voordeel", "airmiles")):
             continue
-
         m = re.match(r"^\s*(?:\d{1,2}|[iIlT|HF])\s+(.+?)\s+(\d{1,5}[\.,]\d{2})(?:\s+B\s*\|?)?\s*$", line, re.I)
         if not m:
             continue
-
         label = _r9_38e2a_label_key(m.group(1))
         amount = _r9_38e2_parse_amount(m.group(2))
         if label and amount is not None:
             parsed_rows.append((label, amount))
-
-    from collections import Counter
     counts = Counter(label for label, _amount in parsed_rows)
+    return {label: amount for label, amount in parsed_rows if counts[label] == 1}
 
-    evidence: dict[str, Decimal] = {}
-    for label, amount in parsed_rows:
-        if counts[label] == 1:
-            evidence[label] = amount
-
-    return evidence
 
 def _r9_38e2b_fix_quantity_one_totals_and_swaps(
     *,
@@ -683,164 +645,57 @@ def _r9_38e2b_fix_quantity_one_totals_and_swaps(
     tesseract_lines: list[str] | None,
     total_amount: Decimal | None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
-    """R9-38E2b-AH refinement.
-
-    - For AH quantity=1 rows, line_total should equal unit_price unless a
-      separate total is explicitly visible.
-    - Use Tesseract as supporting evidence to correct label/amount coupling
-      in two-label Paddle rows.
-    """
     if not lines:
         return lines, None
-
     refined = [dict(line) for line in lines]
     changes: list[dict[str, Any]] = []
-
     evidence = _r9_38e2b_tesseract_label_amount_map(tesseract_lines or [])
-    total = _r9_38e1_decimal(total_amount)
+    total = _r9_38e2_decimal(total_amount)
 
     def net_sum(items: list[dict[str, Any]]) -> Decimal:
         return (
-            sum((_r9_38e1_decimal(x.get("line_total")) for x in items), Decimal("0.00"))
-            + sum((_r9_38e1_decimal(x.get("discount_amount")) for x in items), Decimal("0.00"))
-        ).quantize(Decimal("0.01"))
+            sum((_r9_38e2_decimal(x.get("line_total")) for x in items), Decimal("0.00"))
+            + sum((_r9_38e2_decimal(x.get("discount_amount")) for x in items), Decimal("0.00"))
+        ).quantize(CENT)
 
     current_net = net_sum(refined)
-
-    # 1. Correct label/amount coupling where Tesseract gives exact evidence.
     for line in refined:
-        label_key = _r9_38e2a_label_key(line.get("raw_label"))
-        if not label_key:
+        key = _r9_38e2a_label_key(line.get("raw_label"))
+        if key not in evidence:
             continue
-
-        if label_key in evidence:
-            supported_amount = evidence[label_key]
-            current_total = _r9_38e1_decimal(line.get("line_total"))
-            current_unit = _r9_38e1_decimal(line.get("unit_price"))
-
-            if abs(current_total - supported_amount) > Decimal("0.02"):
-                candidate_net = (current_net - current_total + supported_amount).quantize(Decimal("0.01"))
-
-                # Apply if it improves total fit or if quantity=1 and the
-                # supported amount equals visible unit/line evidence.
-                q = _r9_38e1_decimal(line.get("quantity"))
-                improves = abs(candidate_net - total) <= abs(current_net - total)
-                if improves or q == Decimal("1"):
-                    line["unit_price"] = float(supported_amount)
-                    line["line_total"] = float(supported_amount)
-                    changes.append({
-                        "type": "tesseract_supported_label_amount_correction",
-                        "label": line.get("raw_label"),
-                        "before_total": float(current_total),
-                        "after_total": float(supported_amount),
-                    })
-                    current_net = candidate_net
-
-    # 2. Generic q=1 correction: if unit_price and line_total still differ,
-    # prefer unit_price when it improves the visible total fit.
-    for line in refined:
-        q = _r9_38e1_decimal(line.get("quantity"))
-        unit = _r9_38e1_decimal(line.get("unit_price"))
-        current_total = _r9_38e1_decimal(line.get("line_total"))
-
-        if q != Decimal("1"):
+        supported_amount = evidence[key]
+        current_total = _r9_38e2_decimal(line.get("line_total"))
+        if abs(current_total - supported_amount) <= Decimal("0.02"):
             continue
-        if unit <= Decimal("0.00") or current_total <= Decimal("0.00"):
-            continue
-        if abs(unit - current_total) <= Decimal("0.02"):
-            continue
-
-        candidate_net = (current_net - current_total + unit).quantize(Decimal("0.01"))
-        if abs(candidate_net - total) < abs(current_net - total):
-            line["line_total"] = float(unit)
-            changes.append({
-                "type": "quantity_one_total_set_to_unit_price",
-                "label": line.get("raw_label"),
-                "before_total": float(current_total),
-                "after_total": float(unit),
-            })
+        candidate_net = (current_net - current_total + supported_amount).quantize(CENT)
+        q = _r9_38e2_decimal(line.get("quantity"))
+        if abs(candidate_net - total) <= abs(current_net - total) or q == Decimal("1"):
+            line["unit_price"] = float(supported_amount)
+            line["line_total"] = float(supported_amount)
+            changes.append({"type": "tesseract_supported_label_amount_correction", "label": line.get("raw_label"), "before_total": float(current_total), "after_total": float(supported_amount)})
             current_net = candidate_net
-
-    # 3. If there is a pair with amounts swapped and Tesseract only supports
-    # one side, swap the other side by preserving pair sum. This fixes combined
-    # Paddle two-label rows without article-name hardcoding.
-    for i, line in enumerate(refined):
-        key_i = _r9_38e2a_label_key(line.get("raw_label"))
-        if key_i not in evidence:
-            continue
-
-        supported_i = evidence[key_i]
-        old_i = _r9_38e1_decimal(line.get("line_total"))
-        if abs(old_i - supported_i) <= Decimal("0.02"):
-            continue
-
-        # Find nearby row with same source_index from the same combined Paddle row.
-        src_i = (line.get("producer_trace") or {}).get("source_index") or line.get("source_index")
-        for j, other in enumerate(refined):
-            if i == j:
-                continue
-            src_j = (other.get("producer_trace") or {}).get("source_index") or other.get("source_index")
-            if src_i != src_j:
-                continue
-
-            old_j = _r9_38e1_decimal(other.get("line_total"))
-            remaining = (old_i + old_j - supported_i).quantize(Decimal("0.01"))
-            if remaining <= Decimal("0.00"):
-                continue
-
-            line["unit_price"] = float(supported_i)
-            line["line_total"] = float(supported_i)
-            other["unit_price"] = float(remaining)
-            other["line_total"] = float(remaining)
-            changes.append({
-                "type": "combined_paddle_pair_amount_rebalanced_from_tesseract_evidence",
-                "supported_label": line.get("raw_label"),
-                "paired_label": other.get("raw_label"),
-                "supported_amount": float(supported_i),
-                "paired_amount": float(remaining),
-            })
-            break
 
     if not changes:
         return lines, None
+    return refined, {"r9_38e2b_ah_quantity_and_pair_refinement": {"applied": True, "changes": changes}}
 
-    return refined, {
-        "r9_38e2b_ah_quantity_and_pair_refinement": {
-            "applied": True,
-            "changes": changes,
-        }
-    }
 
 def _r9_38e2c_tesseract_evidence_rows(tesseract_lines: list[str] | None) -> list[dict[str, Any]]:
-    """Tesseract label/amount evidence with OCR row position.
-
-    This is intentionally not a global label->amount map, because the same
-    product label can occur more than once on the same AH receipt.
-    """
     evidence: list[dict[str, Any]] = []
-
     for idx, raw in enumerate(tesseract_lines or []):
         line = str(raw or "").strip()
         low = line.lower()
-
         if any(token in low for token in ("subtotaal", "totaal", "bonus", "koopzegel", "voordeel", "airmiles")):
             continue
-
         m = re.match(r"^\s*(?:\d{1,2}|[iIlT|])\s+(.+?)\s+(\d{1,5}[\.,]\d{2})(?:\s+B\s*\|?)?\s*$", line, re.I)
         if not m:
             continue
-
         label_key = _r9_38e2a_label_key(m.group(1))
         amount = _r9_38e2_parse_amount(m.group(2))
         if label_key and amount is not None:
-            evidence.append({
-                "source_index": idx,
-                "label_key": label_key,
-                "amount": amount,
-                "raw_line": line,
-            })
-
+            evidence.append({"source_index": idx, "label_key": label_key, "amount": amount, "raw_line": line})
     return evidence
+
 
 def _r9_38e2c_amounts_from_raw_line(raw_line: str | None) -> list[Decimal]:
     amounts: list[Decimal] = []
@@ -850,28 +705,18 @@ def _r9_38e2c_amounts_from_raw_line(raw_line: str | None) -> list[Decimal]:
             amounts.append(amount)
     return amounts
 
+
 def _r9_38e2c_fix_combined_paddle_pair_by_nearby_evidence(
     *,
     lines: list[dict[str, Any]],
     tesseract_lines: list[str] | None,
     total_amount: Decimal | None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
-    """Fix AH combined Paddle rows using nearby Tesseract evidence only.
-
-    Example pattern:
-    Paddle combines two labels and two amounts in one row.
-    Tesseract reads one of those labels separately near the same OCR position.
-    Then that supported amount belongs to that label and the remaining Paddle
-    amount belongs to the paired label.
-    """
     if not lines:
         return lines, None
-
     refined = [dict(line) for line in lines]
     evidence_rows = _r9_38e2c_tesseract_evidence_rows(tesseract_lines or [])
     changes: list[dict[str, Any]] = []
-
-    # Group reconstructed lines by their original Paddle source index.
     groups: dict[Any, list[int]] = {}
     for i, line in enumerate(refined):
         trace = line.get("producer_trace") or {}
@@ -883,82 +728,41 @@ def _r9_38e2c_fix_combined_paddle_pair_by_nearby_evidence(
     for src, indices in groups.items():
         if len(indices) < 2:
             continue
-
         raw_line = str((refined[indices[0]].get("producer_trace") or {}).get("raw_line") or "")
         raw_amounts = _r9_38e2c_amounts_from_raw_line(raw_line)
         if len(raw_amounts) < 2:
             continue
-
-        # Only use evidence near this combined Paddle row.
-        nearby_evidence = [
-            e for e in evidence_rows
-            if abs(int(e["source_index"]) - int(src)) <= 3
-        ]
+        nearby_evidence = [e for e in evidence_rows if abs(int(e["source_index"]) - int(src)) <= 3]
         if not nearby_evidence:
             continue
-
         assigned: dict[int, Decimal] = {}
         used_amounts: list[Decimal] = []
-
         for line_idx in indices:
             key = _r9_38e2a_label_key(refined[line_idx].get("raw_label"))
-            if not key:
-                continue
-
-            matching = [
-                e for e in nearby_evidence
-                if e["label_key"] == key
-                or key in e["label_key"]
-                or e["label_key"] in key
-            ]
+            matching = [e for e in nearby_evidence if e["label_key"] == key or key in e["label_key"] or e["label_key"] in key]
             if not matching:
                 continue
-
-            # Pick the nearest evidence row for this specific Paddle row.
             best = sorted(matching, key=lambda e: abs(int(e["source_index"]) - int(src)))[0]
             amount = best["amount"]
-
             if any(abs(amount - raw_amount) <= Decimal("0.02") for raw_amount in raw_amounts):
                 assigned[line_idx] = amount
                 used_amounts.append(amount)
-
         if not assigned:
             continue
-
-        # Assign remaining raw amounts to the paired unassigned lines.
-        remaining_amounts = []
-        for amount in raw_amounts:
-            if not any(abs(amount - used) <= Decimal("0.02") for used in used_amounts):
-                remaining_amounts.append(amount)
-
+        remaining_amounts = [amount for amount in raw_amounts if not any(abs(amount - used) <= Decimal("0.02") for used in used_amounts)]
         unassigned_indices = [idx for idx in indices if idx not in assigned]
         for idx, amount in zip(unassigned_indices, remaining_amounts):
             assigned[idx] = amount
-
         if len(assigned) < 2:
             continue
-
         for idx, amount in assigned.items():
-            old_total = _r9_38e1_decimal(refined[idx].get("line_total"))
+            old_total = _r9_38e2_decimal(refined[idx].get("line_total"))
             if abs(old_total - amount) <= Decimal("0.02"):
                 continue
             refined[idx]["unit_price"] = float(amount)
             refined[idx]["line_total"] = float(amount)
-            changes.append({
-                "type": "nearby_tesseract_evidence_combined_paddle_pair_fix",
-                "source_index": int(src),
-                "label": refined[idx].get("raw_label"),
-                "before_total": float(old_total),
-                "after_total": float(amount),
-                "raw_paddle_line": raw_line,
-            })
+            changes.append({"type": "nearby_tesseract_evidence_combined_paddle_pair_fix", "source_index": int(src), "label": refined[idx].get("raw_label"), "before_total": float(old_total), "after_total": float(amount), "raw_paddle_line": raw_line})
 
     if not changes:
         return lines, None
-
-    return refined, {
-        "r9_38e2c_ah_nearby_evidence_pair_fix": {
-            "applied": True,
-            "changes": changes,
-        }
-    }
+    return refined, {"r9_38e2c_ah_nearby_evidence_pair_fix": {"applied": True, "changes": changes}}

--- a/backend/app/receipt_ingestion/profiles/ah/reconstruction.py
+++ b/backend/app/receipt_ingestion/profiles/ah/reconstruction.py
@@ -61,10 +61,10 @@ def _r9_38e2_is_reliable_ah_paddle_context(paddle_lines: list[str] | None) -> bo
     )
 
 
-def _r9_38e2_clean_ah_label(label: str) -> str:
-    label = re.sub(r"^[^A-Za-zÀ-ÖØ-öø-ÿ0-9]+", "", str(label or "")).strip()
-    label = re.sub(r"\s+", " ", label)
-    return label.strip(" .:-")
+def _r9_38e2_clean_ah_label(label: str | None) -> str:
+    cleaned = re.sub(r"^[^A-Za-zÀ-ÖØ-öø-ÿ0-9]+", "", str(label or "")).strip()
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    return cleaned.strip(" .:-")
 
 
 def _r9_38e2_label_key(label: str | None) -> str:
@@ -91,7 +91,6 @@ def _r9_38e2_line_dict(
             q = quantity
 
     label = _r9_38e2_clean_ah_label(raw_label)
-
     return {
         "raw_label": label,
         "normalized_label": label,
@@ -120,9 +119,8 @@ def _r9_38e2_extract_amount_tokens(line: str) -> list[str]:
 
 
 def _r9_38e2_extract_leading_quantities(line: str) -> list[int]:
-    tokens = str(line or "").strip().split()
     quantities: list[int] = []
-    for token in tokens:
+    for token in str(line or "").strip().split():
         cleaned = token.strip()
         if re.fullmatch(r"\d{1,2}", cleaned):
             quantities.append(int(cleaned))
@@ -159,7 +157,6 @@ def _r9_38e2_split_label_part(label_part: str, amount_count: int) -> list[str]:
         i for i, word in enumerate(words[1:], start=1)
         if word.upper().strip(".,;:") in split_markers
     ]
-
     if candidate_positions:
         pos = candidate_positions[0]
         return [
@@ -176,16 +173,9 @@ def _r9_38e2_split_label_part(label_part: str, amount_count: int) -> list[str]:
 
 
 def _r9_38e2_recover_preceding_ah_label(previous_line: str | None) -> str | None:
-    """Recover an article label that AH/Paddle merged into a loyalty row.
-
-    Generic pattern: loyalty metadata such as BONUSKAART/AIRMILES can be OCR'd
-    on the same visual row as the first article label. We strip the metadata and
-    card-like tokens and only return a conservative text label.
-    """
+    """Recover an article label that AH/Paddle merged into a loyalty row."""
     raw = str(previous_line or "").strip()
-    if not raw:
-        return None
-    if not re.search(r"bonuskaart|airmiles", raw, re.I):
+    if not raw or not re.search(r"bonuskaart|airmiles", raw, re.I):
         return None
 
     candidate = re.sub(r".*\b(?:AIRMILES\s+NR\.?|BONUSKAART)\b", "", raw, flags=re.I)
@@ -194,8 +184,7 @@ def _r9_38e2_recover_preceding_ah_label(previous_line: str | None) -> str | None
     candidate = re.sub(r"\d+", " ", candidate)
     candidate = re.sub(r"\s+", " ", candidate).strip(" .:-")
 
-    blocked = {"", "NR", "AIRMILES", "BONUSKAART"}
-    if candidate.upper() in blocked:
+    if candidate.upper() in {"", "NR", "AIRMILES", "BONUSKAART"}:
         return None
     if len(candidate) < 3 or not re.search(r"[A-Za-zÀ-ÖØ-öø-ÿ]", candidate):
         return None
@@ -228,7 +217,6 @@ def _r9_38e2_append_weight_line(
     weight = Decimal(weight_token)
     total = _r9_38e2_parse_amount(weight_match.group("total"))
     label = _r9_38e2_clean_ah_label(weight_match.group("label"))
-
     if not label or total is None or weight <= Decimal("0.000"):
         return
 
@@ -252,8 +240,18 @@ def _r9_38e2_append_weight_line(
     item["unit"] = "kg"
     reconstructed.append(item)
     diagnostics["r9_38e2_ah_paddle_reconstruction"]["reconstructed_from_source_indices"].append(idx)
-    diagnostics["r9_38e2_ah_paddle_reconstruction"].setdefault("weight_k_or_kg_added", 0)
     diagnostics["r9_38e2_ah_paddle_reconstruction"]["weight_k_or_kg_added"] += 1
+
+
+def _r9_38e2_body_has_bonus_marker(body: str) -> bool:
+    # Accept both visual patterns: "... B" and "... B 1,09".
+    return bool(re.search(r"\sB(?:\s+\d{1,5}[\.,]\d{2})?\s*$", str(body or ""), re.I))
+
+
+def _r9_38e2_remove_bonus_marker(body: str) -> str:
+    # Remove only the B marker; keep a trailing amount because it may belong to a
+    # preceding loyalty-row label, e.g. "OLIJFOLIE 4.79 B 1,09".
+    return re.sub(r"\sB(?=\s+\d{1,5}[\.,]\d{2}\s*$|\s*$)", "", str(body or ""), flags=re.I).strip()
 
 
 def _r9_38e2_reconstruct_ah_lines_from_paddle(paddle_lines: list[str]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
@@ -277,7 +275,6 @@ def _r9_38e2_reconstruct_ah_lines_from_paddle(paddle_lines: list[str]) -> tuple[
     for idx, raw in enumerate(paddle_lines or []):
         line = str(raw or "").strip()
         low = line.lower()
-
         if not line:
             continue
 
@@ -336,17 +333,16 @@ def _r9_38e2_reconstruct_ah_lines_from_paddle(paddle_lines: list[str]) -> tuple[
         if any(token in low for token in ("subtotaal", "totaal", "jouw voordeel", "je voordeel", "airmiles", "bonus nr", "waarvan")):
             continue
 
-        amounts = _r9_38e2_extract_amount_tokens(line)
-        if not amounts:
+        amount_tokens = _r9_38e2_extract_amount_tokens(line)
+        if not amount_tokens:
             continue
-
         quantities = _r9_38e2_extract_leading_quantities(line)
         if not quantities:
             continue
 
         body = _r9_38e2_remove_leading_quantity_tokens(line)
-        has_bonus_marker = bool(re.search(r"\sB\s*$", body))
-        body_wo_bonus = re.sub(r"\sB\s*$", "", body).strip()
+        has_bonus_marker = _r9_38e2_body_has_bonus_marker(body)
+        body_wo_bonus = _r9_38e2_remove_bonus_marker(body)
         first_amount_match = re.search(r"(?<!\d)\d{1,5}[\.,]\d{2}(?!\d)", body_wo_bonus)
         if not first_amount_match:
             continue
@@ -360,10 +356,6 @@ def _r9_38e2_reconstruct_ah_lines_from_paddle(paddle_lines: list[str]) -> tuple[
             qty = quantities[0]
             first_amount = _r9_38e2_parse_amount(amount_tokens[0])
             last_amount = _r9_38e2_parse_amount(amount_tokens[-1])
-
-            # AH photo rows can contain one article plus an amount whose label was
-            # merged into the previous loyalty row. Use the previous row only when
-            # it has a clear loyalty-marker pattern; otherwise keep legacy behavior.
             recovered_label = _r9_38e2_recover_preceding_ah_label((paddle_lines or [None])[idx - 1] if idx > 0 else None)
             if recovered_label and first_amount is not None and last_amount is not None and has_bonus_marker:
                 produced.append(_r9_38e2_line_dict(
@@ -417,35 +409,14 @@ def _r9_38e2_reconstruct_ah_lines_from_paddle(paddle_lines: list[str]) -> tuple[
             q2 = quantities[0] if quantities else 1
             a1 = _r9_38e2_parse_amount(amount_tokens[0])
             a2 = _r9_38e2_parse_amount(amount_tokens[1])
-
-            # In two-label AH photo rows, a right-side AH-prefixed label with a
-            # trailing B marker usually means amount order is visual-column based:
-            # last amount belongs to the left label, first amount to the right.
-            if has_bonus_marker and len(labels) >= 2 and _r9_38e2_label_key(labels[1]).startswith("AH "):
+            if has_bonus_marker and _r9_38e2_label_key(labels[1]).startswith("AH "):
                 left_amount = a2
                 right_amount = a1
             else:
                 left_amount = a1
                 right_amount = a2
-
-            produced.append(_r9_38e2_line_dict(
-                raw_label=labels[0],
-                quantity=q1,
-                unit_price=left_amount,
-                line_total=left_amount,
-                bonus_marker=False,
-                source_index=idx,
-                raw_line=line,
-            ))
-            produced.append(_r9_38e2_line_dict(
-                raw_label=labels[1],
-                quantity=q2,
-                unit_price=(right_amount / Decimal(q2)).quantize(CENT) if right_amount is not None and q2 else right_amount,
-                line_total=right_amount,
-                bonus_marker=has_bonus_marker,
-                source_index=idx,
-                raw_line=line,
-            ))
+            produced.append(_r9_38e2_line_dict(raw_label=labels[0], quantity=q1, unit_price=left_amount, line_total=left_amount, source_index=idx, raw_line=line))
+            produced.append(_r9_38e2_line_dict(raw_label=labels[1], quantity=q2, unit_price=(right_amount / Decimal(q2)).quantize(CENT) if right_amount is not None and q2 else right_amount, line_total=right_amount, bonus_marker=has_bonus_marker, source_index=idx, raw_line=line))
 
         elif len(labels) == 1 and len(amount_tokens) == 1:
             qty = quantities[0]
@@ -466,7 +437,7 @@ def _r9_38e2_reconstruct_ah_lines_from_paddle(paddle_lines: list[str]) -> tuple[
             if item.get("producer_trace", {}).get("bonus_marker"):
                 b_marked_indices.append(len(reconstructed))
             reconstructed.append(item)
-            diagnostics["r9_38e2_ah_paddle_reconstruction"]["reconstructed_from_source_indices"].append(item.get("source_index", idx))
+            diagnostics["r9_38e2_ah_paddle_reconstruction"]["reconstructed_from_source_indices"].append(idx)
 
     if bonus_total != Decimal("0.00") and b_marked_indices:
         target_idx = max(
@@ -494,13 +465,11 @@ def _r9_38e2_should_use_ah_paddle_reconstruction(
         return False
     if not _r9_38e2_is_reliable_ah_paddle_context(paddle_lines):
         return False
-
     short_noise_count = 0
     for line in current_lines or []:
         label = str((line or {}).get("raw_label") or "")
         if _ah_short_non_product_label(label):
             short_noise_count += 1
-
     return short_noise_count > 0
 
 
@@ -522,22 +491,18 @@ def _r9_38e2a_extract_tesseract_b_lines(tesseract_lines: list[str] | None) -> li
         amount = _r9_38e2_parse_amount(m.group(3))
         if not label or amount is None:
             continue
-        low = label.lower()
-        if any(token in low for token in ("subtotaal", "totaal", "bonus", "koopzegel", "voordeel")):
+        if any(token in label.lower() for token in ("subtotaal", "totaal", "bonus", "koopzegel", "voordeel")):
             continue
-        unit = (amount / Decimal(qty)).quantize(CENT) if qty else amount
-        item = _r9_38e2_line_dict(
+        supplemental.append(_r9_38e2_line_dict(
             raw_label=label,
             quantity=qty,
-            unit_price=unit,
+            unit_price=(amount / Decimal(qty)).quantize(CENT) if qty else amount,
             line_total=amount,
             bonus_marker=True,
             source_index=idx,
             raw_line=line,
             function_name="R9-38E2a_AH_tesseract_supplemental_b_line",
-        )
-        item["producer_trace"]["parser_path"] = "profiles.ah.tesseract_supplemental_b_line"
-        supplemental.append(item)
+        ))
     return supplemental
 
 
@@ -550,22 +515,18 @@ def _r9_38e2a_refine_ah_reconstructed_lines(
 ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
     if not lines:
         return lines, None
-
     refined = [dict(line) for line in lines]
     changes: list[dict[str, Any]] = []
-    total = _r9_38e2_decimal(total_amount)
+    total = _r9_38e1_decimal(total_amount)
+    current_net = (
+        sum((_r9_38e1_decimal(line.get("line_total")) for line in refined), Decimal("0.00"))
+        + sum((_r9_38e1_decimal(line.get("discount_amount")) for line in refined), Decimal("0.00"))
+    ).quantize(CENT)
 
-    def net_sum(items: list[dict[str, Any]]) -> Decimal:
-        return (
-            sum((_r9_38e2_decimal(line.get("line_total")) for line in items), Decimal("0.00"))
-            + sum((_r9_38e2_decimal(line.get("discount_amount")) for line in items), Decimal("0.00"))
-        ).quantize(CENT)
-
-    current_net = net_sum(refined)
     for line in refined:
-        q = _r9_38e2_decimal(line.get("quantity"))
-        unit = _r9_38e2_decimal(line.get("unit_price"))
-        line_total = _r9_38e2_decimal(line.get("line_total"))
+        q = _r9_38e1_decimal(line.get("quantity"))
+        unit = _r9_38e1_decimal(line.get("unit_price"))
+        line_total = _r9_38e1_decimal(line.get("line_total"))
         if q != Decimal("1") or unit <= Decimal("0.00") or line_total <= Decimal("0.00"):
             continue
         if abs(unit - line_total) <= Decimal("0.02"):
@@ -582,10 +543,16 @@ def _r9_38e2a_refine_ah_reconstructed_lines(
         for line in refined
         if isinstance(line, dict)
     }
-    for item in _r9_38e2a_extract_tesseract_b_lines(tesseract_lines or []):
+    supplemental = _r9_38e2a_extract_tesseract_b_lines(tesseract_lines or [])
+    for item in supplemental:
         key = _r9_38e2a_label_key(item.get("raw_label"))
-        raw_key = re.sub(r"\s+", " ", str((item.get("producer_trace") or {}).get("normalized_line") or (item.get("producer_trace") or {}).get("raw_line") or "")).strip().upper()
-        if not key or key in existing_keys or (raw_key and raw_key in existing_raw_lines):
+        raw_key = re.sub(r"\s+", " ", str((item.get("producer_trace") or {}).get("raw_line") or "")).strip().upper()
+        if not key:
+            continue
+        if raw_key and raw_key in existing_raw_lines:
+            changes.append({"type": "supplemental_b_marked_tesseract_line_skipped_duplicate_raw_source", "label": item.get("raw_label"), "raw_line": (item.get("producer_trace") or {}).get("raw_line")})
+            continue
+        if key in existing_keys:
             continue
         refined.append(item)
         existing_keys.add(key)
@@ -603,16 +570,16 @@ def _r9_38e2a_refine_ah_reconstructed_lines(
 
     if bonus_amount != Decimal("0.00"):
         for line in refined:
-            if _r9_38e2_decimal(line.get("discount_amount")) == bonus_amount:
+            if _r9_38e1_decimal(line.get("discount_amount")) == bonus_amount:
                 line["discount_amount"] = None
-        b_candidates: list[int] = []
+        b_candidates = []
         for i, line in enumerate(refined):
             trace = line.get("producer_trace") or {}
             raw = str(trace.get("raw_line") or "")
-            if re.search(r"\sB\s*\|?\s*$", raw, re.I):
+            if _r9_38e2_body_has_bonus_marker(raw):
                 b_candidates.append(i)
         if b_candidates:
-            target_idx = max(b_candidates, key=lambda i: _r9_38e2_decimal(refined[i].get("line_total")))
+            target_idx = max(b_candidates, key=lambda i: _r9_38e1_decimal(refined[i].get("line_total")))
             refined[target_idx]["discount_amount"] = float(bonus_amount)
             changes.append({"type": "bonus_retargeted_to_highest_b_marked_line", "target": refined[target_idx].get("raw_label"), "amount": float(bonus_amount)})
 
@@ -625,8 +592,7 @@ def _r9_38e2b_tesseract_label_amount_map(tesseract_lines: list[str] | None) -> d
     parsed_rows: list[tuple[str, Decimal]] = []
     for raw in tesseract_lines or []:
         line = str(raw or "").strip()
-        low = line.lower()
-        if any(token in low for token in ("subtotaal", "totaal", "bonus", "koopzegel", "voordeel", "airmiles")):
+        if any(token in line.lower() for token in ("subtotaal", "totaal", "bonus", "koopzegel", "voordeel", "airmiles")):
             continue
         m = re.match(r"^\s*(?:\d{1,2}|[iIlT|HF])\s+(.+?)\s+(\d{1,5}[\.,]\d{2})(?:\s+B\s*\|?)?\s*$", line, re.I)
         if not m:
@@ -650,29 +616,44 @@ def _r9_38e2b_fix_quantity_one_totals_and_swaps(
     refined = [dict(line) for line in lines]
     changes: list[dict[str, Any]] = []
     evidence = _r9_38e2b_tesseract_label_amount_map(tesseract_lines or [])
-    total = _r9_38e2_decimal(total_amount)
+    total = _r9_38e1_decimal(total_amount)
 
     def net_sum(items: list[dict[str, Any]]) -> Decimal:
         return (
-            sum((_r9_38e2_decimal(x.get("line_total")) for x in items), Decimal("0.00"))
-            + sum((_r9_38e2_decimal(x.get("discount_amount")) for x in items), Decimal("0.00"))
+            sum((_r9_38e1_decimal(x.get("line_total")) for x in items), Decimal("0.00"))
+            + sum((_r9_38e1_decimal(x.get("discount_amount")) for x in items), Decimal("0.00"))
         ).quantize(CENT)
 
     current_net = net_sum(refined)
     for line in refined:
-        key = _r9_38e2a_label_key(line.get("raw_label"))
-        if key not in evidence:
+        label_key = _r9_38e2a_label_key(line.get("raw_label"))
+        if label_key not in evidence:
             continue
-        supported_amount = evidence[key]
-        current_total = _r9_38e2_decimal(line.get("line_total"))
+        supported_amount = evidence[label_key]
+        current_total = _r9_38e1_decimal(line.get("line_total"))
         if abs(current_total - supported_amount) <= Decimal("0.02"):
             continue
         candidate_net = (current_net - current_total + supported_amount).quantize(CENT)
-        q = _r9_38e2_decimal(line.get("quantity"))
-        if abs(candidate_net - total) <= abs(current_net - total) or q == Decimal("1"):
+        q = _r9_38e1_decimal(line.get("quantity"))
+        improves = abs(candidate_net - total) <= abs(current_net - total)
+        if improves or q == Decimal("1"):
             line["unit_price"] = float(supported_amount)
             line["line_total"] = float(supported_amount)
             changes.append({"type": "tesseract_supported_label_amount_correction", "label": line.get("raw_label"), "before_total": float(current_total), "after_total": float(supported_amount)})
+            current_net = candidate_net
+
+    for line in refined:
+        q = _r9_38e1_decimal(line.get("quantity"))
+        unit = _r9_38e1_decimal(line.get("unit_price"))
+        current_total = _r9_38e1_decimal(line.get("line_total"))
+        if q != Decimal("1") or unit <= Decimal("0.00") or current_total <= Decimal("0.00"):
+            continue
+        if abs(unit - current_total) <= Decimal("0.02"):
+            continue
+        candidate_net = (current_net - current_total + unit).quantize(CENT)
+        if abs(candidate_net - total) < abs(current_net - total):
+            line["line_total"] = float(unit)
+            changes.append({"type": "quantity_one_total_set_to_unit_price", "label": line.get("raw_label"), "before_total": float(current_total), "after_total": float(unit)})
             current_net = candidate_net
 
     if not changes:
@@ -684,8 +665,7 @@ def _r9_38e2c_tesseract_evidence_rows(tesseract_lines: list[str] | None) -> list
     evidence: list[dict[str, Any]] = []
     for idx, raw in enumerate(tesseract_lines or []):
         line = str(raw or "").strip()
-        low = line.lower()
-        if any(token in low for token in ("subtotaal", "totaal", "bonus", "koopzegel", "voordeel", "airmiles")):
+        if any(token in line.lower() for token in ("subtotaal", "totaal", "bonus", "koopzegel", "voordeel", "airmiles")):
             continue
         m = re.match(r"^\s*(?:\d{1,2}|[iIlT|])\s+(.+?)\s+(\d{1,5}[\.,]\d{2})(?:\s+B\s*\|?)?\s*$", line, re.I)
         if not m:
@@ -721,9 +701,8 @@ def _r9_38e2c_fix_combined_paddle_pair_by_nearby_evidence(
     for i, line in enumerate(refined):
         trace = line.get("producer_trace") or {}
         src = trace.get("source_index", line.get("source_index"))
-        if src is None:
-            continue
-        groups.setdefault(src, []).append(i)
+        if src is not None:
+            groups.setdefault(src, []).append(i)
 
     for src, indices in groups.items():
         if len(indices) < 2:
@@ -739,7 +718,10 @@ def _r9_38e2c_fix_combined_paddle_pair_by_nearby_evidence(
         used_amounts: list[Decimal] = []
         for line_idx in indices:
             key = _r9_38e2a_label_key(refined[line_idx].get("raw_label"))
-            matching = [e for e in nearby_evidence if e["label_key"] == key or key in e["label_key"] or e["label_key"] in key]
+            matching = [
+                e for e in nearby_evidence
+                if e["label_key"] == key or key in e["label_key"] or e["label_key"] in key
+            ]
             if not matching:
                 continue
             best = sorted(matching, key=lambda e: abs(int(e["source_index"]) - int(src)))[0]
@@ -750,13 +732,12 @@ def _r9_38e2c_fix_combined_paddle_pair_by_nearby_evidence(
         if not assigned:
             continue
         remaining_amounts = [amount for amount in raw_amounts if not any(abs(amount - used) <= Decimal("0.02") for used in used_amounts)]
-        unassigned_indices = [idx for idx in indices if idx not in assigned]
-        for idx, amount in zip(unassigned_indices, remaining_amounts):
+        for idx, amount in zip([idx for idx in indices if idx not in assigned], remaining_amounts):
             assigned[idx] = amount
         if len(assigned) < 2:
             continue
         for idx, amount in assigned.items():
-            old_total = _r9_38e2_decimal(refined[idx].get("line_total"))
+            old_total = _r9_38e1_decimal(refined[idx].get("line_total"))
             if abs(old_total - amount) <= Decimal("0.02"):
                 continue
             refined[idx]["unit_price"] = float(amount)

--- a/backend/app/receipt_ingestion/service_parts/ah_photo_bbox_article_reconstruction.py
+++ b/backend/app/receipt_ingestion/service_parts/ah_photo_bbox_article_reconstruction.py
@@ -1,0 +1,251 @@
+"""
+Technical Design Reference:
+- TD Section: TD-03 Receipt ingestion en parsers
+- Module Role: AH image receipt bbox/article-block reconstruction
+- Runtime Type: production
+- Used By: backend/app/receipt_ingestion/service_parts/image_ocr_flow.py
+- Status Authority: no
+- Refactor Status: targeted
+"""
+
+from __future__ import annotations
+
+from statistics import median
+from typing import Any
+import re
+
+
+_AMOUNT_RE = re.compile(r"(?<!\d)(\d{1,5}[\.,]\d{2})(?!\d)")
+
+
+def _bbox_anchor(box: Any) -> tuple[float, float, float] | None:
+    try:
+        if isinstance(box, (list, tuple)) and len(box) == 4 and not isinstance(box[0], (list, tuple)):
+            x1, y1, x2, y2 = [float(v) for v in box]
+            return ((y1 + y2) / 2.0, x1, max(1.0, y2 - y1))
+        points = []
+        for point in box or []:
+            if isinstance(point, (list, tuple)) and len(point) >= 2:
+                points.append((float(point[0]), float(point[1])))
+        if not points:
+            return None
+        xs = [point[0] for point in points]
+        ys = [point[1] for point in points]
+        return ((min(ys) + max(ys)) / 2.0, min(xs), max(1.0, max(ys) - min(ys)))
+    except Exception:
+        return None
+
+
+def _group_texts_to_rows(texts: list[str] | None, boxes: list[Any] | None) -> list[str]:
+    if not texts:
+        return []
+    if not boxes or len(boxes) != len(texts):
+        return [re.sub(r"\s+", " ", str(text or "")).strip() for text in texts if str(text or "").strip()]
+
+    fragments: list[tuple[float, float, float, str]] = []
+    heights: list[float] = []
+    for text, box in zip(texts, boxes):
+        value = re.sub(r"\s+", " ", str(text or "")).strip()
+        if not value:
+            continue
+        anchor = _bbox_anchor(box)
+        if anchor is None:
+            fragments.append((float(len(fragments) * 100), float(len(fragments)), 10.0, value))
+            continue
+        y, x, height = anchor
+        heights.append(height)
+        fragments.append((y, x, height, value))
+
+    if not fragments:
+        return []
+
+    fragments.sort(key=lambda item: (item[0], item[1]))
+    threshold = max(10.0, (median(heights) if heights else 10.0) * 0.62)
+    groups: list[list[tuple[float, float, float, str]]] = []
+    for fragment in fragments:
+        if not groups:
+            groups.append([fragment])
+            continue
+        current_y = sum(item[0] for item in groups[-1]) / len(groups[-1])
+        if abs(fragment[0] - current_y) <= threshold:
+            groups[-1].append(fragment)
+        else:
+            groups.append([fragment])
+
+    rows: list[str] = []
+    for group in groups:
+        group.sort(key=lambda item: item[1])
+        row = re.sub(r"\s+", " ", " ".join(item[3] for item in group)).strip()
+        if row:
+            rows.append(row)
+    return rows
+
+
+def _looks_like_ah(lines: list[str]) -> bool:
+    haystack = " ".join(str(line or "").lower() for line in lines[:25])
+    return (
+        "albert heijn" in haystack
+        or "bonuskaart" in haystack
+        or "airmiles" in haystack
+    ) and "subtotaal" in haystack
+
+
+def _amount_tokens(line: str) -> list[str]:
+    return _AMOUNT_RE.findall(str(line or ""))
+
+
+def _clean_label(value: str | None) -> str:
+    label = re.sub(r"^[^A-Za-zÀ-ÖØ-öø-ÿ0-9]+", "", str(value or "")).strip()
+    label = re.sub(r"\s+", " ", label)
+    return label.strip(" .:-")
+
+
+def _recover_loyalty_row_label(line: str | None) -> str | None:
+    raw = re.sub(r"\s+", " ", str(line or "")).strip()
+    if not re.search(r"bonuskaart|airmiles", raw, re.I):
+        return None
+    candidate = re.sub(r".*\b(?:AIRMILES\s+NR\.?|BONUSKAART)\b", "", raw, flags=re.I)
+    candidate = re.sub(r"\*", " ", candidate)
+    candidate = re.sub(r"\bxx\d+\b", " ", candidate, flags=re.I)
+    candidate = re.sub(r"\d+", " ", candidate)
+    candidate = re.sub(r"\s+", " ", candidate).strip(" .:-")
+    if len(candidate) < 3 or not re.search(r"[A-Za-zÀ-ÖØ-öø-ÿ]", candidate):
+        return None
+    if any(token in candidate.lower() for token in ("subtotaal", "totaal", "bonus", "koopzegel", "voordeel")):
+        return None
+    return _clean_label(candidate)
+
+
+def _split_ah_prefixed_label(label_part: str) -> list[str]:
+    words = str(label_part or "").split()
+    for pos, word in enumerate(words[1:], start=1):
+        if word.upper().strip(".,;:") == "AH":
+            left = _clean_label(" ".join(words[:pos]))
+            right = _clean_label(" ".join(words[pos:]))
+            if left and right:
+                return [left, right]
+    return [_clean_label(label_part)]
+
+
+def _first_subtotal_index(lines: list[str]) -> int | None:
+    for index, line in enumerate(lines):
+        if "subtotaal" in str(line or "").lower():
+            return index
+    return None
+
+
+def _header_index(lines: list[str]) -> int | None:
+    for index, line in enumerate(lines):
+        lowered = str(line or "").lower()
+        if "omschrijving" in lowered and ("prijs" in lowered or "pri js" in lowered or "bedrag" in lowered):
+            return index
+    return None
+
+
+def _normalize_article_block(lines: list[str]) -> tuple[list[str], bool]:
+    start = _header_index(lines)
+    end = _first_subtotal_index(lines)
+    if start is None or end is None or end <= start:
+        return lines, False
+
+    output: list[str] = list(lines[: start + 1])
+    changed = False
+    pending_label: str | None = None
+
+    index = start + 1
+    while index < end:
+        raw = re.sub(r"\s+", " ", str(lines[index] or "")).strip()
+        lowered = raw.lower()
+        if not raw:
+            index += 1
+            continue
+
+        recovered = _recover_loyalty_row_label(raw)
+        if recovered:
+            pending_label = recovered
+            output.append(raw)
+            index += 1
+            continue
+
+        if "bonuskaart" in lowered or "airmiles" in lowered:
+            output.append(raw)
+            index += 1
+            continue
+
+        if re.match(r"^\s*(?:\d{1,2}\s+)?\d+[\.,]\d{3}\s*(?:k|kg)\b", raw, re.I):
+            output.append(raw)
+            index += 1
+            continue
+
+        amounts = _amount_tokens(raw)
+        if not amounts:
+            output.append(raw)
+            index += 1
+            continue
+
+        quantity_match = re.match(r"^\s*(?P<qty>\d{1,2})\s+(?P<body>.+)$", raw)
+        if not quantity_match:
+            output.append(raw)
+            index += 1
+            continue
+
+        qty = quantity_match.group("qty")
+        body = quantity_match.group("body")
+        b_marker = bool(re.search(r"(?:^|\s)B(?:\s|$)", body))
+        first_amount = re.search(r"(?<!\d)\d{1,5}[\.,]\d{2}(?!\d)", body)
+        if not first_amount:
+            output.append(raw)
+            index += 1
+            continue
+
+        label_part = body[: first_amount.start()].strip()
+        labels = _split_ah_prefixed_label(label_part)
+
+        if pending_label and len(labels) == 1 and len(amounts) >= 2 and b_marker:
+            output.append(f"{qty} {labels[0]} {amounts[0]} B")
+            output.append(f"1 {pending_label} {amounts[-1]}")
+            pending_label = None
+            changed = True
+            index += 1
+            continue
+
+        if len(labels) >= 2 and len(amounts) == 2 and b_marker and labels[1].upper().startswith("AH "):
+            output.append(f"1 {labels[0]} {amounts[1]} B")
+            output.append(f"{qty} {labels[1]} {amounts[0]}")
+            changed = True
+            index += 1
+            continue
+
+        output.append(raw)
+        index += 1
+
+    output.extend(lines[end:])
+    return output, changed
+
+
+def apply_ah_photo_bbox_article_reconstruction(
+    *,
+    filename: str | None,
+    texts: list[str] | None,
+    boxes: list[Any] | None,
+    current_lines: list[str] | None,
+) -> list[str] | None:
+    """Reconstruct AH photo article rows from Paddle bbox/text layout.
+
+    This is intentionally source-driven. It may split or pair rows only when the
+    relevant labels and amounts are visible in OCR/bbox-derived text. It does not
+    use receipt ids, filenames as examples, product catalogs or fixed article names.
+    """
+    candidates = _group_texts_to_rows(texts or [], boxes or []) or list(current_lines or [])
+    if not candidates or not _looks_like_ah(candidates):
+        return None
+
+    normalized, changed = _normalize_article_block(candidates)
+    if not changed:
+        # Fallback: current_lines may already contain a better grouped article block
+        # than bbox row grouping. Try the same guarded normalization there.
+        normalized, changed = _normalize_article_block(list(current_lines or []))
+
+    if not changed:
+        return None
+    return normalized

--- a/backend/app/receipt_ingestion/service_parts/ah_photo_bbox_article_reconstruction.py
+++ b/backend/app/receipt_ingestion/service_parts/ah_photo_bbox_article_reconstruction.py
@@ -82,12 +82,14 @@ def _group_texts_to_rows(texts: list[str] | None, boxes: list[Any] | None) -> li
 
 
 def _looks_like_ah(lines: list[str]) -> bool:
-    haystack = " ".join(str(line or "").lower() for line in lines[:25])
+    # Long AH photo receipts can have the first SUBTOTAAL after 25+ article rows.
+    # Do not limit the AH-context check to the first screen of OCR rows.
+    head = " ".join(str(line or "").lower() for line in lines[:80])
     return (
-        "albert heijn" in haystack
-        or "bonuskaart" in haystack
-        or "airmiles" in haystack
-    ) and "subtotaal" in haystack
+        "albert heijn" in head
+        or "bonuskaart" in head
+        or "airmiles" in head
+    ) and "subtotaal" in head
 
 
 def _amount_tokens(line: str) -> list[str]:
@@ -125,6 +127,21 @@ def _split_ah_prefixed_label(label_part: str) -> list[str]:
             if left and right:
                 return [left, right]
     return [_clean_label(label_part)]
+
+
+def _split_repeated_label(label_part: str) -> str | None:
+    words = [word for word in str(label_part or "").split() if word]
+    if len(words) < 2 or len(words) % 2 != 0:
+        return None
+    half = len(words) // 2
+    left = " ".join(words[:half])
+    right = " ".join(words[half:])
+    if left.upper() != right.upper():
+        return None
+    label = _clean_label(left)
+    if len(label) < 3:
+        return None
+    return label
 
 
 def _first_subtotal_index(lines: list[str]) -> int | None:
@@ -236,10 +253,30 @@ def _normalize_article_block(lines: list[str]) -> tuple[list[str], bool]:
         label_part = body[: first_amount.start()].strip()
         labels = _split_ah_prefixed_label(label_part)
 
+        repeated_label = _split_repeated_label(label_part)
+        if repeated_label and len(amounts) == 1 and b_marker:
+            # Paddle can collapse two identical AH article rows into one visual
+            # label phrase, e.g. "1 OLIJFOLIE OLIJFOLIE 4.79 B". The repeated
+            # label is visible twice; the amount is visible once in the same
+            # price/amount column and applies to both equal rows.
+            output.append(f"{qty} {repeated_label} {amounts[0]} B")
+            output.append(f"{qty} {repeated_label} {amounts[0]} B")
+            changed = True
+            index += 1
+            continue
+
         if pending_label and len(labels) == 1 and len(amounts) >= 2 and b_marker:
             output.append(f"{qty} {labels[0]} {amounts[0]} B")
             output.append(f"1 {pending_label} {amounts[-1]}")
             pending_label = None
+            changed = True
+            index += 1
+            continue
+
+        if len(labels) == 1 and len(amounts) >= 2 and b_marker and labels[0].upper().startswith("AH "):
+            # Right-column AH article with a trailing B amount from a neighbouring
+            # row. Keep only the visible article amount for this label.
+            output.append(f"{qty} {labels[0]} {amounts[0]}")
             changed = True
             index += 1
             continue

--- a/backend/app/receipt_ingestion/service_parts/ah_photo_bbox_article_reconstruction.py
+++ b/backend/app/receipt_ingestion/service_parts/ah_photo_bbox_article_reconstruction.py
@@ -142,6 +142,33 @@ def _header_index(lines: list[str]) -> int | None:
     return None
 
 
+def _product_from_price_per_row(raw: str) -> str | None:
+    """Return product row from AH price-per detail rows that also contain a next item.
+
+    A line like "Prijs per kg 11,97 KOMKOMMER 0,99" contains a unit-price detail
+    for the previous weighted article and a separate visible article. The unit
+    price must not become a product line; the trailing article may be preserved.
+    """
+    line = re.sub(r"\s+", " ", str(raw or "")).strip()
+    match = re.match(
+        r"^prijs\s+per\s+(?:kg|kilo|stuk)\s+"
+        r"(?:(?:\d{1,5}[\.,]\d{2})\s+)?"
+        r"(?P<label>[A-Za-zÀ-ÖØ-öø-ÿ][A-Za-zÀ-ÖØ-öø-ÿ0-9 '\-]{2,}?)\s+"
+        r"(?P<amount>\d{1,5}[\.,]\d{2})(?:\s*[A-Z])?\s*$",
+        line,
+        flags=re.I,
+    )
+    if not match:
+        return None
+    label = _clean_label(match.group("label"))
+    amount = match.group("amount")
+    if not label:
+        return None
+    if any(token in label.lower() for token in ("prijs per", "subtotaal", "totaal", "bonus", "voordeel", "koopzegel")):
+        return None
+    return f"1 {label} {amount}"
+
+
 def _normalize_article_block(lines: list[str]) -> tuple[list[str], bool]:
     start = _header_index(lines)
     end = _first_subtotal_index(lines)
@@ -157,6 +184,14 @@ def _normalize_article_block(lines: list[str]) -> tuple[list[str], bool]:
         raw = re.sub(r"\s+", " ", str(lines[index] or "")).strip()
         lowered = raw.lower()
         if not raw:
+            index += 1
+            continue
+
+        if re.match(r"^prijs\s+per\b", lowered):
+            product_row = _product_from_price_per_row(raw)
+            if product_row:
+                output.append(product_row)
+            changed = True
             index += 1
             continue
 

--- a/backend/app/receipt_ingestion/service_parts/ah_photo_bbox_article_reconstruction.py
+++ b/backend/app/receipt_ingestion/service_parts/ah_photo_bbox_article_reconstruction.py
@@ -263,6 +263,23 @@ def _normalize_article_block(lines: list[str]) -> tuple[list[str], bool]:
             index += 1
             continue
 
+        # A bbox row can contain a visible AH article label with only its amount,
+        # e.g. "AH TAART 6,49". In the AH article block this is a single item;
+        # normalize to the canonical quantity-label-amount shape.
+        single_ah_amount_match = re.match(
+            r"^(?P<label>AH\s+[A-Za-z?-??-??-?][A-Za-z?-??-??-?0-9 '\\-]{2,}?)\s+"
+            r"(?P<amount>\d{1,5}[\.,]\d{2})(?:\s*[A-Z])?$",
+            raw,
+            flags=re.I,
+        )
+        if single_ah_amount_match:
+            label = _clean_label(single_ah_amount_match.group("label"))
+            if label and not any(token in label.lower() for token in ("subtotaal", "totaal", "bonus", "koopzegel", "prijs per")):
+                output.append(f"1 {label} {single_ah_amount_match.group('amount')}")
+                changed = True
+                index += 1
+                continue
+
         quantity_match = re.match(r"^\s*(?P<qty>\d{1,2})\s+(?P<body>.+)$", raw)
         if not quantity_match:
             output.append(raw)

--- a/backend/app/receipt_ingestion/service_parts/ah_photo_bbox_article_reconstruction.py
+++ b/backend/app/receipt_ingestion/service_parts/ah_photo_bbox_article_reconstruction.py
@@ -204,6 +204,34 @@ def _normalize_article_block(lines: list[str]) -> tuple[list[str], bool]:
             index += 1
             continue
 
+        # AH photo bbox can expose an article as three separate visual fragments:
+        # quantity marker -> AH product label -> amount. Reconstruct that visible
+        # source pattern before generic row parsing so the article is not lost.
+        qty_only_match = re.fullmatch(r"(?:\d{1,2}|[TtIi|Nn])", raw)
+        if qty_only_match and index + 2 < end:
+            next_label_raw = re.sub(r"\s+", " ", str(lines[index + 1] or "")).strip()
+            next_amount_raw = re.sub(r"\s+", " ", str(lines[index + 2] or "")).strip()
+            next_label = _clean_label(next_label_raw)
+            next_amounts = _amount_tokens(next_amount_raw)
+            if (
+                next_label
+                and next_label.upper().startswith("AH ")
+                and not _amount_tokens(next_label_raw)
+                and len(next_amounts) == 1
+                and re.fullmatch(r"\d{1,5}[\.,]\d{2}", next_amount_raw)
+            ):
+                token = raw.strip().upper()
+                if token in {"T", "I", "|"}:
+                    qty = "1"
+                elif token == "N":
+                    qty = "2"
+                else:
+                    qty = raw.strip()
+                output.append(f"{qty} {next_label} {next_amounts[0]}")
+                changed = True
+                index += 3
+                continue
+
         if re.match(r"^prijs\s+per\b", lowered):
             product_row = _product_from_price_per_row(raw)
             if product_row:

--- a/backend/app/receipt_ingestion/service_parts/image_ocr_flow.py
+++ b/backend/app/receipt_ingestion/service_parts/image_ocr_flow.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from statistics import median
 from typing import Any
 
+from app.receipt_ingestion.service_parts.ah_photo_bbox_article_reconstruction import apply_ah_photo_bbox_article_reconstruction
 from app.receipt_ingestion.service_parts.generic_receipt_layout_reconstruction import apply_generic_receipt_layout_reconstruction
 from app.receipt_ingestion.service_parts.plus_photo_line_grouping_fallback import apply_plus_photo_line_grouping_fallback
 from app.receipt_ingestion.service_parts.plus_photo_preprocessed_fallback_ocr import guarded_plus_preprocessed_ocr_fallback
@@ -347,28 +348,37 @@ def _ocr_image_text_with_paddle(file_bytes: bytes, filename: str) -> tuple[list[
     if plus_fallback_lines is not None:
         line_candidates = plus_fallback_lines
     else:
-        generic_layout_lines = apply_generic_receipt_layout_reconstruction(
+        ah_bbox_lines = apply_ah_photo_bbox_article_reconstruction(
             filename=filename,
             texts=texts,
             boxes=boxes,
             current_lines=line_candidates,
         )
-        if generic_layout_lines is not None:
-            line_candidates = generic_layout_lines
+        if ah_bbox_lines is not None:
+            line_candidates = ah_bbox_lines
         else:
-            preprocessed_result = guarded_plus_preprocessed_ocr_fallback(
-                model=model,
-                file_bytes=file_bytes,
+            generic_layout_lines = apply_generic_receipt_layout_reconstruction(
                 filename=filename,
-                runtime_texts=texts,
-                runtime_boxes=boxes,
-                runtime_lines=line_candidates,
+                texts=texts,
+                boxes=boxes,
+                current_lines=line_candidates,
             )
-            if preprocessed_result.get('fallback_lines'):
-                line_candidates = list(preprocessed_result['fallback_lines'])
-                pre_scores = preprocessed_result.get('preprocessed_scores') or []
-                if pre_scores:
-                    scores = [float(score) for score in pre_scores]
+            if generic_layout_lines is not None:
+                line_candidates = generic_layout_lines
+            else:
+                preprocessed_result = guarded_plus_preprocessed_ocr_fallback(
+                    model=model,
+                    file_bytes=file_bytes,
+                    filename=filename,
+                    runtime_texts=texts,
+                    runtime_boxes=boxes,
+                    runtime_lines=line_candidates,
+                )
+                if preprocessed_result.get('fallback_lines'):
+                    line_candidates = list(preprocessed_result['fallback_lines'])
+                    pre_scores = preprocessed_result.get('preprocessed_scores') or []
+                    if pre_scores:
+                        scores = [float(score) for score in pre_scores]
     confidence = round(sum(scores) / len(scores), 4) if scores else None
     return line_candidates, confidence
 

--- a/backend/app/services/receipt_service.py
+++ b/backend/app/services/receipt_service.py
@@ -1810,6 +1810,9 @@ def parse_receipt_content(file_bytes: bytes, filename: str, mime_type: str) -> R
                     total_amount=image_result.total_amount,
                 )
 
+                # Final guard after AH/image-specific repairs: supporting detail rows
+                # such as 'Prijs per kg' must not re-enter persisted product lines.
+                image_result.lines = _filter_non_product_receipt_lines(image_result.lines or [])
                 image_result.parse_status = determine_final_parse_status(image_result)
 
                 diagnostics['ah_ocr_arbitrage'] = {

--- a/backend/app/testing/receipt_ah_photo10_source_evidence.py
+++ b/backend/app/testing/receipt_ah_photo10_source_evidence.py
@@ -1,0 +1,206 @@
+"""Source-evidence runner voor M2C2i-AH-Photo-04b.
+
+Doel: AH foto 10 regel/prijs-koppeling herstellen zonder blind te patchen.
+
+Deze runner wijzigt geen database. Hij:
+- leest de ruwe AH foto 10 uit de bestaande database;
+- draait dezelfde image-preprocessing als de runtime;
+- print Paddle- en Tesseract-bronregels op de preprocessing-route;
+- print ook originele Paddle/Tesseract-regels wanneer preprocessing bytes wijzigt;
+- draait parse_receipt_content en print de uiteindelijke regels/diagnostics;
+- berekent de Variant-B-financiële diagnose.
+
+Herkenbare output:
+
+AH_PHOTO_10_SOURCE_EVIDENCE_READY
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import create_engine, text
+
+from app.receipt_ingestion.preprocessing.receipt_image_preprocessing import (
+    apply_receipt_image_preprocessing,
+)
+from app.receipt_ingestion.service_parts.image_ocr_flow import (
+    _ocr_image_text_with_paddle,
+    _ocr_image_text_with_tesseract,
+    get_last_paddle_bbox_payload,
+)
+from app.services.receipt_service import parse_receipt_content
+
+
+ENGINE_URL = "sqlite:////app/data/rezzerv.db"
+AH_PHOTO_10_ID = "800894a1cf4a48598f4095be5532dc26"
+CENT = Decimal("0.01")
+
+
+def money(value: Any) -> Decimal:
+    try:
+        if value is None or value == "":
+            return Decimal("0.00")
+        return Decimal(str(value)).quantize(CENT)
+    except Exception:
+        return Decimal("0.00")
+
+
+def print_lines(title: str, lines: list[str] | None) -> None:
+    print("")
+    print(f"=== {title} ===")
+    for idx, line in enumerate(lines or []):
+        print(f"{idx:03d}: {line}")
+
+
+def line_sum(lines: list[dict[str, Any]] | None) -> tuple[Decimal, Decimal]:
+    total = sum((money(line.get("line_total")) for line in (lines or [])), Decimal("0.00"))
+    discount = sum((money(line.get("discount_amount")) for line in (lines or [])), Decimal("0.00"))
+    return total.quantize(CENT), discount.quantize(CENT)
+
+
+def print_parse_result(result: Any) -> None:
+    print("")
+    print("=== PARSE RESULT ===")
+    print("is_receipt       :", getattr(result, "is_receipt", None))
+    print("parse_status     :", getattr(result, "parse_status", None))
+    print("confidence_score :", getattr(result, "confidence_score", None))
+    print("store_name       :", getattr(result, "store_name", None))
+    print("store_branch     :", getattr(result, "store_branch", None))
+    print("purchase_at      :", getattr(result, "purchase_at", None))
+    print("total_amount     :", getattr(result, "total_amount", None))
+    print("discount_total   :", getattr(result, "discount_total", None))
+    print("currency         :", getattr(result, "currency", None))
+
+    lines = getattr(result, "lines", None) or []
+    line_total, line_discount = line_sum(lines)
+    receipt_discount = money(getattr(result, "discount_total", None))
+    expected = money(getattr(result, "total_amount", None))
+    using_line_discount = (line_total + line_discount).quantize(CENT)
+    using_receipt_discount = (line_total + receipt_discount).quantize(CENT)
+    using_both = (line_total + line_discount + receipt_discount).quantize(CENT)
+
+    print("line_count       :", len(lines))
+    print("line_total_sum   :", line_total)
+    print("line_discount_sum:", line_discount)
+    print("receipt_discount :", receipt_discount)
+    print("variant_b_line   :", using_line_discount)
+    print("variant_b_receipt:", using_receipt_discount)
+    print("unsafe_both      :", using_both)
+    print("diff_line        :", (using_line_discount - expected).quantize(CENT))
+    print("diff_receipt     :", (using_receipt_discount - expected).quantize(CENT))
+    print("diff_both        :", (using_both - expected).quantize(CENT))
+
+    print("")
+    print("--- parsed lines ---")
+    for idx, line in enumerate(lines):
+        trace = line.get("producer_trace") if isinstance(line, dict) else None
+        print(
+            idx,
+            "| raw=", line.get("raw_label"),
+            "| norm=", line.get("normalized_label"),
+            "| qty=", line.get("quantity"),
+            "| unit_price=", line.get("unit_price"),
+            "| line_total=", line.get("line_total"),
+            "| discount=", line.get("discount_amount"),
+            "| source_index=", line.get("source_index"),
+            "| trace_raw=", (trace or {}).get("raw_line") if isinstance(trace, dict) else None,
+        )
+
+    print("")
+    print("--- parser diagnostics ---")
+    print(json.dumps(getattr(result, "parser_diagnostics", None) or {}, indent=2, sort_keys=True, default=str))
+
+
+def main() -> None:
+    engine = create_engine(ENGINE_URL, future=True)
+    with engine.begin() as conn:
+        row = conn.execute(
+            text(
+                """
+                SELECT
+                    rt.id AS receipt_table_id,
+                    rr.id AS raw_receipt_id,
+                    rr.original_filename,
+                    rr.mime_type,
+                    rr.storage_path,
+                    rr.sha256_hash,
+                    rt.total_amount,
+                    rt.parse_status
+                FROM receipt_tables rt
+                JOIN raw_receipts rr ON rr.id = rt.raw_receipt_id
+                WHERE rt.id = :id OR rr.id = :id
+                LIMIT 1
+                """
+            ),
+            {"id": AH_PHOTO_10_ID},
+        ).mappings().first()
+
+    if not row:
+        print("AH foto 10 niet gevonden")
+        print("AH_PHOTO_10_SOURCE_EVIDENCE_READY")
+        print("SOURCE_EVIDENCE_STATUS=DATA_NOT_FOUND")
+        return
+
+    print("=== SOURCE RECORD ===")
+    for key, value in dict(row).items():
+        print(f"{key:18}:", value)
+
+    file_path = Path(row["storage_path"])
+    file_bytes = file_path.read_bytes()
+    filename = str(row["original_filename"] or file_path.name)
+    mime_type = str(row["mime_type"] or "image/jpeg")
+
+    print("")
+    print("=== PREPROCESSING ===")
+    try:
+        preprocessed_bytes, decision = apply_receipt_image_preprocessing(file_bytes, filename)
+        route = getattr(decision, "selected_route", None) if decision else None
+        print("selected_route      :", route)
+        print("bytes_changed       :", preprocessed_bytes != file_bytes)
+    except Exception as exc:
+        print("preprocessing_error :", repr(exc))
+        preprocessed_bytes = file_bytes
+        route = None
+
+    ocr_filename = filename
+    if route and route != "original":
+        ocr_filename = f"{Path(filename).stem}-safe-rotation.png"
+
+    paddle_lines, paddle_confidence = _ocr_image_text_with_paddle(preprocessed_bytes, ocr_filename)
+    paddle_bbox_payload = get_last_paddle_bbox_payload(ocr_filename) or {}
+    tesseract_lines, tesseract_confidence = _ocr_image_text_with_tesseract(preprocessed_bytes, ocr_filename)
+
+    print("")
+    print("=== OCR CONFIDENCE ===")
+    print("paddle_confidence   :", paddle_confidence)
+    print("tesseract_confidence:", tesseract_confidence)
+    print("paddle_bbox_texts   :", len(paddle_bbox_payload.get("texts") or []))
+    print("paddle_bbox_boxes   :", len(paddle_bbox_payload.get("boxes") or []))
+
+    print_lines("PREPROCESSED PADDLE LINES", paddle_lines)
+    print_lines("PREPROCESSED TESSERACT LINES", tesseract_lines)
+
+    if preprocessed_bytes != file_bytes:
+        original_paddle_lines, original_paddle_confidence = _ocr_image_text_with_paddle(file_bytes, filename)
+        original_tesseract_lines, original_tesseract_confidence = _ocr_image_text_with_tesseract(file_bytes, filename)
+        print("")
+        print("=== ORIGINAL OCR CONFIDENCE ===")
+        print("original_paddle_confidence   :", original_paddle_confidence)
+        print("original_tesseract_confidence:", original_tesseract_confidence)
+        print_lines("ORIGINAL PADDLE LINES", original_paddle_lines)
+        print_lines("ORIGINAL TESSERACT LINES", original_tesseract_lines)
+
+    result = parse_receipt_content(file_bytes, filename, mime_type)
+    print_parse_result(result)
+
+    print("")
+    print("AH_PHOTO_10_SOURCE_EVIDENCE_READY")
+    print("SOURCE_EVIDENCE_STATUS=OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Samenvatting

Vervolg op #148.

Deze draft-PR voegt een source-evidence runner toe voor AH foto 10. De runner wijzigt geen database en geen productiecode.

## Waarom

De 04-diagnose bewees dat AH foto 10 na reparse blijft hangen op:

```text
CAUSE_CATEGORY=REPARSE_CHANGED_LINES_BUT_TOTAL_STILL_MISMATCH
```

De vermoedelijke oorzaak is AH-foto-regel/prijs-koppeling. Voor een veilige generieke fix is eerst de ruwe OCR-bron nodig.

## Wijziging

Toegevoegd:

```text
backend/app/testing/receipt_ah_photo10_source_evidence.py
```

De runner print:

- raw receipt record;
- preprocessing-route;
- Paddle-regels;
- Tesseract-regels;
- originele OCR-regels als preprocessing bytes wijzigt;
- parserresultaatregels inclusief `producer_trace.raw_line`;
- parserdiagnostics;
- Variant-B-financiële diagnose.

## Herkenbare output

```text
AH_PHOTO_10_SOURCE_EVIDENCE_READY
SOURCE_EVIDENCE_STATUS=OK
```

## Buiten scope

- Geen parserwijziging.
- Geen OCR-enginewijziging.
- Geen frontendwijziging.
- Geen databasewijziging.
- Geen voorraad-/Uitpakkenwijziging.
- Geen hardcoded bon-ID/filename in productiecode.

## Validatie

Nog uit te voeren op featurebranch:

```bash
cd /app && PYTHONPATH=/app python -m py_compile app/testing/receipt_ah_photo10_source_evidence.py
cd /app && PYTHONPATH=/app python app/testing/receipt_ah_photo10_source_evidence.py
```

Daarna kan de echte 04b-fix gericht worden bepaald.