### PR TITLE
fix(uitpakken): vervang Mijn artikel door Artikelgroep

### DIFF
--- a/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
+++ b/frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx
@@ -161,7 +161,7 @@ export default function ExternalDatabasesPage() {
         <div className="rz-external-databases-test">
           <div className="rz-external-databases-section-header">
             <h3>Lidl-kandidaatpreview</h3>
-            <span className="rz-external-databases-muted">Preview-only: geen Mijn artikel, product of voorraadmutatie.</span>
+            <span className="rz-external-databases-muted">Preview-only: geen artikelgroep, product of voorraadmutatie.</span>
           </div>
           <form onSubmit={testCandidateMatch} className="rz-external-databases-form">
             <div className="rz-external-databases-form-grid">
@@ -186,7 +186,7 @@ export default function ExternalDatabasesPage() {
               <Button type="button" variant="secondary" disabled={isSaving || !candidates.length} onClick={saveCandidateMatches}>{isSaving ? 'Opslaan...' : 'Kandidaten opslaan'}</Button>
             </div>
           </form>
-          <div className="rz-external-databases-muted">Drempel probable_candidate: {formatScore(selectedRetailerConfig?.probable_candidate_threshold)}. Deze opslag maakt geen Mijn artikel, global_product of voorraadmutatie aan.</div>
+          <div className="rz-external-databases-muted">Drempel probable_candidate: {formatScore(selectedRetailerConfig?.probable_candidate_threshold)}. Deze opslag maakt geen artikelgroep, global_product of voorraadmutatie aan.</div>
           {matchResult ? (
             <div className="rz-external-databases-preview-meta" data-testid="external-database-preview-meta">
               <span>Bron: {matchResult.candidate_source || '-'}</span>
@@ -228,7 +228,7 @@ export default function ExternalDatabasesPage() {
             <div className="rz-external-databases-header">
               <div className="rz-external-databases-title-group">
                 <h2 className="rz-external-databases-title">Externe databases</h2>
-                <p className="rz-external-databases-subtitle">Eerste versie voor externe productkandidaten. Deze preview maakt geen Mijn artikel, product of voorraadmutatie aan.</p>
+                <p className="rz-external-databases-subtitle">Eerste versie voor externe productkandidaten. Deze preview maakt geen artikelgroep, product of voorraadmutatie aan.</p>
               </div>
             </div>
             {renderTabContent(TAB_LABELS.overzicht)}

--- a/frontend/src/features/stores/StoreBatchDetailPage.jsx
+++ b/frontend/src/features/stores/StoreBatchDetailPage.jsx
@@ -1,4 +1,4 @@
-﻿import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import AppShell from '../../app/AppShell'
 import ScreenCard from '../../ui/ScreenCard'
@@ -748,7 +748,7 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
     if (!batch || selectedLineIds.length === 0) return
     const selectedSet = new Set(selectedLineIds.map((id) => String(id)))
     const rows = lineUiStates.filter((entry) => selectedSet.has(String(entry.line.id)))
-    const header = ['Bonartikel', 'Mijn artikel', 'Locatie', 'Aantal', 'Standaardartikel', 'Status']
+    const header = ['Bonartikel', 'Artikelgroep', 'Locatie', 'Aantal', 'Standaardartikel', 'Status']
     const csvRows = rows.map((entry) => {
       const articleName = entry.line.resolved_household_article_name || articleLabel(articleOptions.find((option) => String(option.id) === String(entry.draft.articleId))) || ''
       const locationLabel = locationOptions.find((location) => String(location.id) === String(entry.draft.locationId))?.label || ''
@@ -1034,13 +1034,13 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
                   <ResizableHeaderCell columnKey="bonartikel" widths={lineColumnWidths} onStartResize={startLineResize} className="rz-store-batch-col-item" sortable isSorted={tableSort.key === 'bonartikel'} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { bonartikel: 'asc', locatie: 'asc', aantal: 'desc', gekoppeld: 'asc', standaardartikel: 'asc' }))}>Bonartikel</ResizableHeaderCell>
                   <ResizableHeaderCell columnKey="locatie" widths={lineColumnWidths} onStartResize={startLineResize} className="rz-store-batch-col-location" sortable isSorted={tableSort.key === 'locatie'} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { bonartikel: 'asc', locatie: 'asc', aantal: 'desc', gekoppeld: 'asc', standaardartikel: 'asc' }))}>Locatie / sublocatie</ResizableHeaderCell>
                   <ResizableHeaderCell columnKey="aantal" widths={lineColumnWidths} onStartResize={startLineResize} className="rz-num rz-store-batch-col-quantity" sortable isSorted={tableSort.key === 'aantal'} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { bonartikel: 'asc', locatie: 'asc', aantal: 'desc', gekoppeld: 'asc', standaardartikel: 'asc' }))}>Aantal</ResizableHeaderCell>
