### PR TITLE
fix(receipts): handle VAT-labelled totals and PLUS group discounts

### DIFF
--- a/backend/app/receipt_ingestion/header_parser.py
+++ b/backend/app/receipt_ingestion/header_parser.py
@@ -58,12 +58,33 @@ def _looks_like_fuzzy_total_label(value: str | None) -> bool:
 
 
 def _looks_like_vat_total_line(value: str | None) -> bool:
-    """Return True for VAT/tax summary rows that must not become receipt totals."""
+    """Return True for VAT/tax summary rows that must not become receipt totals.
+
+    Guardrail:
+    A final receipt total may legitimately be labelled as ``Totaal (incl. BTW)``.
+    Such lines are explicit receipt totals and must not be filtered merely
+    because they mention VAT/BTW. VAT summary rows such as ``BTW Totaal`` or
+    rows with ``Bedrag excl/incl`` remain excluded.
+    """
     lowered = re.sub(r'\s+', ' ', str(value or '')).strip().lower()
     if not lowered:
         return False
-    if any(token in lowered for token in ('btw', 'vat', 'biw', 'bedr.excl', 'bedr.incl', 'bedrag excl', 'bedrag incl')):
+
+    explicit_total_at_start = _looks_like_fuzzy_total_label(lowered)
+    includes_vat_marker = bool(re.search(r'\b(?:incl|inclusief)\.?\s*(?:btw|vat|biw)\b', lowered))
+
+    if explicit_total_at_start and includes_vat_marker:
+        return False
+
+    if re.search(r'^\s*(?:btw|vat|biw)\b', lowered):
         return True
+
+    if any(token in lowered for token in ('btw totaal', 'vat total', 'bedr.excl', 'bedr.incl', 'bedrag excl', 'bedrag incl')):
+        return True
+
+    if any(token in lowered for token in ('btw', 'vat', 'biw')):
+        return True
+
     return False
 
 

--- a/backend/app/receipt_ingestion/parsing/plus_correction_runtime.py
+++ b/backend/app/receipt_ingestion/parsing/plus_correction_runtime.py
@@ -116,6 +116,17 @@ def _sanitize_summary_plus_line_discounts(lines: list[dict[str, Any]], summary_a
 def apply_plus_runtime_corrections(**kwargs: Any):
     lines, discount_total, diagnostics = _base_apply_plus_runtime_corrections(**kwargs)
     sanitized_lines, removed_implausible = _sanitize_implausible_plus_line_discounts(lines)
+
+    parked_receipt_discount = Decimal('0.00')
+    for item in removed_implausible:
+        parked_receipt_discount += _money(item.get('removed_discount_amount'))
+
+    if parked_receipt_discount != Decimal('0.00'):
+        discount_total = (_money(discount_total) + parked_receipt_discount).quantize(
+            Decimal('0.01'),
+            rounding=ROUND_HALF_UP,
+        )
+
     summary_amounts = _summary_discount_amounts(kwargs.get('text_lines'))
     sanitized_lines, removed_summary = _sanitize_summary_plus_line_discounts(sanitized_lines, summary_amounts)
     if removed_implausible or removed_summary:
@@ -124,6 +135,7 @@ def apply_plus_runtime_corrections(**kwargs: Any):
         if removed_implausible:
             plus_diag['implausible_line_discount_guardrail_applied'] = True
             plus_diag['removed_implausible_line_discounts'] = removed_implausible
+            plus_diag['implausible_line_discounts_parked_as_receipt_discount'] = float(parked_receipt_discount)
         if removed_summary:
             plus_diag['summary_line_discount_guardrail_applied'] = True
             plus_diag['removed_summary_line_discounts'] = removed_summary


### PR DESCRIPTION
## Samenvatting

Deze patch lost twee generieke receipt parsing issues op:

1. `Totaal (incl. BTW)` werd ten onrechte weggefilterd als BTW-samenvattingsregel.
2. PLUS-groepskortingen die groter zijn dan één individuele artikelregel werden verwijderd in plaats van als bonniveau-korting meegenomen.

## Gewijzigde bestanden

- `backend/app/receipt_ingestion/header_parser.py`
- `backend/app/receipt_ingestion/parsing/plus_correction_runtime.py`

## Validatie

- `python -m py_compile backend/app/receipt_ingestion/header_parser.py backend/app/receipt_ingestion/parsing/plus_correction_runtime.py`
- `generic_chain_validation_v5.txt`

Resultaat:

- Jumbo App 1: `Gecontroleerd`, totaal `56.91`, regelsom `56.91`
- PLUS foto 1: `Gecontroleerd`, netto totaal `14.33`
- `ALL_GREEN : True`

## Guardrails

- Geen receipt-id/filename/productnaam hardcoding in productiecode.
- Geen baseline-afhankelijkheid.
- Geen inventory-mutatie.
- Geen fallback-kandidaten als echte matches.