### PR TITLE
fix artikelgroep cleanup terminology

### DIFF
--- a/backend/app/services/external_receipt_auto_coverage.py
+++ b/backend/app/services/external_receipt_auto_coverage.py
@@ -116,7 +116,7 @@ def auto_ensure_external_candidates_for_receipt_table(
     """Lees echte externe kandidaten bij voor productregels zonder bekende GTIN/EAN.
 
     Dit is productgedrag, geen PO-rapport. De functie mag uitsluitend kandidaatcache
-    vullen in `external_product_candidates`. Ze maakt geen Mijn artikel, geen
+    vullen in `external_product_candidates`. Ze maakt geen huishoudelijk artikel, geen
     global product en geen voorraadmutatie. Regels met een bestaande geldige
     GTIN/EAN hebben al een externe identiteit en worden niet opnieuw van
     kandidaatartikelen voorzien.

--- a/backend/app/testing/uitpakken_smoke.py
+++ b/backend/app/testing/uitpakken_smoke.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Technical Design Reference:
 - TD Section: TD-08 Test, baseline en regressie
 - Module Role: Uitpakken smoke test

--- a/backend/app/testing/uitpakken_smoke.py
+++ b/backend/app/testing/uitpakken_smoke.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 Technical Design Reference:
 - TD Section: TD-08 Test, baseline en regressie
 - Module Role: Uitpakken smoke test
@@ -114,9 +114,9 @@ def run_smoke() -> dict[str, Any]:
 
             line_before = fetch_one(db.conn, "select * from purchase_import_lines where id = ?", (LINE_PASTA_ID,))
             if line_before and line_before.get("matched_household_article_id") is not None:
-                results.append(passed_result("U-SM-03", "smokeregel heeft gekoppeld Mijn artikel", {"line_id": LINE_PASTA_ID, "article_id": line_before.get("matched_household_article_id")}))
+                results.append(passed_result("U-SM-03", "smokeregel heeft gekoppeld huishoudelijk artikel", {"line_id": LINE_PASTA_ID, "article_id": line_before.get("matched_household_article_id")}))
             else:
-                results.append(failed_result("U-SM-03", "smokeregel heeft gekoppeld Mijn artikel", "matched_household_article_id ontbreekt"))
+                results.append(failed_result("U-SM-03", "smokeregel heeft gekoppeld huishoudelijk artikel", "matched_household_article_id ontbreekt"))
 
             assigned = assign_target_location(
                 db.conn,


### PR DESCRIPTION
Fase 2B-0 cleanup.

Wijzigingen:
- external_receipt_auto_coverage.py: oude term vervangen door huishoudelijk artikel in docstring.
- uitpakken_smoke.py: oude term vervangen door huishoudelijk artikel in testlabels.

Niet gewijzigd:
- geen datamodelwijziging
- geen migratie
- geen nieuwe Artikelgroepenfunctionaliteit
- technische household_article identifiers blijven bestaan

Validatie:
- git diff --check origin/main...HEAD: geen output / akkoord
- git diff --stat origin/main...HEAD: 2 bestanden, 3 insertions, 3 deletions
- python -m backend.app.testing.uitpakken_smoke: passed, 8/8 passed, 0 failed, 0 blocked

Let op lokaal:
- uitpakken_smoke_report.json is gegenereerd als untracked bestand en hoort niet in deze PR.