-                  <ResizableHeaderCell columnKey="gekoppeld" widths={lineColumnWidths} onStartResize={startLineResize} className="rz-store-batch-col-linked" sortable isSorted={tableSort.key === 'gekoppeld'} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { bonartikel: 'asc', locatie: 'asc', aantal: 'desc', gekoppeld: 'asc', standaardartikel: 'asc' }))}>Mijn artikel</ResizableHeaderCell>
+                  <ResizableHeaderCell columnKey="gekoppeld" widths={lineColumnWidths} onStartResize={startLineResize} className="rz-store-batch-col-linked" sortable isSorted={tableSort.key === 'gekoppeld'} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { bonartikel: 'asc', locatie: 'asc', aantal: 'desc', gekoppeld: 'asc', standaardartikel: 'asc' }))}>Artikelgroep</ResizableHeaderCell>
                   <ResizableHeaderCell columnKey="standaardartikel" widths={lineColumnWidths} onStartResize={startLineResize} className="rz-store-batch-col-standard" sortable isSorted={tableSort.key === 'standaardartikel'} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { bonartikel: 'asc', locatie: 'asc', aantal: 'desc', gekoppeld: 'asc', standaardartikel: 'asc' }))}>Standaardartikel</ResizableHeaderCell>
                 </tr>
                 <tr className="rz-table-filters">
                   <th />
                   <th>
-                    <input className="rz-input rz-inline-input" type="text" placeholder="Filter" value={searchValue} onChange={(event) => setSearchValue(event.target.value)} aria-label="Filter op bonartikel of mijn artikel" />
+                    <input className="rz-input rz-inline-input" type="text" placeholder="Filter" value={searchValue} onChange={(event) => setSearchValue(event.target.value)} aria-label="Filter op bonartikel of artikelgroep" />
                   </th>
                   <th>
                     <select className="rz-input rz-inline-input" value={locationFilter} onChange={(event) => setLocationFilter(event.target.value)}>


### PR DESCRIPTION
## Samenvatting

Deze PR past de bronteksten rechtstreeks aan voor de eerste Artikelgroep-stap.

Wijziging:
- Uitpakken toont `Artikelgroep` in plaats van `Mijn artikel`.
- CSV-export gebruikt `Artikelgroep` als kolomkop.
- Filter-aria-label gebruikt `artikelgroep`.
- Externe databases-preview benoemt dat er geen artikelgroep, product of voorraadmutatie wordt aangemaakt.

## Gewijzigde bestanden

- `frontend/src/features/stores/StoreBatchDetailPage.jsx`
- `frontend/src/features/externalDatabases/ExternalDatabasesPage.jsx`

## Niet gewijzigd

- Geen databasewijziging.
- Geen parserwijziging.
- Geen OCR-wijziging.
- Geen receipt-ingestionwijziging.
- Geen voorraadmutatie.
- Geen externe kandidaatselectie.
- Geen Vite-transform workaround.

## Validatie

Lokaal uitgevoerd vanaf branch `m2c2i-artikelgroep-uitpakken-terminology`:

- Oude term `Mijn artikel` / `mijn artikel` niet meer gevonden in beide aangepaste bestanden.
- `git diff --check`: geen blokkerende fouten; alleen Windows LF/CRLF-waarschuwingen.
- `docker compose up -d --build`: geslaagd.
- `Invoke-RestMethod http://localhost:8011/api/health`: `status=ok`.
- `./scripts/run-frontend-regression-report.ps1 -SkipDockerBuild`: 15/15 Playwright-tests geslaagd.

## Guardrails

- Alleen zichtbare terminologie aangepast.
- Technische identifiers zoals `household_article_id` blijven ongemoeid.
- Artikelgroep blijft gebruikersordening, geen productidentiteit.