### PR TITLE
feat(article-groups): add household article group management

### DIFF
--- a/backend/app/api/article_group_routes.py
+++ b/backend/app/api/article_group_routes.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Body, HTTPException, Query
+
+from app.services.article_group_store import (
+    assign_household_article_group,
+    create_article_group,
+    delete_article_group,
+    list_article_groups,
+    list_household_articles_for_grouping,
+    update_article_group,
+)
+
+router = APIRouter()
+
+
+@router.get('/api/article-groups')
+def article_groups(
+    household_id: str | None = Query(default=None),
+    include_inactive: bool = Query(default=False),
+):
+    return list_article_groups(household_id=household_id, include_inactive=include_inactive)
+
+
+@router.post('/api/article-groups')
+def article_group_create(payload: dict[str, Any] = Body(default_factory=dict)):
+    result = create_article_group(
+        household_id=payload.get('household_id'),
+        name=payload.get('name'),
+    )
+    if not bool(result.get('ok', False)):
+        raise HTTPException(status_code=400, detail=result.get('error') or 'Artikelgroep kon niet worden toegevoegd')
+    return result
+
+
+@router.put('/api/article-groups/{group_id}')
+def article_group_update(group_id: str, payload: dict[str, Any] = Body(default_factory=dict)):
+    result = update_article_group(
+        group_id=group_id,
+        household_id=payload.get('household_id'),
+        name=payload.get('name'),
+        status=payload.get('status'),
+        sort_order=payload.get('sort_order'),
+    )
+    if not bool(result.get('ok', False)):
+        raise HTTPException(status_code=400, detail=result.get('error') or 'Artikelgroep kon niet worden bijgewerkt')
+    return result
+
+
+@router.delete('/api/article-groups/{group_id}')
+def article_group_delete(group_id: str, household_id: str | None = Query(default=None)):
+    result = delete_article_group(group_id=group_id, household_id=household_id)
+    if not bool(result.get('ok', False)):
+        raise HTTPException(status_code=400, detail=result.get('error') or 'Artikelgroep kon niet worden verwijderd')
+    return result
+
+
+@router.get('/api/article-groups/household-articles')
+def article_group_household_articles(household_id: str | None = Query(default=None)):
+    return list_household_articles_for_grouping(household_id=household_id)
+
+
+@router.put('/api/household-articles/{article_id}/article-group')
+def household_article_group_update(article_id: str, payload: dict[str, Any] = Body(default_factory=dict)):
+    result = assign_household_article_group(
+        article_id=article_id,
+        article_group_id=payload.get('article_group_id'),
+        household_id=payload.get('household_id'),
+    )
+    if not bool(result.get('ok', False)):
+        raise HTTPException(status_code=400, detail=result.get('error') or 'Artikelgroep kon niet worden gekoppeld')
+    return result

--- a/backend/app/api/article_group_routes.py
+++ b/backend/app/api/article_group_routes.py
@@ -17,11 +17,8 @@ router = APIRouter()
 
 
 @router.get('/api/article-groups')
-def article_groups(
-    household_id: str | None = Query(default=None),
-    include_inactive: bool = Query(default=False),
-):
-    return list_article_groups(household_id=household_id, include_inactive=include_inactive)
+def article_groups(household_id: str | None = Query(default=None)):
+    return list_article_groups(household_id=household_id)
 
 
 @router.post('/api/article-groups')
@@ -41,7 +38,6 @@ def article_group_update(group_id: str, payload: dict[str, Any] = Body(default_f
         group_id=group_id,
         household_id=payload.get('household_id'),
         name=payload.get('name'),
-        status=payload.get('status'),
         sort_order=payload.get('sort_order'),
     )
     if not bool(result.get('ok', False)):

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -13,6 +13,7 @@ Technical Design Reference:
 
 from fastapi import APIRouter
 
+from app.api.article_group_routes import router as article_group_router
 from app.api.routes.debug import router as debug_router
 from app.api.routes.receipt_db_snapshot import router as receipt_db_snapshot_router
 from app.api.routes.receipt_parser_diagnosis import router as receipt_parser_diagnosis_router
@@ -23,6 +24,7 @@ from app.services import receipt_loyalty_line_patch
 from app.services import receipt_g1_merge
 
 api_router = APIRouter()
+api_router.include_router(article_group_router)
 api_router.include_router(debug_router)
 api_router.include_router(receipt_db_snapshot_router)
 api_router.include_router(receipt_parser_diagnosis_router)

--- a/backend/app/api/system_routes.py
+++ b/backend/app/api/system_routes.py
@@ -52,6 +52,7 @@ from app.services.external_relation_batch_store import (
 )
 from app.services.open_food_facts_candidate_store import save_open_food_facts_preview_candidates
 from app.services.open_food_facts_search_preview import search_open_food_facts_preview
+from app.services.off_search_service import OffSearchError, search_off_candidates
 
 router = APIRouter()
 logger = logging.getLogger('rezzerv.api')
@@ -280,6 +281,15 @@ def external_databases_save_candidates(retailer_code: str, payload: dict[str, An
         purchase_import_line_id=str(payload.get('purchase_import_line_id') or '').strip() or None,
         include_below_threshold=bool(payload.get('include_below_threshold', False)),
     )
+
+
+@router.post('/api/external-products/off/search')
+def external_products_open_food_facts_search(payload: dict[str, Any] = Body(default_factory=dict)):
+    """Nieuwe tijdelijke OFF-zoekflow zonder databasewrites."""
+    try:
+        return search_off_candidates(payload)
+    except OffSearchError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post('/api/external-databases/off/search-preview')

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -173,7 +173,8 @@ def _dev_inventory_preview_row(row):
 
 
 @app.get("/api/dev/inventory-preview")
-def dev_inventory_preview():
+def dev_inventory_preview(authorization: Optional[str] = Header(None)):
+    effective_household_id = get_request_household_id(authorization)
     with engine.begin() as conn:
         rows = conn.execute(text(
             """
@@ -182,6 +183,7 @@ def dev_inventory_preview():
                 i.naam AS artikel,
                 i.aantal,
                 i.household_id,
+                i.household_article_id AS household_article_id,
                 i.space_id,
                 i.sublocation_id,
                 s.naam AS locatie,
@@ -189,10 +191,11 @@ def dev_inventory_preview():
             FROM inventory i
             LEFT JOIN spaces s ON s.id = i.space_id
             LEFT JOIN sublocations sl ON sl.id = i.sublocation_id
-            WHERE COALESCE(i.status, 'active') = 'active'
+            WHERE i.household_id = :household_id
+              AND COALESCE(i.status, 'active') = 'active'
             ORDER BY lower(COALESCE(i.naam, '')) ASC, i.id ASC
             """
-        )).mappings().all()
+        ), {"household_id": effective_household_id}).mappings().all()
 
     return {"rows": [_dev_inventory_preview_row(row) for row in rows]}
 
@@ -8113,6 +8116,7 @@ def ensure_release_3_schema():
                     id TEXT PRIMARY KEY,
                     household_id TEXT NOT NULL,
                     article_id TEXT,
+                    household_article_id TEXT,
                     article_name TEXT NOT NULL,
                     location_id TEXT,
                     location_label TEXT,
@@ -8132,6 +8136,9 @@ def ensure_release_3_schema():
             conn.execute(text("ALTER TABLE inventory_events ADD COLUMN old_quantity NUMERIC"))
         if "new_quantity" not in inventory_event_columns:
             conn.execute(text("ALTER TABLE inventory_events ADD COLUMN new_quantity NUMERIC"))
+        if "household_article_id" not in inventory_event_columns:
+            conn.execute(text("ALTER TABLE inventory_events ADD COLUMN household_article_id TEXT"))
+        conn.execute(text("CREATE INDEX IF NOT EXISTS idx_inventory_events_household_article_id ON inventory_events (household_article_id)"))
 
 
 
@@ -8200,6 +8207,9 @@ def ensure_release_814_schema():
             conn.execute(text("ALTER TABLE inventory ADD COLUMN archived_at DATETIME"))
         if "archive_reason" not in inventory_columns:
             conn.execute(text("ALTER TABLE inventory ADD COLUMN archive_reason TEXT"))
+        if "household_article_id" not in inventory_columns:
+            conn.execute(text("ALTER TABLE inventory ADD COLUMN household_article_id TEXT"))
+        conn.execute(text("CREATE INDEX IF NOT EXISTS idx_inventory_household_article_id ON inventory (household_article_id)"))
         conn.execute(text("UPDATE inventory SET status = COALESCE(status, 'active')"))
 
 
@@ -8921,6 +8931,72 @@ def require_resolved_location(resolved_location: dict | None):
     return resolved_location
 
 
+def resolve_or_create_inventory_household_article(
+    conn,
+    *,
+    household_id: str,
+    article_name: str,
+    preferred_household_article_id: str | None = None,
+    source: str = "inventory",
+) -> str:
+    normalized_household_id = str(household_id or "").strip()
+    normalized_article_name = normalize_household_article_name(article_name)
+    preferred_id = str(preferred_household_article_id or "").strip()
+
+    if not normalized_household_id:
+        raise HTTPException(status_code=400, detail="Huishouden ontbreekt voor voorraadmutatie")
+    if not normalized_article_name:
+        raise HTTPException(status_code=400, detail="Artikelnaam ontbreekt voor voorraadmutatie")
+
+    if preferred_id:
+        existing_id = conn.execute(
+            text("SELECT id FROM household_articles WHERE id = :id AND household_id = :household_id LIMIT 1"),
+            {"id": preferred_id, "household_id": normalized_household_id},
+        ).scalar()
+        if existing_id:
+            return str(existing_id)
+
+    matches = conn.execute(
+        text(
+            """
+            SELECT id
+            FROM household_articles
+            WHERE household_id = :household_id
+              AND lower(trim(COALESCE(custom_name, naam))) = lower(trim(:article_name))
+              AND COALESCE(status, 'active') = 'active'
+            ORDER BY datetime(created_at) ASC, id ASC
+            LIMIT 2
+            """
+        ),
+        {"household_id": normalized_household_id, "article_name": normalized_article_name},
+    ).scalars().all()
+
+    if len(matches) == 1:
+        return str(matches[0])
+    if len(matches) > 1:
+        raise HTTPException(status_code=409, detail="Meerdere huishoudartikelen gevonden; voorraadmutatie is geblokkeerd")
+
+    household_article_id = str(uuid.uuid4())
+    conn.execute(
+        text(
+            """
+            INSERT INTO household_articles (
+                id, household_id, naam, consumable, created_at, updated_at, source, status
+            ) VALUES (
+                :id, :household_id, :naam, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, :source, 'active'
+            )
+            """
+        ),
+        {
+            "id": household_article_id,
+            "household_id": normalized_household_id,
+            "naam": normalized_article_name,
+            "source": str(source or "inventory").strip() or "inventory",
+        },
+    )
+    return household_article_id
+
+
 def create_inventory_event(
     conn,
     *,
@@ -8942,16 +9018,23 @@ def create_inventory_event(
     barcode: str | None = None,
 ):
     safe_location = require_resolved_location(resolved_location)
+    household_article_id = resolve_or_create_inventory_household_article(
+        conn,
+        household_id=household_id,
+        article_name=article_name,
+        preferred_household_article_id=article_id,
+        source=source,
+    )
     event_id = str(uuid.uuid4())
     conn.execute(
         text(
             """
             INSERT INTO inventory_events (
-                id, household_id, article_id, article_name, location_id, location_label,
+                id, household_id, article_id, household_article_id, article_name, location_id, location_label,
                 event_type, quantity, old_quantity, new_quantity, source, note,
                 purchase_date, supplier_name, article_number, price, currency, barcode, created_at
             ) VALUES (
-                :id, :household_id, :article_id, :article_name, :location_id, :location_label,
+                :id, :household_id, :article_id, :household_article_id, :article_name, :location_id, :location_label,
                 :event_type, :quantity, :old_quantity, :new_quantity, :source, :note,
                 :purchase_date, :supplier_name, :article_number, :price, :currency, :barcode, CURRENT_TIMESTAMP
             )
@@ -8960,7 +9043,8 @@ def create_inventory_event(
         {
             "id": event_id,
             "household_id": str(household_id),
-            "article_id": article_id,
+            "article_id": household_article_id,
+            "household_article_id": household_article_id,
             "article_name": article_name,
             "location_id": safe_location["location_id"],
             "location_label": safe_location["location_label"],
@@ -8985,6 +9069,12 @@ def apply_inventory_purchase(conn, household_id: str, article_name: str, quantit
     safe_location = require_resolved_location(resolved_location)
     space_id = safe_location["space_id"]
     sublocation_id = safe_location["sublocation_id"]
+    household_article_id = resolve_or_create_inventory_household_article(
+        conn,
+        household_id=household_id,
+        article_name=article_name,
+        source="inventory_purchase",
+    )
 
     existing = conn.execute(
         text(
@@ -8992,14 +9082,14 @@ def apply_inventory_purchase(conn, household_id: str, article_name: str, quantit
             SELECT id, aantal
             FROM inventory
             WHERE household_id = :household_id
-              AND naam = :naam
+              AND household_article_id = :household_article_id
               AND COALESCE(space_id, '') = COALESCE(:space_id, '')
               AND COALESCE(sublocation_id, '') = COALESCE(:sublocation_id, '')
             """
         ),
         {
             "household_id": household_id,
-            "naam": article_name,
+            "household_article_id": household_article_id,
             "space_id": space_id,
             "sublocation_id": sublocation_id,
         },
@@ -9024,8 +9114,14 @@ def apply_inventory_purchase(conn, household_id: str, article_name: str, quantit
     conn.execute(
         text(
             """
-            INSERT INTO inventory (id, naam, aantal, household_id, space_id, sublocation_id, status, updated_at)
-            VALUES (:id, :naam, :aantal, :household_id, :space_id, :sublocation_id, 'active', CURRENT_TIMESTAMP)
+            INSERT INTO inventory (
+                id, naam, aantal, household_id, household_article_id,
+                space_id, sublocation_id, status, updated_at
+            )
+            VALUES (
+                :id, :naam, :aantal, :household_id, :household_article_id,
+                :space_id, :sublocation_id, 'active', CURRENT_TIMESTAMP
+            )
             """
         ),
         {
@@ -9033,6 +9129,7 @@ def apply_inventory_purchase(conn, household_id: str, article_name: str, quantit
             "naam": article_name,
             "aantal": quantity_int,
             "household_id": household_id,
+            "household_article_id": household_article_id,
             "space_id": space_id,
             "sublocation_id": sublocation_id,
         },
@@ -9056,12 +9153,19 @@ def apply_manual_inventory_adjustment(
     sublocation_id = safe_location["sublocation_id"]
 
     old_total = get_article_total_quantity(conn, household_id, old_article_name)
+    household_article_id = resolve_or_create_inventory_household_article(
+        conn,
+        household_id=household_id,
+        article_name=new_article_name,
+        source="manual_inventory",
+    )
 
     conn.execute(
         text(
             """
             UPDATE inventory
             SET naam = :naam,
+                household_article_id = :household_article_id,
                 aantal = :aantal,
                 space_id = :space_id,
                 sublocation_id = :sublocation_id,
@@ -9072,6 +9176,7 @@ def apply_manual_inventory_adjustment(
         {
             "id": inventory_id,
             "naam": new_article_name,
+            "household_article_id": household_article_id,
             "aantal": int(new_quantity),
             "space_id": space_id,
             "sublocation_id": sublocation_id,
@@ -9080,7 +9185,7 @@ def apply_manual_inventory_adjustment(
 
     new_total = get_article_total_quantity(conn, household_id, new_article_name)
     delta = int(new_quantity) - int(old_quantity)
-    article_id = build_live_article_option_id(new_article_name)
+    article_id = household_article_id
 
     if delta > 0:
         mutation_label = 'handmatige ophoging'
@@ -9113,7 +9218,7 @@ def apply_manual_inventory_adjustment(
               i.aantal AS aantal,
               i.space_id AS space_id,
               i.sublocation_id AS sublocation_id,
-              ha.id AS household_article_id,
+              i.household_article_id AS household_article_id,
               COALESCE(ha.custom_name, i.naam, '') AS household_article_name,
               COALESCE(gp.name, ha.naam, i.naam, '') AS product_name,
               COALESCE(s.naam, '') AS locatie,
@@ -9122,7 +9227,7 @@ def apply_manual_inventory_adjustment(
             FROM inventory i
             LEFT JOIN spaces s ON s.id = i.space_id
             LEFT JOIN sublocations sl ON sl.id = i.sublocation_id
-            LEFT JOIN household_articles ha ON ha.household_id = i.household_id AND lower(trim(ha.naam)) = lower(trim(i.naam))
+            LEFT JOIN household_articles ha ON ha.id = i.household_article_id AND ha.household_id = i.household_id
             LEFT JOIN global_products gp ON gp.id = ha.global_product_id
             WHERE i.id = :id
             """
@@ -15553,7 +15658,7 @@ def inventory_preview(response: Response, authorization: Optional[str] = Header(
               i.aantal AS aantal,
               i.space_id AS space_id,
               i.sublocation_id AS sublocation_id,
-              ha.id AS household_article_id,
+              i.household_article_id AS household_article_id,
               COALESCE(ha.custom_name, i.naam, '') AS household_article_name,
               COALESCE(gp.name, ha.naam, i.naam, '') AS product_name,
               COALESCE(s.naam, '') AS locatie,
@@ -15562,7 +15667,7 @@ def inventory_preview(response: Response, authorization: Optional[str] = Header(
             FROM inventory i
             LEFT JOIN spaces s ON s.id = i.space_id
             LEFT JOIN sublocations sl ON sl.id = i.sublocation_id
-            LEFT JOIN household_articles ha ON ha.household_id = i.household_id AND lower(trim(ha.naam)) = lower(trim(i.naam))
+            LEFT JOIN household_articles ha ON ha.id = i.household_article_id AND ha.household_id = i.household_id
             LEFT JOIN global_products gp ON gp.id = ha.global_product_id
             WHERE i.household_id = :household_id
               AND COALESCE(i.status, 'active') = 'active'

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -51,6 +51,7 @@ from app.schemas.receipts import (
     ReceiptHeaderUpdateRequest,
     ReceiptLineUpdateRequest,
     ReceiptLineCreateRequest,
+    ProductIdentityLookupRequest,
 )
 from app.services.testing_service import testing_service
 from app.testing.almost_out_self_test import run_almost_out_backend_self_test
@@ -2729,6 +2730,8 @@ def normalize_product_identity_type(value: str | None) -> str:
     normalized = str(value or '').strip().lower()
     if normalized in {'barcode', 'ean', 'gtin', 'upc'}:
         return 'gtin'
+    if normalized == 'retailer_article_number':
+        return 'retailer_article_number'
     if normalized in {'store_sku', 'text_match', 'external_article_number', 'article_number'}:
         return 'external_article_number' if normalized in {'external_article_number', 'article_number'} else normalized
     return 'gtin'
@@ -2739,6 +2742,17 @@ def normalize_product_identity_value(identity_type: str | None, identity_value: 
     if normalized_type == 'gtin':
         return normalize_barcode_value(identity_value) if identity_value else None
     return normalize_identity_lookup_value(identity_value)
+
+
+def build_retailer_article_identity_value(
+    retailer_code: str | None,
+    article_code: str | None,
+) -> str | None:
+    normalized_retailer = normalize_identity_lookup_value(retailer_code)
+    normalized_article_code = normalize_identity_lookup_value(article_code)
+    if not normalized_retailer or not normalized_article_code:
+        return None
+    return f'retailer:{normalized_retailer}:{normalized_article_code}'
 
 
 @dataclass
@@ -5162,52 +5176,161 @@ def get_global_product_row_by_identity(conn, identity_value: str | None, identit
     return None
 
 
-def find_global_product_match_for_receipt_line(conn, barcode: str | None, article_name: str | None, brand: str | None = None, external_article_code: str | None = None):
+def build_product_identity_lookup_product(row) -> dict | None:
+    if not row:
+        return None
+    return {
+        "id": str(row.get("id") or ""),
+        "name": row.get("name") or None,
+        "brand": row.get("brand") or None,
+        "barcode": row.get("primary_gtin") or None,
+        "category": row.get("category") or None,
+        "size_value": float(row["size_value"]) if row.get("size_value") is not None else None,
+        "size_unit": row.get("size_unit") or None,
+        "source": row.get("source") or None,
+        "status": row.get("status") or None,
+    }
+
+
+def build_product_identity_lookup_suggestion(result: EnrichmentLookupResult) -> dict | None:
+    if result.status != "found" or not isinstance(result.payload, dict):
+        return None
+    payload = result.payload
+    return {
+        "name": payload.get("title") or None,
+        "brand": payload.get("brand") or None,
+        "barcode": result.normalized_barcode or payload.get("normalized_barcode") or None,
+        "category": payload.get("category") or None,
+        "size_value": payload.get("size_value"),
+        "size_unit": payload.get("size_unit") or None,
+        "image_url": payload.get("image_url") or None,
+        "source_url": payload.get("source_url") or result.source_url or None,
+        "source": result.source_name,
+    }
+
+
+def find_global_product_match_for_receipt_line(
+    conn,
+    barcode: str | None,
+    article_name: str | None,
+    brand: str | None = None,
+    external_article_code: str | None = None,
+    retailer_code: str | None = None,
+):
     normalized_barcode = normalize_barcode_value(barcode) if barcode else None
+
+    # Een universele barcode of GTIN heeft altijd voorrang.
     if normalized_barcode:
-        by_barcode = get_global_product_row_by_barcode(conn, normalized_barcode)
+        by_barcode = get_global_product_row_by_barcode(
+            conn,
+            normalized_barcode,
+        )
         if by_barcode:
             payload = dict(by_barcode)
             payload['match_method'] = 'gtin:primary'
             payload['confidence_score'] = 1.0
             return payload
-    normalized_external_article_code = normalize_identity_lookup_value(external_article_code or barcode)
+
+        by_gtin_identity = get_global_product_row_by_identity(
+            conn,
+            normalized_barcode,
+            identity_types=('gtin',),
+        )
+        if by_gtin_identity:
+            payload = dict(by_gtin_identity)
+            payload['match_method'] = 'identity:gtin'
+            payload['confidence_score'] = 1.0
+            return payload
+
+    normalized_external_article_code = normalize_identity_lookup_value(
+        external_article_code
+    )
+
+    # Winkelartikelcodes zijn alleen uniek binnen de winkelketen.
+    retailer_identity = build_retailer_article_identity_value(
+        retailer_code,
+        normalized_external_article_code,
+    )
+    if retailer_identity:
+        by_retailer_identity = get_global_product_row_by_identity(
+            conn,
+            retailer_identity,
+            identity_types=('retailer_article_number',),
+        )
+        if by_retailer_identity:
+            payload = dict(by_retailer_identity)
+            payload['match_method'] = (
+                'identity:retailer_article_number'
+            )
+            payload['confidence_score'] = 0.95
+            return payload
+
+    # Alleen expliciet universele externe artikelidentiteiten mogen
+    # zonder retailercontext worden hergebruikt.
     if normalized_external_article_code:
-        by_identity = get_global_product_row_by_identity(conn, normalized_external_article_code)
-        if by_identity:
-            payload = dict(by_identity)
-            identity_type = normalize_product_identity_type(by_identity.get('identity_type'))
+        by_external_identity = get_global_product_row_by_identity(
+            conn,
+            normalized_external_article_code,
+            identity_types=(
+                'external_article_number',
+                'store_sku',
+            ),
+        )
+        if by_external_identity:
+            payload = dict(by_external_identity)
+            identity_type = normalize_product_identity_type(
+                by_external_identity.get('identity_type')
+            )
             payload['match_method'] = f'identity:{identity_type}'
             payload['confidence_score'] = 0.95
             return payload
+
     normalized_name = normalize_household_article_name(article_name)
     normalized_brand = normalize_optional_text_field(brand)
     if not normalized_name:
         return None
+
     params = {'name': normalized_name}
     brand_clause = ''
     if normalized_brand:
         params['brand'] = normalized_brand
-        brand_clause = " AND lower(trim(COALESCE(brand, ''))) = lower(trim(:brand))"
+        brand_clause = (
+            " AND lower(trim(COALESCE(brand, ''))) "
+            "= lower(trim(:brand))"
+        )
+
     row = conn.execute(
         text(
             f"""
-            SELECT id, primary_gtin, name, brand, category, size_value, size_unit, source, status, created_at, updated_at
+            SELECT id, primary_gtin, name, brand, category,
+                   size_value, size_unit, source, status,
+                   created_at, updated_at
             FROM global_products
             WHERE lower(trim(name)) = lower(trim(:name)){brand_clause}
-            ORDER BY CASE WHEN primary_gtin IS NOT NULL AND trim(primary_gtin) <> '' THEN 0 ELSE 1 END,
-                     datetime(updated_at) DESC,
-                     id DESC
+            ORDER BY
+                CASE
+                    WHEN primary_gtin IS NOT NULL
+                     AND trim(primary_gtin) <> ''
+                    THEN 0 ELSE 1
+                END,
+                datetime(updated_at) DESC,
+                id DESC
             LIMIT 1
             """
         ),
         params,
     ).mappings().first()
+
     if not row:
         return None
+
     payload = dict(row)
-    payload['match_method'] = 'text:name_brand' if normalized_brand else 'text:name'
-    payload['confidence_score'] = 0.8 if normalized_brand else 0.75
+    payload['match_method'] = (
+        'text:name_brand' if normalized_brand else 'text:name'
+    )
+    payload['confidence_score'] = (
+        0.8 if normalized_brand else 0.75
+    )
     return payload
 
 
@@ -5264,12 +5387,12 @@ def find_household_article_for_global_product(conn, household_id: str, global_pr
     return dict(row) if row else None
 
 
-def resolve_receipt_line_product_links(conn, household_id: str | None, article_name: str | None, *, barcode: str | None = None, brand: str | None = None, matched_article_id: str | None = None, create_global_product: bool = True, create_household_article: bool = False, external_article_code: str | None = None):
+def resolve_receipt_line_product_links(conn, household_id: str | None, article_name: str | None, *, barcode: str | None = None, brand: str | None = None, matched_article_id: str | None = None, create_global_product: bool = True, create_household_article: bool = False, external_article_code: str | None = None, retailer_code: str | None = None):
     normalized_household_id = str(household_id or '').strip()
     normalized_barcode = normalize_barcode_value(barcode) if barcode else None
     normalized_article_name = normalize_household_article_name(article_name)
     normalized_brand = normalize_optional_text_field(brand)
-    normalized_external_article_code = normalize_identity_lookup_value(external_article_code or barcode)
+    normalized_external_article_code = normalize_identity_lookup_value(external_article_code)
     resolved_article_option_id = str(matched_article_id or '').strip() or None
     resolved_global_product_id = None
     match_method = None
@@ -5304,6 +5427,7 @@ def resolve_receipt_line_product_links(conn, household_id: str | None, article_n
             normalized_article_name,
             normalized_brand,
             external_article_code=normalized_external_article_code,
+            retailer_code=retailer_code,
         )
         if matched_product and matched_product.get('id'):
             resolved_global_product_id = str(matched_product.get('id'))
@@ -5470,6 +5594,7 @@ def sync_receipt_table_line_product_links(conn, receipt_table_id: str, line_id: 
             """
             SELECT id,
                    barcode,
+                   external_article_code,
                    COALESCE(corrected_raw_label, raw_label) AS article_name,
                    matched_article_id,
                    matched_global_product_id
@@ -5491,7 +5616,8 @@ def sync_receipt_table_line_product_links(conn, receipt_table_id: str, line_id: 
         matched_article_id=line.get('matched_article_id'),
         create_global_product=create_global_product,
         create_household_article=create_household_article,
-        external_article_code=line.get('barcode'),
+        external_article_code=line.get('external_article_code'),
+        retailer_code=receipt_header.get('store_name'),
     )
     conn.execute(
         text(
@@ -8152,6 +8278,7 @@ def ensure_release_902_schema():
                     line_total NUMERIC(12,2),
                     discount_amount NUMERIC(12,2),
                     barcode TEXT,
+                    external_article_code TEXT,
                     article_match_status TEXT NOT NULL DEFAULT 'unmatched',
                     matched_article_id TEXT,
                     matched_global_product_id TEXT,
@@ -8337,6 +8464,7 @@ def ensure_release_941_receipt_edit_schema():
             'is_deleted': 'INTEGER NOT NULL DEFAULT 0',
             'is_validated': 'INTEGER NOT NULL DEFAULT 0',
             'matched_global_product_id': 'TEXT',
+            'external_article_code': 'TEXT',
         }
         for column_name, column_type in line_additions.items():
             if column_name not in line_columns:
@@ -9490,7 +9618,8 @@ def sync_unpack_batch_lines_for_receipt(conn, batch_id: str, receipt, *, refresh
                COALESCE(corrected_quantity, quantity) AS quantity,
                COALESCE(corrected_unit, unit) AS unit,
                COALESCE(corrected_line_total, line_total) AS line_total,
-               barcode
+               barcode,
+               external_article_code
         FROM receipt_table_lines
         WHERE receipt_table_id = :receipt_table_id
           AND COALESCE(is_deleted, 0) = 0
@@ -9521,9 +9650,10 @@ def sync_unpack_batch_lines_for_receipt(conn, batch_id: str, receipt, *, refresh
             raw_label,
             barcode=line.get('barcode'),
             brand=(receipt or {}).get('store_name'),
-            create_global_product=True,
-            create_household_article=False,  # M2A: geen automatisch Mijn artikel vanuit bon/import
-            external_article_code=line.get('barcode'),
+            create_global_product=False,
+            create_household_article=False,  # Alleen bestaande standaardartikelen matchen
+            external_article_code=line.get('external_article_code'),
+            retailer_code=(receipt or {}).get('store_name'),
         )
         matched_global_product_id = str((resolved_links or {}).get('matched_global_product_id') or '').strip() or None
         # M2A: bij eerste import blijft 'Mijn artikel' leeg.
@@ -9552,7 +9682,7 @@ def sync_unpack_batch_lines_for_receipt(conn, batch_id: str, receipt, *, refresh
                         ELSE suggested_household_article_id
                     END,
                     match_status = CASE
-                        WHEN COALESCE(article_override_mode, 'auto') = 'auto' AND :matched_household_article_id IS NOT NULL THEN 'matched'
+                        WHEN COALESCE(article_override_mode, 'auto') = 'auto' AND :matched_global_product_id IS NOT NULL THEN 'matched'
                         WHEN COALESCE(article_override_mode, 'auto') = 'auto' THEN 'unmatched'
                         ELSE match_status
                     END,
@@ -9611,7 +9741,7 @@ def sync_unpack_batch_lines_for_receipt(conn, batch_id: str, receipt, *, refresh
                 'line_price_raw': line_price_value,
                 'currency_code': (receipt or {}).get('currency') or 'EUR',
                 'ui_sort_order': int(line.get('line_index') or offset),
-                'match_status': 'matched' if matched_household_article_id else 'unmatched',
+                'match_status': 'matched' if matched_global_product_id else 'unmatched',
                 'matched_global_product_id': matched_global_product_id,
                 'matched_household_article_id': matched_household_article_id,
                 'suggested_household_article_id': matched_household_article_id,
@@ -12681,29 +12811,76 @@ def update_receipt_line(receipt_table_id: str, line_id: str, payload: ReceiptLin
 def create_receipt_line(receipt_table_id: str, payload: ReceiptLineCreateRequest, authorization: Optional[str] = Header(None)):
     with engine.begin() as conn:
         context = require_receipt_write_context(conn, receipt_table_id, authorization)
-        existing = conn.execute(text("SELECT id FROM receipt_tables WHERE id = :id LIMIT 1"), {'id': receipt_table_id}).mappings().first()
+        existing = conn.execute(
+            text("SELECT id, household_id, store_name FROM receipt_tables WHERE id = :id LIMIT 1"),
+            {'id': receipt_table_id},
+        ).mappings().first()
         if not existing:
             raise HTTPException(status_code=404, detail='Bon niet gevonden')
-        next_index = conn.execute(text("SELECT COALESCE(MAX(line_index), 0) + 1 AS next_index FROM receipt_table_lines WHERE receipt_table_id = :receipt_table_id"), {'receipt_table_id': receipt_table_id}).scalar()
+
+        normalized_barcode = normalize_barcode_value(payload.barcode) if payload.barcode else None
+        normalized_external_article_code = (
+            normalize_identity_lookup_value(payload.external_article_code)
+            if payload.external_article_code
+            else None
+        )
+
+        # Een universele barcode is leidend. De winkelartikelcode blijft hooguit
+        # als aanvullende of historische identiteit beschikbaar.
+        existing_product = find_global_product_match_for_receipt_line(
+            conn,
+            normalized_barcode,
+            payload.article_name,
+            external_article_code=normalized_external_article_code,
+            retailer_code=existing.get('store_name'),
+        )
+        matched_global_product_id = (
+            str(existing_product.get('id') or '').strip()
+            if existing_product
+            else None
+        )
+        article_match_status = 'product_matched' if matched_global_product_id else 'unmatched'
+        confidence_score = (
+            float(existing_product.get('confidence_score') or 1.0)
+            if existing_product
+            else None
+        )
+
+        next_index = conn.execute(
+            text(
+                "SELECT COALESCE(MAX(line_index), 0) + 1 AS next_index "
+                "FROM receipt_table_lines WHERE receipt_table_id = :receipt_table_id"
+            ),
+            {'receipt_table_id': receipt_table_id},
+        ).scalar()
+
         quantity = float(payload.quantity if payload.quantity is not None else 1.0)
         unit_price = float(payload.unit_price) if payload.unit_price is not None else None
-        line_total = float(payload.line_total) if payload.line_total is not None else (round(quantity * unit_price, 2) if unit_price is not None else None)
+        line_total = (
+            float(payload.line_total)
+            if payload.line_total is not None
+            else (round(quantity * unit_price, 2) if unit_price is not None else None)
+        )
+        inserted_line_id = str(uuid.uuid4())
+
         conn.execute(
             text("""
             INSERT INTO receipt_table_lines (
                 id, receipt_table_id, line_index, raw_label, corrected_raw_label, normalized_label,
                 quantity, corrected_quantity, unit, corrected_unit, unit_price, corrected_unit_price,
-                line_total, corrected_line_total, article_match_status, matched_article_id, matched_global_product_id,
+                line_total, corrected_line_total, barcode, external_article_code,
+                article_match_status, matched_article_id, matched_global_product_id,
                 confidence_score, is_deleted, is_validated, created_at, updated_at
             ) VALUES (
                 :id, :receipt_table_id, :line_index, :raw_label, :corrected_raw_label, :normalized_label,
                 :quantity, :corrected_quantity, :unit, :corrected_unit, :unit_price, :corrected_unit_price,
-                :line_total, :corrected_line_total, 'manual', :matched_article_id, NULL,
-                1.0, 0, :is_validated, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                :line_total, :corrected_line_total, :barcode, :external_article_code,
+                :article_match_status, :matched_article_id, :matched_global_product_id,
+                :confidence_score, 0, :is_validated, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
             )
             """),
             {
-                'id': str(uuid.uuid4()),
+                'id': inserted_line_id,
                 'receipt_table_id': receipt_table_id,
                 'line_index': int(next_index or 1),
                 'raw_label': payload.article_name,
@@ -12717,15 +12894,40 @@ def create_receipt_line(receipt_table_id: str, payload: ReceiptLineCreateRequest
                 'corrected_unit_price': unit_price,
                 'line_total': line_total,
                 'corrected_line_total': line_total,
+                'barcode': normalized_barcode,
+                'external_article_code': normalized_external_article_code,
+                'article_match_status': article_match_status,
                 'matched_article_id': (str(payload.matched_article_id or '').strip() or None),
+                'matched_global_product_id': matched_global_product_id,
+                'confidence_score': confidence_score,
                 'is_validated': int(bool(payload.is_validated)),
             },
         )
-        conn.execute(text("UPDATE receipt_tables SET corrected_by_user_email = :user_email, reviewed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = :id"), {'id': receipt_table_id, 'user_email': str(context.get('email') or '').strip().lower()})
-        inserted_line_id = conn.execute(text("SELECT id FROM receipt_table_lines WHERE receipt_table_id = :receipt_table_id ORDER BY line_index DESC, created_at DESC, id DESC LIMIT 1"), {'receipt_table_id': receipt_table_id}).scalar()
-        if inserted_line_id:
-            sync_receipt_table_line_product_links(conn, receipt_table_id, str(inserted_line_id), create_global_product=True, create_household_article=False)
+
+        conn.execute(
+            text(
+                "UPDATE receipt_tables "
+                "SET corrected_by_user_email = :user_email, "
+                "reviewed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP "
+                "WHERE id = :id"
+            ),
+            {
+                'id': receipt_table_id,
+                'user_email': str(context.get('email') or '').strip().lower(),
+            },
+        )
+
+        # Alleen bestaande standaardartikelen koppelen. Een handmatig ingevoerde
+        # onbekende code of naam mag geen nieuw catalogusproduct veroorzaken.
+        sync_receipt_table_line_product_links(
+            conn,
+            receipt_table_id,
+            inserted_line_id,
+            create_global_product=False,
+            create_household_article=False,
+        )
         recompute_receipt_review_state(conn, receipt_table_id)
+
     return get_receipt_detail(receipt_table_id, authorization)
 
 
@@ -12806,7 +13008,7 @@ def approve_receipt_table(receipt_table_id: str, authorization: Optional[str] = 
             if row[0]
         ]
         for current_line_id in line_ids:
-            sync_receipt_table_line_product_links(conn, receipt_table_id, current_line_id, create_global_product=True, create_household_article=False)
+            sync_receipt_table_line_product_links(conn, receipt_table_id, current_line_id, create_global_product=False, create_household_article=False)
         receipt_header = conn.execute(
             text("""
             SELECT id AS receipt_table_id, household_id, store_name, store_branch, purchase_at, created_at, currency
@@ -14440,6 +14642,122 @@ def get_article_product_details_endpoint(article_name: Optional[str] = None, art
             'product_details': details.get('product_details') or {},
             'product': details.get('product') or {},
         }
+
+
+@app.post("/api/product-identities/lookup")
+def lookup_product_identity(
+    payload: ProductIdentityLookupRequest,
+    authorization: Optional[str] = Header(None),
+):
+    require_household_context(
+        authorization,
+        requested_household_id=payload.household_id,
+    )
+
+    identifier = str(payload.identifier or "").strip()
+    requested_type = str(payload.identifier_type or "auto").strip().lower()
+    retailer_code = str(payload.retailer_code or "").strip().lower() or None
+
+    if requested_type == "retailer_article_number" and not retailer_code:
+        raise HTTPException(
+            status_code=400,
+            detail="retailer_code is verplicht bij retailer_article_number",
+        )
+
+    normalized_gtin = None
+    if requested_type == "gtin":
+        try:
+            normalized_gtin = normalize_barcode_value(identifier)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+    elif requested_type == "auto" and identifier.isdigit():
+        try:
+            normalized_gtin = normalize_barcode_value(identifier)
+        except ValueError:
+            normalized_gtin = None
+
+    resolved_type = requested_type
+    matched_product = None
+    match_method = None
+
+    with engine.connect() as conn:
+        if normalized_gtin:
+            matched_product = get_global_product_row_by_barcode(conn, normalized_gtin)
+            match_method = "gtin:primary" if matched_product else None
+            if not matched_product:
+                matched_product = get_global_product_row_by_identity(
+                    conn,
+                    normalized_gtin,
+                    identity_types=("gtin",),
+                )
+                match_method = "identity:gtin" if matched_product else None
+            resolved_type = "gtin"
+
+        if not matched_product and requested_type in {"auto", "external_article_number"}:
+            matched_product = get_global_product_row_by_identity(
+                conn,
+                identifier,
+                identity_types=("external_article_number",),
+            )
+            if matched_product:
+                resolved_type = "external_article_number"
+                match_method = "identity:external_article_number"
+
+        if not matched_product and requested_type in {"auto", "retailer_article_number"} and retailer_code:
+            retailer_identity = build_retailer_article_identity_value(
+                retailer_code,
+                identifier,
+            )
+            matched_product = get_global_product_row_by_identity(
+                conn,
+                retailer_identity,
+                identity_types=("retailer_article_number",),
+            )
+            if matched_product:
+                resolved_type = "retailer_article_number"
+                match_method = "identity:retailer_article_number"
+            elif requested_type == "retailer_article_number":
+                resolved_type = "retailer_article_number"
+
+    if matched_product:
+        return {
+            "valid": True,
+            "identifier_type": resolved_type,
+            "found": True,
+            "global_product_id": str(matched_product.get("id") or ""),
+            "product": build_product_identity_lookup_product(matched_product),
+            "suggestion": None,
+            "source": "internal_catalog",
+            "match_method": match_method,
+            "creates_global_product": False,
+            "creates_household_article": False,
+            "creates_candidate": False,
+            "creates_inventory_event": False,
+        }
+
+    suggestion = None
+    source = "none"
+    lookup_message = None
+    if normalized_gtin:
+        external_result = OpenFoodFactsAdapter().lookup_by_barcode(normalized_gtin)
+        suggestion = build_product_identity_lookup_suggestion(external_result)
+        source = external_result.source_name if suggestion else "none"
+        lookup_message = external_result.message
+
+    return {
+        "valid": True,
+        "identifier_type": resolved_type,
+        "found": False,
+        "global_product_id": None,
+        "product": None,
+        "suggestion": suggestion,
+        "source": source,
+        "message": lookup_message,
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_candidate": False,
+        "creates_inventory_event": False,
+    }
 
 
 @app.get("/api/products/sources")

--- a/backend/app/schemas/receipts.py
+++ b/backend/app/schemas/receipts.py
@@ -45,12 +45,51 @@ class ReceiptLineUpdateRequest(BaseModel):
     is_deleted: Optional[bool] = None
 
 
+class ProductIdentityLookupRequest(BaseModel):
+    identifier: str
+    identifier_type: str = "auto"
+    retailer_code: Optional[str] = None
+    household_id: Optional[str] = None
+
+    @field_validator("identifier")
+    @classmethod
+    def validate_identifier(cls, value):
+        normalized = str(value or "").strip()
+        if not normalized:
+            raise ValueError("Identifier is verplicht")
+        if len(normalized) > 120:
+            raise ValueError("Identifier mag maximaal 120 tekens bevatten")
+        return normalized
+
+    @field_validator("identifier_type")
+    @classmethod
+    def validate_identifier_type(cls, value):
+        normalized = str(value or "auto").strip().lower()
+        allowed = {
+            "auto",
+            "gtin",
+            "external_article_number",
+            "retailer_article_number",
+        }
+        if normalized not in allowed:
+            raise ValueError("Ongeldig type productidentiteit")
+        return normalized
+
+    @field_validator("retailer_code")
+    @classmethod
+    def normalize_retailer_code(cls, value):
+        normalized = str(value or "").strip().lower()
+        return normalized or None
+
+
 class ReceiptLineCreateRequest(BaseModel):
     article_name: str
     quantity: Optional[float] = 1.0
     unit: Optional[str] = None
     unit_price: Optional[float] = None
     line_total: Optional[float] = None
+    barcode: Optional[str] = None
+    external_article_code: Optional[str] = None
     matched_article_id: Optional[str] = None
     is_validated: bool = True
 

--- a/backend/app/services/article_group_store.py
+++ b/backend/app/services/article_group_store.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db import engine
+
+
+ARTICLE_GROUPS_SQL = """
+CREATE TABLE IF NOT EXISTS article_groups (
+    id TEXT PRIMARY KEY,
+    household_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    normalized_name TEXT NOT NULL,
+    status TEXT DEFAULT 'active',
+    sort_order INTEGER DEFAULT 0,
+    created_at TEXT,
+    updated_at TEXT
+)
+"""
+
+ARTICLE_GROUPS_HOUSEHOLD_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_article_groups_household_status
+ON article_groups (household_id, status, normalized_name)
+"""
+
+HOUSEHOLD_ARTICLE_GROUP_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_household_articles_article_group
+ON household_articles (article_group_id)
+"""
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def normalize_article_group_name(value: Any) -> str:
+    normalized = str(value or "").strip().lower()
+    normalized = normalized.replace("ë", "e").replace("é", "e").replace("è", "e").replace("ï", "i")
+    return " ".join(re.sub(r"\s+", " ", normalized).split())
+
+
+def display_article_group_name(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+def _table_exists(conn, table_name: str) -> bool:
+    dialect_name = str(engine.dialect.name or "").lower()
+    if dialect_name == "sqlite":
+        return conn.execute(
+            text("SELECT name FROM sqlite_master WHERE type = 'table' AND name = :table_name"),
+            {"table_name": table_name},
+        ).mappings().first() is not None
+    return conn.execute(
+        text("""
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_name = :table_name
+            LIMIT 1
+        """),
+        {"table_name": table_name},
+    ).mappings().first() is not None
+
+
+def _get_columns(conn, table_name: str) -> set[str]:
+    dialect_name = str(engine.dialect.name or "").lower()
+    if dialect_name == "sqlite":
+        rows = conn.execute(text(f"PRAGMA table_info({table_name})")).mappings().all()
+        return {str(row.get("name") or "") for row in rows}
+    rows = conn.execute(
+        text("SELECT column_name FROM information_schema.columns WHERE table_name = :table_name"),
+        {"table_name": table_name},
+    ).mappings().all()
+    return {str(row.get("column_name") or "") for row in rows}
+
+
+def _ensure_missing_column(conn, table_name: str, column_name: str, definition: str) -> None:
+    if not _table_exists(conn, table_name):
+        return
+    if column_name in _get_columns(conn, table_name):
+        return
+    conn.execute(text(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {definition}"))
+
+
+def ensure_article_group_schema() -> None:
+    with engine.begin() as conn:
+        conn.execute(text(ARTICLE_GROUPS_SQL))
+        conn.execute(text(ARTICLE_GROUPS_HOUSEHOLD_INDEX_SQL))
+        _ensure_missing_column(conn, "household_articles", "article_group_id", "TEXT")
+        if _table_exists(conn, "household_articles"):
+            conn.execute(text(HOUSEHOLD_ARTICLE_GROUP_INDEX_SQL))
+
+
+def _normalize_household_id(household_id: Any) -> str:
+    return str(household_id or "1").strip() or "1"
+
+
+def _article_group_row(row: Any) -> dict[str, Any]:
+    return {
+        "id": str(row.get("id") or ""),
+        "household_id": str(row.get("household_id") or ""),
+        "name": str(row.get("name") or ""),
+        "normalized_name": str(row.get("normalized_name") or ""),
+        "status": str(row.get("status") or "active"),
+        "sort_order": int(row.get("sort_order") or 0),
+        "created_at": row.get("created_at"),
+        "updated_at": row.get("updated_at"),
+    }
+
+
+def list_article_groups(household_id: Any = None, include_inactive: bool = False) -> dict[str, Any]:
+    ensure_article_group_schema()
+    normalized_household_id = _normalize_household_id(household_id)
+    where_status = "1 = 1" if include_inactive else "COALESCE(status, 'active') = 'active'"
+    with engine.begin() as conn:
+        rows = conn.execute(
+            text(f"""
+                SELECT id, household_id, name, normalized_name, status, sort_order, created_at, updated_at
+                FROM article_groups
+                WHERE household_id = :household_id
+                  AND {where_status}
+                ORDER BY sort_order ASC, lower(name) ASC, id ASC
+            """),
+            {"household_id": normalized_household_id},
+        ).mappings().all()
+    return {"ok": True, "items": [_article_group_row(row) for row in rows], "mutates_inventory": False}
+
+
+def create_article_group(household_id: Any, name: Any) -> dict[str, Any]:
+    ensure_article_group_schema()
+    normalized_household_id = _normalize_household_id(household_id)
+    display_name = display_article_group_name(name)
+    normalized_name = normalize_article_group_name(display_name)
+    if not display_name or not normalized_name:
+        return {"ok": False, "error": "Artikelgroepnaam is verplicht"}
+    timestamp = now_iso()
+    group_id = str(uuid.uuid4())
+    with engine.begin() as conn:
+        duplicate = conn.execute(
+            text("""
+                SELECT id
+                FROM article_groups
+                WHERE household_id = :household_id
+                  AND normalized_name = :normalized_name
+                  AND COALESCE(status, 'active') = 'active'
+                LIMIT 1
+            """),
+            {"household_id": normalized_household_id, "normalized_name": normalized_name},
+        ).mappings().first()
+        if duplicate:
+            return {"ok": False, "error": "Artikelgroep bestaat al"}
+        max_sort = conn.execute(
+            text("SELECT COALESCE(MAX(sort_order), 0) AS max_sort FROM article_groups WHERE household_id = :household_id"),
+            {"household_id": normalized_household_id},
+        ).mappings().first()
+        sort_order = int(max_sort.get("max_sort") or 0) + 10 if max_sort else 10
+        conn.execute(
+            text("""
+                INSERT INTO article_groups (id, household_id, name, normalized_name, status, sort_order, created_at, updated_at)
+                VALUES (:id, :household_id, :name, :normalized_name, 'active', :sort_order, :created_at, :updated_at)
+            """),
+            {
+                "id": group_id,
+                "household_id": normalized_household_id,
+                "name": display_name,
+                "normalized_name": normalized_name,
+                "sort_order": sort_order,
+                "created_at": timestamp,
+                "updated_at": timestamp,
+            },
+        )
+    return {"ok": True, "item": {"id": group_id, "household_id": normalized_household_id, "name": display_name, "normalized_name": normalized_name, "status": "active", "sort_order": sort_order}, "mutates_inventory": False}
+
+
+def update_article_group(group_id: Any, household_id: Any = None, name: Any = None, status: Any = None, sort_order: Any = None) -> dict[str, Any]:
+    ensure_article_group_schema()
+    normalized_group_id = str(group_id or "").strip()
+    if not normalized_group_id:
+        return {"ok": False, "error": "Artikelgroep-id is verplicht"}
+    timestamp = now_iso()
+    with engine.begin() as conn:
+        existing = conn.execute(
+            text("SELECT * FROM article_groups WHERE id = :id LIMIT 1"),
+            {"id": normalized_group_id},
+        ).mappings().first()
+        if not existing:
+            return {"ok": False, "error": "Artikelgroep niet gevonden"}
+        normalized_household_id = _normalize_household_id(household_id or existing.get("household_id"))
+        if str(existing.get("household_id") or "") != normalized_household_id:
+            return {"ok": False, "error": "Artikelgroep hoort niet bij dit huishouden"}
+        next_name = display_article_group_name(name if name is not None else existing.get("name"))
+        next_normalized_name = normalize_article_group_name(next_name)
+        if not next_name or not next_normalized_name:
+            return {"ok": False, "error": "Artikelgroepnaam is verplicht"}
+        duplicate = conn.execute(
+            text("""
+                SELECT id
+                FROM article_groups
+                WHERE household_id = :household_id
+                  AND normalized_name = :normalized_name
+                  AND id <> :id
+                  AND COALESCE(status, 'active') = 'active'
+                LIMIT 1
+            """),
+            {"household_id": normalized_household_id, "normalized_name": next_normalized_name, "id": normalized_group_id},
+        ).mappings().first()
+        if duplicate:
+            return {"ok": False, "error": "Artikelgroep bestaat al"}
+        next_status = str(status if status is not None else existing.get("status") or "active").strip().lower() or "active"
+        if next_status not in {"active", "inactive"}:
+            return {"ok": False, "error": "Status moet active of inactive zijn"}
+        try:
+            next_sort_order = int(sort_order if sort_order is not None else existing.get("sort_order") or 0)
+        except (TypeError, ValueError):
+            next_sort_order = int(existing.get("sort_order") or 0)
+        conn.execute(
+            text("""
+                UPDATE article_groups
+                SET name = :name,
+                    normalized_name = :normalized_name,
+                    status = :status,
+                    sort_order = :sort_order,
+                    updated_at = :updated_at
+                WHERE id = :id
+            """),
+            {"id": normalized_group_id, "name": next_name, "normalized_name": next_normalized_name, "status": next_status, "sort_order": next_sort_order, "updated_at": timestamp},
+        )
+    return {"ok": True, "item": {"id": normalized_group_id, "household_id": normalized_household_id, "name": next_name, "normalized_name": next_normalized_name, "status": next_status, "sort_order": next_sort_order}, "mutates_inventory": False}
+
+
+def delete_article_group(group_id: Any, household_id: Any = None) -> dict[str, Any]:
+    ensure_article_group_schema()
+    normalized_group_id = str(group_id or "").strip()
+    if not normalized_group_id:
+        return {"ok": False, "error": "Artikelgroep-id is verplicht"}
+    with engine.begin() as conn:
+        existing = conn.execute(text("SELECT * FROM article_groups WHERE id = :id LIMIT 1"), {"id": normalized_group_id}).mappings().first()
+        if not existing:
+            return {"ok": False, "error": "Artikelgroep niet gevonden"}
+        normalized_household_id = _normalize_household_id(household_id or existing.get("household_id"))
+        if str(existing.get("household_id") or "") != normalized_household_id:
+            return {"ok": False, "error": "Artikelgroep hoort niet bij dit huishouden"}
+        linked_count = 0
+        if _table_exists(conn, "household_articles") and "article_group_id" in _get_columns(conn, "household_articles"):
+            linked_count = int(conn.execute(
+                text("SELECT COUNT(*) AS count FROM household_articles WHERE article_group_id = :id"),
+                {"id": normalized_group_id},
+            ).mappings().first().get("count") or 0)
+        if linked_count > 0:
+            conn.execute(
+                text("UPDATE article_groups SET status = 'inactive', updated_at = :updated_at WHERE id = :id"),
+                {"id": normalized_group_id, "updated_at": now_iso()},
+            )
+            return {"ok": True, "id": normalized_group_id, "deleted": False, "deactivated": True, "linked_count": linked_count, "mutates_inventory": False}
+        conn.execute(text("DELETE FROM article_groups WHERE id = :id"), {"id": normalized_group_id})
+    return {"ok": True, "id": normalized_group_id, "deleted": True, "deactivated": False, "linked_count": 0, "mutates_inventory": False}
+
+
+def _first_existing(columns: set[str], candidates: list[str]) -> str | None:
+    for candidate in candidates:
+        if candidate in columns:
+            return candidate
+    return None
+
+
+def list_household_articles_for_grouping(household_id: Any = None) -> dict[str, Any]:
+    ensure_article_group_schema()
+    normalized_household_id = _normalize_household_id(household_id)
+    with engine.begin() as conn:
+        if not _table_exists(conn, "household_articles"):
+            return {"ok": True, "items": [], "mutates_inventory": False}
+        columns = _get_columns(conn, "household_articles")
+        id_column = _first_existing(columns, ["id", "household_article_id"])
+        if not id_column:
+            return {"ok": True, "items": [], "mutates_inventory": False}
+        household_column = _first_existing(columns, ["household_id"])
+        name_columns = [col for col in ["custom_name", "name", "article_name", "display_name", "canonical_name"] if col in columns]
+        name_expr = "COALESCE(" + ", ".join(f"NULLIF(CAST(ha.{col} AS TEXT), '')" for col in name_columns) + ", '')" if name_columns else "''"
+        group_expr = "ha.article_group_id" if "article_group_id" in columns else "NULL"
+        where_clause = "1 = 1"
+        params: dict[str, Any] = {}
+        if household_column:
+            where_clause = f"CAST(ha.{household_column} AS TEXT) = :household_id"
+            params["household_id"] = normalized_household_id
+        rows = conn.execute(
+            text(f"""
+                SELECT
+                    CAST(ha.{id_column} AS TEXT) AS id,
+                    {f'CAST(ha.{household_column} AS TEXT)' if household_column else "''"} AS household_id,
+                    {name_expr} AS article_name,
+                    {group_expr} AS article_group_id,
+                    ag.name AS article_group_name
+                FROM household_articles ha
+                LEFT JOIN article_groups ag ON ag.id = {group_expr}
+                WHERE {where_clause}
+                ORDER BY lower({name_expr}) ASC, CAST(ha.{id_column} AS TEXT) ASC
+            """),
+            params,
+        ).mappings().all()
+    items = []
+    for row in rows:
+        article_name = str(row.get("article_name") or "").strip() or "Onbekend artikel"
+        items.append({
+            "id": str(row.get("id") or ""),
+            "household_id": str(row.get("household_id") or normalized_household_id),
+            "article_name": article_name,
+            "article_group_id": row.get("article_group_id") or None,
+            "article_group_name": row.get("article_group_name") or "Niet ingedeeld",
+        })
+    return {"ok": True, "items": items, "mutates_inventory": False}
+
+
+def assign_household_article_group(article_id: Any, article_group_id: Any = None, household_id: Any = None) -> dict[str, Any]:
+    ensure_article_group_schema()
+    normalized_article_id = str(article_id or "").strip()
+    if not normalized_article_id:
+        return {"ok": False, "error": "Artikel-id is verplicht"}
+    normalized_group_id = str(article_group_id or "").strip() or None
+    with engine.begin() as conn:
+        if not _table_exists(conn, "household_articles"):
+            return {"ok": False, "error": "household_articles tabel ontbreekt"}
+        columns = _get_columns(conn, "household_articles")
+        id_column = _first_existing(columns, ["id", "household_article_id"])
+        if not id_column:
+            return {"ok": False, "error": "household_articles heeft geen id-kolom"}
+        household_column = _first_existing(columns, ["household_id"])
+        household_expr = f"CAST({household_column} AS TEXT)" if household_column else "''"
+        row = conn.execute(
+            text(f"SELECT CAST({id_column} AS TEXT) AS id, {household_expr} AS household_id FROM household_articles WHERE CAST({id_column} AS TEXT) = :id LIMIT 1"),
+            {"id": normalized_article_id},
+        ).mappings().first()
+        if not row:
+            return {"ok": False, "error": "Huishoudelijk artikel niet gevonden"}
+        normalized_household_id = _normalize_household_id(household_id or row.get("household_id"))
+        if household_column and str(row.get("household_id") or "") != normalized_household_id:
+            return {"ok": False, "error": "Artikel hoort niet bij dit huishouden"}
+        group_name = "Niet ingedeeld"
+        if normalized_group_id:
+            group = conn.execute(
+                text("""
+                    SELECT id, name
+                    FROM article_groups
+                    WHERE id = :id
+                      AND household_id = :household_id
+                      AND COALESCE(status, 'active') = 'active'
+                    LIMIT 1
+                """),
+                {"id": normalized_group_id, "household_id": normalized_household_id},
+            ).mappings().first()
+            if not group:
+                return {"ok": False, "error": "Artikelgroep niet gevonden"}
+            group_name = str(group.get("name") or "") or group_name
+        conn.execute(
+            text(f"UPDATE household_articles SET article_group_id = :article_group_id WHERE CAST({id_column} AS TEXT) = :id"),
+            {"id": normalized_article_id, "article_group_id": normalized_group_id},
+        )
+    return {"ok": True, "article_id": normalized_article_id, "article_group_id": normalized_group_id, "article_group_name": group_name, "mutates_inventory": False}

--- a/backend/app/services/article_group_store.py
+++ b/backend/app/services/article_group_store.py
@@ -24,8 +24,8 @@ CREATE TABLE IF NOT EXISTS article_groups (
 """
 
 ARTICLE_GROUPS_HOUSEHOLD_INDEX_SQL = """
-CREATE INDEX IF NOT EXISTS idx_article_groups_household_status
-ON article_groups (household_id, status, normalized_name)
+CREATE INDEX IF NOT EXISTS idx_article_groups_household_name
+ON article_groups (household_id, normalized_name)
 """
 
 HOUSEHOLD_ARTICLE_GROUP_INDEX_SQL = """
@@ -90,6 +90,7 @@ def ensure_article_group_schema() -> None:
     with engine.begin() as conn:
         conn.execute(text(ARTICLE_GROUPS_SQL))
         conn.execute(text(ARTICLE_GROUPS_HOUSEHOLD_INDEX_SQL))
+        conn.execute(text("UPDATE article_groups SET status = 'active' WHERE COALESCE(status, 'active') <> 'active'"))
         _ensure_missing_column(conn, "household_articles", "article_group_id", "TEXT")
         if _table_exists(conn, "household_articles"):
             conn.execute(text(HOUSEHOLD_ARTICLE_GROUP_INDEX_SQL))
@@ -105,24 +106,21 @@ def _article_group_row(row: Any) -> dict[str, Any]:
         "household_id": str(row.get("household_id") or ""),
         "name": str(row.get("name") or ""),
         "normalized_name": str(row.get("normalized_name") or ""),
-        "status": str(row.get("status") or "active"),
         "sort_order": int(row.get("sort_order") or 0),
         "created_at": row.get("created_at"),
         "updated_at": row.get("updated_at"),
     }
 
 
-def list_article_groups(household_id: Any = None, include_inactive: bool = False) -> dict[str, Any]:
+def list_article_groups(household_id: Any = None) -> dict[str, Any]:
     ensure_article_group_schema()
     normalized_household_id = _normalize_household_id(household_id)
-    where_status = "1 = 1" if include_inactive else "COALESCE(status, 'active') = 'active'"
     with engine.begin() as conn:
         rows = conn.execute(
-            text(f"""
-                SELECT id, household_id, name, normalized_name, status, sort_order, created_at, updated_at
+            text("""
+                SELECT id, household_id, name, normalized_name, sort_order, created_at, updated_at
                 FROM article_groups
                 WHERE household_id = :household_id
-                  AND {where_status}
                 ORDER BY sort_order ASC, lower(name) ASC, id ASC
             """),
             {"household_id": normalized_household_id},
@@ -146,7 +144,6 @@ def create_article_group(household_id: Any, name: Any) -> dict[str, Any]:
                 FROM article_groups
                 WHERE household_id = :household_id
                   AND normalized_name = :normalized_name
-                  AND COALESCE(status, 'active') = 'active'
                 LIMIT 1
             """),
             {"household_id": normalized_household_id, "normalized_name": normalized_name},
@@ -173,10 +170,10 @@ def create_article_group(household_id: Any, name: Any) -> dict[str, Any]:
                 "updated_at": timestamp,
             },
         )
-    return {"ok": True, "item": {"id": group_id, "household_id": normalized_household_id, "name": display_name, "normalized_name": normalized_name, "status": "active", "sort_order": sort_order}, "mutates_inventory": False}
+    return {"ok": True, "item": {"id": group_id, "household_id": normalized_household_id, "name": display_name, "normalized_name": normalized_name, "sort_order": sort_order}, "mutates_inventory": False}
 
 
-def update_article_group(group_id: Any, household_id: Any = None, name: Any = None, status: Any = None, sort_order: Any = None) -> dict[str, Any]:
+def update_article_group(group_id: Any, household_id: Any = None, name: Any = None, sort_order: Any = None) -> dict[str, Any]:
     ensure_article_group_schema()
     normalized_group_id = str(group_id or "").strip()
     if not normalized_group_id:
@@ -203,16 +200,12 @@ def update_article_group(group_id: Any, household_id: Any = None, name: Any = No
                 WHERE household_id = :household_id
                   AND normalized_name = :normalized_name
                   AND id <> :id
-                  AND COALESCE(status, 'active') = 'active'
                 LIMIT 1
             """),
             {"household_id": normalized_household_id, "normalized_name": next_normalized_name, "id": normalized_group_id},
         ).mappings().first()
         if duplicate:
             return {"ok": False, "error": "Artikelgroep bestaat al"}
-        next_status = str(status if status is not None else existing.get("status") or "active").strip().lower() or "active"
-        if next_status not in {"active", "inactive"}:
-            return {"ok": False, "error": "Status moet active of inactive zijn"}
         try:
             next_sort_order = int(sort_order if sort_order is not None else existing.get("sort_order") or 0)
         except (TypeError, ValueError):
@@ -222,14 +215,13 @@ def update_article_group(group_id: Any, household_id: Any = None, name: Any = No
                 UPDATE article_groups
                 SET name = :name,
                     normalized_name = :normalized_name,
-                    status = :status,
                     sort_order = :sort_order,
                     updated_at = :updated_at
                 WHERE id = :id
             """),
-            {"id": normalized_group_id, "name": next_name, "normalized_name": next_normalized_name, "status": next_status, "sort_order": next_sort_order, "updated_at": timestamp},
+            {"id": normalized_group_id, "name": next_name, "normalized_name": next_normalized_name, "sort_order": next_sort_order, "updated_at": timestamp},
         )
-    return {"ok": True, "item": {"id": normalized_group_id, "household_id": normalized_household_id, "name": next_name, "normalized_name": next_normalized_name, "status": next_status, "sort_order": next_sort_order}, "mutates_inventory": False}
+    return {"ok": True, "item": {"id": normalized_group_id, "household_id": normalized_household_id, "name": next_name, "normalized_name": next_normalized_name, "sort_order": next_sort_order}, "mutates_inventory": False}
 
 
 def delete_article_group(group_id: Any, household_id: Any = None) -> dict[str, Any]:
@@ -251,11 +243,15 @@ def delete_article_group(group_id: Any, household_id: Any = None) -> dict[str, A
                 {"id": normalized_group_id},
             ).mappings().first().get("count") or 0)
         if linked_count > 0:
-            conn.execute(
-                text("UPDATE article_groups SET status = 'inactive', updated_at = :updated_at WHERE id = :id"),
-                {"id": normalized_group_id, "updated_at": now_iso()},
-            )
-            return {"ok": True, "id": normalized_group_id, "deleted": False, "deactivated": True, "linked_count": linked_count, "mutates_inventory": False}
+            return {
+                "ok": False,
+                "error": f"Artikelgroep kan niet worden verwijderd zolang er {linked_count} artikel{'en' if linked_count != 1 else ''} aan gekoppeld zijn",
+                "id": normalized_group_id,
+                "deleted": False,
+                "deactivated": False,
+                "linked_count": linked_count,
+                "mutates_inventory": False,
+            }
         conn.execute(text("DELETE FROM article_groups WHERE id = :id"), {"id": normalized_group_id})
     return {"ok": True, "id": normalized_group_id, "deleted": True, "deactivated": False, "linked_count": 0, "mutates_inventory": False}
 
@@ -278,7 +274,7 @@ def list_household_articles_for_grouping(household_id: Any = None) -> dict[str, 
         if not id_column:
             return {"ok": True, "items": [], "mutates_inventory": False}
         household_column = _first_existing(columns, ["household_id"])
-        name_columns = [col for col in ["custom_name", "name", "article_name", "display_name", "canonical_name"] if col in columns]
+        name_columns = [col for col in ["custom_name", "naam", "name", "article_name", "display_name", "canonical_name"] if col in columns]
         name_expr = "COALESCE(" + ", ".join(f"NULLIF(CAST(ha.{col} AS TEXT), '')" for col in name_columns) + ", '')" if name_columns else "''"
         group_expr = "ha.article_group_id" if "article_group_id" in columns else "NULL"
         where_clause = "1 = 1"
@@ -346,7 +342,6 @@ def assign_household_article_group(article_id: Any, article_group_id: Any = None
                     FROM article_groups
                     WHERE id = :id
                       AND household_id = :household_id
-                      AND COALESCE(status, 'active') = 'active'
                     LIMIT 1
                 """),
                 {"id": normalized_group_id, "household_id": normalized_household_id},

--- a/backend/app/services/external_product_candidate_store.py
+++ b/backend/app/services/external_product_candidate_store.py
@@ -463,8 +463,12 @@ def _build_receipt_line_placeholder(row: dict[str, Any]) -> dict[str, Any]:
         receipt_line_id=receipt_line_id or None,
     )
 
+    receipt_item_id = f"receipt-line:{receipt_line_id}" if receipt_line_id else ""
     return {
-        "id": f"{context_key}:receipt-item",
+        "id": receipt_item_id,
+        "receipt_item_id": receipt_item_id,
+        "receipt_item_type": "receipt_line",
+        "receipt_item_source_id": receipt_line_id or None,
         "receipt_line_id": receipt_line_id or None,
         "purchase_import_line_id": str(row.get("purchase_import_line_id") or "").strip() or None,
         "context_key": context_key,
@@ -761,8 +765,12 @@ def _m2c2h5_purchase_import_placeholder(row: dict[str, Any]) -> dict[str, Any]:
     )
     global_product_id = str(row.get("global_product_id") or "").strip()
 
+    receipt_item_id = f"purchase-import-line:{purchase_import_line_id}" if purchase_import_line_id else ""
     return {
-        "id": f"{context_key}:receipt-item",
+        "id": receipt_item_id,
+        "receipt_item_id": receipt_item_id,
+        "receipt_item_type": "purchase_import_line",
+        "receipt_item_source_id": purchase_import_line_id or None,
         "receipt_line_id": None,
         "purchase_import_line_id": purchase_import_line_id or None,
         "context_key": context_key,

--- a/backend/app/services/external_receipt_item_projection.py
+++ b/backend/app/services/external_receipt_item_projection.py
@@ -132,8 +132,12 @@ def _receipt_table_line_placeholder(row: dict[str, Any]) -> dict[str, Any]:
         receipt_line_id=receipt_line_id or None,
     )
 
+    receipt_item_id = f"receipt-table-line:{receipt_line_id}" if receipt_line_id else ""
     return {
-        "id": f"{context_key}:receipt-item",
+        "id": receipt_item_id,
+        "receipt_item_id": receipt_item_id,
+        "receipt_item_type": "receipt_table_line",
+        "receipt_item_source_id": receipt_line_id or None,
         "receipt_line_id": receipt_line_id or None,
         "purchase_import_line_id": None,
         "context_key": context_key,

--- a/backend/app/services/off_search_service.py
+++ b/backend/app/services/off_search_service.py
@@ -1,0 +1,786 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.parse
+import urllib.request
+import uuid
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db import engine
+
+
+SEARCH_A_LICIOUS_URL = os.getenv(
+    "REZZERV_OFF_SEARCH_A_LICIOUS_BASE_URL",
+    "https://search.openfoodfacts.org/search",
+).strip()
+LEGACY_CGI_URL = os.getenv(
+    "REZZERV_OFF_SEARCH_BASE_URL",
+    "https://world.openfoodfacts.org/cgi/search.pl",
+).strip()
+TIMEOUT_SECONDS = float(os.getenv("REZZERV_OFF_SEARCH_TIMEOUT_SECONDS", "8") or 8)
+
+OFF_FIELDS = [
+    "code",
+    "product_name",
+    "product_name_nl",
+    "brands",
+    "quantity",
+    "categories",
+    "categories_tags",
+    "countries",
+    "countries_tags",
+    "stores",
+    "stores_tags",
+    "image_front_small_url",
+    "image_front_url",
+]
+
+
+class OffSearchError(ValueError):
+    pass
+
+
+def _text(value: Any) -> str:
+    if isinstance(value, list):
+        return " ".join(_text(item) for item in value if _text(item))
+    return str(value or "").strip()
+
+
+def _normalize(value: Any) -> str:
+    normalized = _text(value).lower().replace(".", " ").replace("-", " ")
+    normalized = re.sub(
+        r"[^a-z0-9áéíóúàèìòùäëïöüâêîôûçñ\s]+",
+        " ",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    return " ".join(normalized.split())
+
+
+def _tokens(value: Any) -> set[str]:
+    return {token for token in _normalize(value).split() if len(token) >= 3}
+
+
+def _table_exists(conn, table_name: str) -> bool:
+    dialect = str(engine.dialect.name or "").lower()
+    if dialect == "sqlite":
+        return conn.execute(
+            text("SELECT name FROM sqlite_master WHERE type = 'table' AND name = :name"),
+            {"name": table_name},
+        ).first() is not None
+    return conn.execute(
+        text(
+            '''
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_name = :name
+            LIMIT 1
+            '''
+        ),
+        {"name": table_name},
+    ).first() is not None
+
+
+def _resolve_purchase_import_line(conn, source_id: str) -> dict[str, Any] | None:
+    if not _table_exists(conn, "purchase_import_lines"):
+        return None
+    row = conn.execute(
+        text(
+            '''
+            SELECT
+                pil.id AS source_id,
+                pil.article_name_raw AS receipt_line_text,
+                pil.external_article_code AS external_article_code,
+                pil.brand_raw AS brand,
+                pil.quantity_raw AS quantity,
+                pil.unit_raw AS unit,
+                pib.raw_payload AS batch_raw_payload
+            FROM purchase_import_lines pil
+            LEFT JOIN purchase_import_batches pib ON pib.id = pil.batch_id
+            WHERE pil.id = :source_id
+            LIMIT 1
+            '''
+        ),
+        {"source_id": source_id},
+    ).mappings().first()
+    if not row:
+        return None
+
+    retailer = ""
+    raw_payload = row.get("batch_raw_payload")
+    if raw_payload:
+        try:
+            payload = json.loads(raw_payload) if isinstance(raw_payload, str) else raw_payload
+        except Exception:
+            payload = {}
+        if isinstance(payload, dict):
+            metadata = payload.get("batch_metadata") if isinstance(payload.get("batch_metadata"), dict) else {}
+            retailer = _text(
+                metadata.get("store_name")
+                or metadata.get("store_label")
+                or payload.get("store_name")
+                or payload.get("store_label")
+                or payload.get("retailer_code")
+                or payload.get("retailer")
+            )
+
+    return {
+        "receipt_item_type": "purchase_import_line",
+        "receipt_item_source_id": source_id,
+        "receipt_line_text": _text(row.get("receipt_line_text") or row.get("external_article_code")),
+        "retailer_code": retailer,
+        "brand": _text(row.get("brand")),
+        "quantity_label": " ".join(
+            value for value in (_text(row.get("quantity")), _text(row.get("unit"))) if value
+        ),
+    }
+
+
+def _resolve_receipt_line(conn, source_id: str) -> dict[str, Any] | None:
+    if not _table_exists(conn, "receipt_lines"):
+        return None
+    row = conn.execute(
+        text(
+            '''
+            SELECT
+                rl.id AS source_id,
+                COALESCE(NULLIF(rl.parsed_name, ''), rl.raw_text) AS receipt_line_text,
+                COALESCE(rl.parsed_quantity, '') AS quantity,
+                COALESCE(rl.parsed_unit, '') AS unit,
+                COALESCE(r.store_name, '') AS retailer_code
+            FROM receipt_lines rl
+            LEFT JOIN receipts r ON r.id = rl.receipt_id
+            WHERE rl.id = :source_id
+            LIMIT 1
+            '''
+        ),
+        {"source_id": source_id},
+    ).mappings().first()
+    if not row:
+        return None
+    return {
+        "receipt_item_type": "receipt_line",
+        "receipt_item_source_id": source_id,
+        "receipt_line_text": _text(row.get("receipt_line_text")),
+        "retailer_code": _text(row.get("retailer_code")),
+        "brand": "",
+        "quantity_label": " ".join(
+            value for value in (_text(row.get("quantity")), _text(row.get("unit"))) if value
+        ),
+    }
+
+
+def _resolve_receipt_table_line(conn, source_id: str) -> dict[str, Any] | None:
+    if not _table_exists(conn, "receipt_table_lines") or not _table_exists(conn, "receipt_tables"):
+        return None
+    row = conn.execute(
+        text(
+            '''
+            SELECT
+                rtl.id AS source_id,
+                COALESCE(NULLIF(rtl.raw_label, ''), rtl.normalized_label) AS receipt_line_text,
+                COALESCE(rtl.quantity, '') AS quantity,
+                COALESCE(rtl.unit, '') AS unit,
+                COALESCE(rt.store_name, '') AS retailer_code
+            FROM receipt_table_lines rtl
+            JOIN receipt_tables rt ON rt.id = rtl.receipt_table_id
+            WHERE rtl.id = :source_id
+            LIMIT 1
+            '''
+        ),
+        {"source_id": source_id},
+    ).mappings().first()
+    if not row:
+        return None
+    return {
+        "receipt_item_type": "receipt_table_line",
+        "receipt_item_source_id": source_id,
+        "receipt_line_text": _text(row.get("receipt_line_text")),
+        "retailer_code": _text(row.get("retailer_code")),
+        "brand": "",
+        "quantity_label": " ".join(
+            value for value in (_text(row.get("quantity")), _text(row.get("unit"))) if value
+        ),
+    }
+
+
+def resolve_receipt_item(receipt_item_id: str) -> dict[str, Any]:
+    normalized_id = _text(receipt_item_id)
+    if ":" not in normalized_id:
+        raise OffSearchError("Ongeldige receipt_item_id")
+
+    prefix, source_id = normalized_id.split(":", 1)
+    source_id = source_id.strip()
+    if not source_id:
+        raise OffSearchError("Ongeldige receipt_item_id")
+
+    resolvers = {
+        "purchase-import-line": _resolve_purchase_import_line,
+        "receipt-line": _resolve_receipt_line,
+        "receipt-table-line": _resolve_receipt_table_line,
+    }
+    resolver = resolvers.get(prefix)
+    if resolver is None:
+        raise OffSearchError("Onbekend receipt_item_type")
+
+    with engine.begin() as conn:
+        item = resolver(conn, source_id)
+
+    if not item:
+        raise OffSearchError("Bonartikel niet gevonden")
+
+    item["receipt_item_id"] = normalized_id
+    return item
+
+
+def _strip_retailer_prefix(receipt_text: str, retailer_code: str) -> str:
+    text_value = _text(receipt_text)
+    retailer = _normalize(retailer_code)
+    normalized_text = _normalize(text_value)
+    if retailer and normalized_text.startswith(f"{retailer} "):
+        parts = text_value.split(maxsplit=1)
+        return parts[1].strip() if len(parts) == 2 else text_value
+    return text_value
+
+
+def _extract_products(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    candidates = (
+        payload.get("products")
+        or payload.get("items")
+        or payload.get("results")
+        or payload.get("documents")
+        or payload.get("hits")
+        or []
+    )
+    if isinstance(candidates, dict):
+        candidates = candidates.get("hits") or candidates.get("items") or candidates.get("results") or []
+    if not isinstance(candidates, list):
+        return []
+
+    products: list[dict[str, Any]] = []
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        source = item.get("_source") or item.get("source") or item.get("document") or item.get("data") or item
+        if isinstance(source, dict):
+            products.append(source)
+    return products
+
+
+def _query_search_a_licious(query: str, page_size: int) -> tuple[list[dict[str, Any]], str]:
+    request_payload = {
+        "q": query,
+        "page_size": page_size,
+        "page": 1,
+        "fields": OFF_FIELDS,
+        "langs": ["nl", "en"],
+        "boost_phrase": True,
+    }
+    request = urllib.request.Request(
+        SEARCH_A_LICIOUS_URL,
+        data=json.dumps(request_payload).encode("utf-8"),
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": "Rezzerv OFF search v2",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    return _extract_products(payload), "search_a_licious"
+
+
+def _query_legacy_cgi(query: str, page_size: int) -> tuple[list[dict[str, Any]], str]:
+    params = {
+        "search_terms": query,
+        "search_simple": "1",
+        "action": "process",
+        "json": "1",
+        "page_size": str(page_size),
+        "fields": ",".join(OFF_FIELDS),
+    }
+    url = f"{LEGACY_CGI_URL}?{urllib.parse.urlencode(params)}"
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json", "User-Agent": "Rezzerv OFF search v2"},
+    )
+    with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    return _extract_products(payload), "legacy_cgi"
+
+
+def _query_off(query: str, page_size: int) -> tuple[list[dict[str, Any]], str]:
+    errors: list[str] = []
+    successful_provider = ""
+
+    # OFF is aantoonbaar incidenteel onbereikbaar. Elke provider krijgt daarom
+    # maximaal twee directe pogingen. Er wordt niet gewacht en er vindt geen
+    # databasewijziging plaats.
+    for provider in (_query_search_a_licious, _query_legacy_cgi):
+        for attempt in (1, 2):
+            try:
+                products, provider_name = provider(query, page_size)
+                successful_provider = successful_provider or provider_name
+                if products:
+                    return products, provider_name
+                break
+            except Exception as exc:
+                errors.append(
+                    f"{provider.__name__} poging {attempt}: {exc}"
+                )
+
+    if successful_provider:
+        return [], successful_provider
+
+    raise OffSearchError(
+        "Open Food Facts is niet beschikbaar"
+        + (f" ({'; '.join(errors)})" if errors else "")
+    )
+
+
+def _name_score(query: str, product_name: str) -> float:
+    query_norm = _normalize(query)
+    product_norm = _normalize(product_name)
+    if not query_norm or not product_norm:
+        return 0.0
+    if query_norm == product_norm:
+        return 1.0
+    if query_norm in product_norm or product_norm in query_norm:
+        return 0.9
+
+    query_tokens = _tokens(query_norm)
+    product_tokens = _tokens(product_norm)
+    if not query_tokens or not product_tokens:
+        return 0.0
+
+    overlap = query_tokens & product_tokens
+    if not overlap:
+        return 0.0
+    return len(overlap) / len(query_tokens)
+
+
+def _score_product(
+    *,
+    query: str,
+    retailer_code: str,
+    quantity_label: str,
+    product: dict[str, Any],
+) -> tuple[float, dict[str, float]]:
+    product_name = _text(product.get("product_name_nl") or product.get("product_name"))
+    name = _name_score(query, product_name)
+    required_match = 1.0 if _contains_required_product_tokens(query, product_name) else 0.0
+
+    if name <= 0 or required_match <= 0:
+        return 0.0, {
+            "name": round(name, 3),
+            "required_product_match": required_match,
+            "brand": 0.0,
+            "quantity": 0.0,
+            "market": 0.0,
+            "completeness": 0.0,
+        }
+
+    brand = _retailer_brand_affinity(retailer_code, product)
+
+    requested_quantity = _tokens(quantity_label)
+    product_quantity = _tokens(product.get("quantity"))
+    quantity = (
+        len(requested_quantity & product_quantity) / len(requested_quantity)
+        if requested_quantity
+        else 0.0
+    )
+
+    country_tokens = _tokens(product.get("countries")) | _tokens(product.get("countries_tags"))
+    market = 1.0 if {"netherlands", "nederland"} & country_tokens else 0.0
+    completeness = 1.0 if _text(
+        product.get("image_front_small_url") or product.get("image_front_url")
+    ) else 0.0
+
+    score = round(
+        min(
+            1.0,
+            name * 0.68
+            + required_match * 0.12
+            + brand * 0.10
+            + quantity * 0.05
+            + market * 0.03
+            + completeness * 0.02,
+        ),
+        3,
+    )
+    return score, {
+        "name": round(name, 3),
+        "required_product_match": required_match,
+        "brand": round(brand, 3),
+        "quantity": round(quantity, 3),
+        "market": round(market, 3),
+        "completeness": round(completeness, 3),
+    }
+
+
+def _normalize_result(
+    *,
+    query: str,
+    retailer_code: str,
+    quantity_label: str,
+    product: dict[str, Any],
+) -> dict[str, Any] | None:
+    gtin = _text(product.get("code") or product.get("id") or product.get("_id"))
+    product_name = _text(product.get("product_name_nl") or product.get("product_name"))
+    if not gtin or not product_name:
+        return None
+    if not (gtin.isdigit() and len(gtin) in {8, 12, 13, 14}):
+        return None
+
+    score, breakdown = _score_product(
+        query=query,
+        retailer_code=retailer_code,
+        quantity_label=quantity_label,
+        product=product,
+    )
+    if breakdown["name"] <= 0:
+        return None
+
+    return {
+        "gtin": gtin,
+        "product_name": product_name,
+        "brand": _text(product.get("brands")),
+        "quantity": _text(product.get("quantity")),
+        "category": _text(product.get("categories")),
+        "image_url": _text(product.get("image_front_small_url") or product.get("image_front_url")),
+        "source_url": f"https://world.openfoodfacts.org/product/{urllib.parse.quote(gtin)}",
+        "score": score,
+        "score_breakdown": breakdown,
+    }
+
+
+AUTO_QUERY_STOPWORDS = {
+    "jumbo", "ah", "albert", "heijn", "lidl", "plus", "aldi", "coop", "dirk",
+    "deka", "dekamarkt", "hoogvliet", "spar", "vomar", "picnic",
+    "rust", "vers", "verse", "bio", "biologisch", "mini", "groot", "klein",
+    "pak", "zak", "doos", "fles", "blik", "pot", "stuks", "stuk",
+}
+
+
+def _automatic_query_variants(item: dict[str, Any]) -> list[dict[str, Any]]:
+    receipt_text = _strip_retailer_prefix(
+        item.get("receipt_line_text", ""),
+        item.get("retailer_code", ""),
+    )
+    raw_tokens = [token for token in _normalize(receipt_text).split() if len(token) >= 3]
+    core_tokens = [token for token in raw_tokens if token not in AUTO_QUERY_STOPWORDS]
+
+    variants: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    def add(kind: str, query: str, weight: float) -> None:
+        normalized = _normalize(query)
+        if not normalized or normalized in seen:
+            return
+        seen.add(normalized)
+        variants.append({"kind": kind, "query": normalized, "weight": weight})
+
+    if len(core_tokens) >= 2:
+        add("core_phrase", " ".join(core_tokens), 1.0)
+    if len(raw_tokens) >= 2:
+        add("clean_phrase", " ".join(raw_tokens), 0.9)
+    if len(core_tokens) == 1:
+        add("single_core", core_tokens[0], 0.55)
+    elif len(core_tokens) >= 2:
+        for token in core_tokens:
+            add("single_core", token, 0.35)
+
+    return variants[:5]
+
+
+PRODUCT_MODIFIER_TOKENS = {
+    "halfvolle",
+    "halfvol",
+    "magere",
+    "mager",
+    "volle",
+    "vol",
+    "verse",
+    "vers",
+    "bio",
+    "biologisch",
+    "rust",
+    "naturel",
+    "original",
+    "klassiek",
+    "classic",
+    "licht",
+    "light",
+}
+
+RETAILER_BRAND_ALIASES = {
+    "jumbo": {"jumbo"},
+    "lidl": {"lidl", "milbona", "deluxe", "chef select", "favorina"},
+    "albert heijn": {"albert heijn", "ah"},
+    "ah": {"albert heijn", "ah"},
+    "aldi": {"aldi", "milsani"},
+    "plus": {"plus"},
+}
+
+
+def _required_product_tokens(query: str) -> set[str]:
+    query_tokens = _tokens(query)
+    required = {
+        token
+        for token in query_tokens
+        if token not in PRODUCT_MODIFIER_TOKENS
+    }
+    return required or query_tokens
+
+
+def _contains_required_product_tokens(query: str, product_name: str) -> bool:
+    required = _required_product_tokens(query)
+    product_tokens = _tokens(product_name)
+    return bool(required) and required.issubset(product_tokens)
+
+
+def _retailer_brand_affinity(retailer_code: str, product: dict[str, Any]) -> float:
+    retailer = _normalize(retailer_code)
+    if not retailer:
+        return 0.0
+
+    aliases = RETAILER_BRAND_ALIASES.get(retailer, {retailer})
+    candidate_text = _normalize(
+        " ".join(
+            [
+                _text(product.get("brands")),
+                _text(product.get("stores")),
+                _text(product.get("stores_tags")),
+            ]
+        )
+    )
+    candidate_tokens = _tokens(candidate_text)
+
+    for alias in aliases:
+        alias_tokens = _tokens(alias)
+        if alias_tokens and alias_tokens.issubset(candidate_tokens):
+            return 1.0
+    return 0.0
+
+
+def _automatic_candidate_is_acceptable(candidate: dict[str, Any]) -> bool:
+    phrase_hits = int(candidate.get("phrase_hits") or 0)
+    total_hits = int(candidate.get("query_hits") or 0)
+    exact_single_hits = int(candidate.get("exact_single_hits") or 0)
+    best_name_score = float(candidate.get("best_name_score") or 0)
+    best_score = float(candidate.get("best_score") or 0)
+
+    if phrase_hits >= 1 and best_name_score >= 0.80 and best_score >= 0.70:
+        return True
+
+    if total_hits >= 2 and best_name_score >= 0.70 and best_score >= 0.70:
+        return True
+
+    if exact_single_hits >= 1 and best_name_score >= 1.0 and best_score >= 0.80:
+        return True
+
+    return False
+
+
+def _automatic_search(item: dict[str, Any], limit: int) -> tuple[str, str, list[dict[str, Any]], list[dict[str, Any]]]:
+    variants = _automatic_query_variants(item)
+    if not variants:
+        raise OffSearchError("Geen automatische zoektekst beschikbaar")
+
+    aggregate: dict[str, dict[str, Any]] = {}
+    providers: list[str] = []
+    diagnostics: list[dict[str, Any]] = []
+    successful_queries = 0
+
+    for variant in variants:
+        query = variant["query"]
+
+        try:
+            products, provider = _query_off(query, max(limit * 3, 10))
+            successful_queries += 1
+        except OffSearchError as exc:
+            diagnostics.append(
+                {
+                    "kind": variant["kind"],
+                    "query": query,
+                    "provider": "error",
+                    "raw_count": 0,
+                    "accepted_count": 0,
+                    "error": str(exc),
+                }
+            )
+            continue
+
+        if provider and provider not in providers:
+            providers.append(provider)
+
+        accepted_count = 0
+        for product in products:
+            result = _normalize_result(
+                query=query,
+                retailer_code=item.get("retailer_code", ""),
+                quantity_label=item.get("quantity_label", ""),
+                product=product,
+            )
+            if result is None:
+                continue
+
+            accepted_count += 1
+            gtin = result["gtin"]
+            entry = aggregate.setdefault(
+                gtin,
+                {
+                    "result": result,
+                    "query_hits": 0,
+                    "phrase_hits": 0,
+                    "exact_single_hits": 0,
+                    "weighted_hits": 0.0,
+                    "best_name_score": 0.0,
+                    "best_score": 0.0,
+                    "matched_queries": [],
+                },
+            )
+
+            entry["query_hits"] += 1
+            if variant["kind"] in {"core_phrase", "clean_phrase"}:
+                entry["phrase_hits"] += 1
+
+            current_name_score = float(
+                result.get("score_breakdown", {}).get("name") or 0
+            )
+            if variant["kind"] == "single_core" and current_name_score >= 1.0:
+                entry["exact_single_hits"] += 1
+
+            entry["weighted_hits"] += float(variant["weight"])
+            entry["best_name_score"] = max(
+                entry["best_name_score"],
+                current_name_score,
+            )
+            entry["best_score"] = max(
+                entry["best_score"],
+                float(result.get("score") or 0),
+            )
+            entry["matched_queries"].append(query)
+
+            current = entry["result"]
+            if float(result.get("score") or 0) > float(current.get("score") or 0):
+                entry["result"] = result
+
+        diagnostics.append(
+            {
+                "kind": variant["kind"],
+                "query": query,
+                "provider": provider,
+                "raw_count": len(products),
+                "accepted_count": accepted_count,
+            }
+        )
+
+    ranked: list[dict[str, Any]] = []
+    for entry in aggregate.values():
+        if not _automatic_candidate_is_acceptable(entry):
+            continue
+
+        result = dict(entry["result"])
+        result["automatic_evidence"] = {
+            "query_hits": entry["query_hits"],
+            "phrase_hits": entry["phrase_hits"],
+            "exact_single_hits": entry["exact_single_hits"],
+            "weighted_hits": round(entry["weighted_hits"], 3),
+            "best_name_score": round(entry["best_name_score"], 3),
+            "matched_queries": entry["matched_queries"],
+        }
+        result["automatic_rank_score"] = round(
+            float(result.get("score") or 0) * 0.65
+            + min(1.0, entry["weighted_hits"] / 1.5) * 0.20
+            + min(1.0, entry["phrase_hits"]) * 0.15,
+            3,
+        )
+        result["confidence"] = (
+            "high"
+            if result["automatic_rank_score"] >= 0.85
+            else "medium"
+            if result["automatic_rank_score"] >= 0.70
+            else "low"
+        )
+        ranked.append(result)
+
+    ranked.sort(
+        key=lambda row: (
+            float(row.get("automatic_rank_score") or 0),
+            float(row.get("score") or 0),
+            row.get("product_name", "").lower(),
+        ),
+        reverse=True,
+    )
+
+    primary_query = variants[0]["query"]
+
+    if successful_queries == 0:
+        return primary_query, "unavailable", [], diagnostics
+
+    provider_label = ",".join(providers) if providers else "none"
+    return primary_query, provider_label, ranked[:limit], diagnostics
+
+
+def search_off_candidates(payload: dict[str, Any]) -> dict[str, Any]:
+    receipt_item_id = _text(payload.get("receipt_item_id"))
+    mode = _text(payload.get("mode") or "manual").lower()
+    if mode not in {"manual", "automatic"}:
+        raise OffSearchError("mode moet manual of automatic zijn")
+
+    item = resolve_receipt_item(receipt_item_id)
+    limit = max(1, min(int(payload.get("limit") or 10), 20))
+    query_diagnostics: list[dict[str, Any]] = []
+
+    if mode == "manual":
+        query = _text(payload.get("query"))
+        if not query:
+            raise OffSearchError("query is verplicht bij handmatig zoeken")
+
+        raw_products, provider = _query_off(query, max(limit * 3, 10))
+        best_by_gtin: dict[str, dict[str, Any]] = {}
+        for product in raw_products:
+            result = _normalize_result(
+                query=query,
+                retailer_code=item.get("retailer_code", ""),
+                quantity_label=item.get("quantity_label", ""),
+                product=product,
+            )
+            if result is None:
+                continue
+            existing = best_by_gtin.get(result["gtin"])
+            if existing is None or result["score"] > existing["score"]:
+                best_by_gtin[result["gtin"]] = result
+
+        results = sorted(
+            best_by_gtin.values(),
+            key=lambda row: (row["score"], row["product_name"].lower()),
+            reverse=True,
+        )[:limit]
+    else:
+        query, provider, results, query_diagnostics = _automatic_search(item, limit)
+
+    return {
+        "search_id": str(uuid.uuid4()),
+        "receipt_item_id": receipt_item_id,
+        "query": query,
+        "mode": mode,
+        "provider": provider,
+        "results": results,
+        "result_count": len(results),
+        "status": "found" if results else "no_results",
+        "query_diagnostics": query_diagnostics,
+        "mutated": False,
+        "creates_global_product": False,
+        "creates_household_article": False,
+        "creates_inventory_event": False,
+        "creates_external_candidate": False,
+    }

--- a/backend/app/services/open_food_facts_candidate_store.py
+++ b/backend/app/services/open_food_facts_candidate_store.py
@@ -146,6 +146,33 @@ def save_open_food_facts_preview_candidates(payload: dict[str, Any]) -> dict[str
     saved_rows: list[dict[str, Any]] = []
 
     with engine.begin() as conn:
+        # OFF_ACTUELE_ZOEKRESULTATEN_REPLACE:
+        # Verwijder eerst de nog niet beschermde OFF-kandidaten van deze context.
+        # Hierdoor worden resultaten uit eerdere zoekteksten niet meer vermengd
+        # met de actuele zoekresultaten.
+        conn.execute(
+            text(
+                """
+                DELETE FROM external_product_candidates
+                WHERE context_key = :context_key
+                  AND (
+                        lower(replace(COALESCE(candidate_source_name, ''), '_', ' ')) = 'open food facts'
+                        OR lower(replace(COALESCE(source_name, ''), '_', ' ')) = 'open food facts'
+                        OR lower(COALESCE(created_by, '')) = 'open_food_facts_search_preview_save_v1'
+                      )
+                  AND COALESCE(is_user_confirmed, 0) = 0
+                  AND COALESCE(is_external_database_override, 0) = 0
+                  AND lower(COALESCE(candidate_status, 'candidate')) NOT IN (
+                        'linked_to_catalog',
+                        'user_confirmed',
+                        'confirmed',
+                        'linked'
+                  )
+                """
+            ),
+            {"context_key": context_key},
+        )
+
         for candidate in candidates:
             if not candidate.get("candidate_name") or not candidate.get("candidate_source_product_code"):
                 skipped.append({"reason": "missing_identity", "candidate_name": candidate.get("candidate_name")})

--- a/backend/app/services/open_food_facts_search_preview.py
+++ b/backend/app/services/open_food_facts_search_preview.py
@@ -364,15 +364,25 @@ def search_open_food_facts_preview(payload: dict[str, Any]) -> dict[str, Any]:
             "creates_household_article": False,
             "creates_inventory_event": False,
         }
-    search_terms = build_off_search_terms(
-        receipt_line_text=receipt_line_text,
-        retailer_code=retailer_code,
-        candidate_name=_text(payload.get("candidate_name")),
-        candidate_brand=_text(payload.get("candidate_brand")),
-        category=_text(payload.get("category")),
-        product_type=_text(payload.get("product_type")),
-        quantity_label=_text(payload.get("quantity_label")),
-    )
+    manual_search_text = _text(payload.get("candidate_name"))
+    is_manual_search = _text(payload.get("source")).lower() == "manual_off_search" and bool(manual_search_text)
+
+    # OFF_HANDMATIGE_ZOEKOPDRACHT_STRIKT:
+    # Een handmatige zoekactie gebruikt uitsluitend de door de gebruiker
+    # ingevoerde zoektekst. Taxonomie-, merk- en bonregelvarianten mogen deze
+    # expliciete zoekopdracht niet vervangen of verbreden.
+    if is_manual_search:
+        search_terms = _unique_terms([manual_search_text])
+    else:
+        search_terms = build_off_search_terms(
+            receipt_line_text=receipt_line_text,
+            retailer_code=retailer_code,
+            candidate_name=manual_search_text,
+            candidate_brand=_text(payload.get("candidate_brand")),
+            category=_text(payload.get("category")),
+            product_type=_text(payload.get("product_type")),
+            quantity_label=_text(payload.get("quantity_label")),
+        )
     limit = max(1, min(int(payload.get("limit") or 5), OFF_SEARCH_MAX_RESULTS))
     requested_query_limit = int(payload.get("max_queries") or OFF_SEARCH_MAX_QUERIES)
     query_limit = max(1, min(requested_query_limit, OFF_SEARCH_MAX_QUERIES))
@@ -390,6 +400,15 @@ def search_open_food_facts_preview(payload: dict[str, Any]) -> dict[str, Any]:
             normalized = _normalize_off_product(product, search_terms, payload)
             if not normalized:
                 continue
+
+            # Bij een handmatige zoekopdracht moet de productnaam inhoudelijk
+            # overeenkomen met de ingevoerde tekst. Providerresultaten zonder
+            # woordoverlap worden niet als kandidaat getoond.
+            if is_manual_search:
+                name_score = float((normalized.get("score_breakdown") or {}).get("name_score") or 0)
+                if name_score <= 0:
+                    continue
+
             existing = results_by_code.get(normalized["code"])
             if not existing or float(normalized.get("score") or 0) > float(existing.get("score") or 0):
                 results_by_code[normalized["code"]] = normalized

--- a/backend/tests/test_off_search_service_contract_selftest.py
+++ b/backend/tests/test_off_search_service_contract_selftest.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import sys
+import traceback
+
+from app.services import off_search_service as service
+
+
+def assert_equal(actual, expected, label: str) -> None:
+    if actual != expected:
+        raise AssertionError(f"{label}: verwacht {expected!r}, ontvangen {actual!r}")
+
+
+def run_manual_search_contract() -> None:
+    original_resolve_receipt_item = service.resolve_receipt_item
+    original_query_off = service._query_off
+    try:
+        service.resolve_receipt_item = lambda receipt_item_id: {
+            "receipt_item_id": receipt_item_id,
+            "receipt_item_type": "purchase_import_line",
+            "receipt_item_source_id": "line-1",
+            "receipt_line_text": "Jumbo Passata Rust",
+            "retailer_code": "Jumbo",
+            "quantity_label": "",
+        }
+        service._query_off = lambda query, page_size: (
+            [
+                {"code": "8718452504435", "product_name": "Tomaten Gezeefd Passata", "brands": "Jumbo"},
+                {"code": "8718452474356", "product_name": "Basmati rijst", "brands": "Jumbo"},
+            ],
+            "test_provider",
+        )
+
+        result = service.search_off_candidates(
+            {
+                "receipt_item_id": "purchase-import-line:line-1",
+                "query": "Passata",
+                "mode": "manual",
+                "limit": 10,
+            }
+        )
+
+        assert_equal(result["query"], "Passata", "handmatige zoekterm")
+        assert_equal(result["mutated"], False, "handmatige zoekactie muteert niet")
+        assert_equal(result["creates_external_candidate"], False, "maakt geen externe kandidaat")
+        assert_equal(
+            [row["product_name"] for row in result["results"]],
+            ["Tomaten Gezeefd Passata"],
+            "handmatige zoekresultaten",
+        )
+    finally:
+        service.resolve_receipt_item = original_resolve_receipt_item
+        service._query_off = original_query_off
+
+
+def run_automatic_search_contract() -> None:
+    original_resolve_receipt_item = service.resolve_receipt_item
+    original_query_off = service._query_off
+    captured = {}
+
+    try:
+        service.resolve_receipt_item = lambda receipt_item_id: {
+            "receipt_item_id": receipt_item_id,
+            "receipt_item_type": "purchase_import_line",
+            "receipt_item_source_id": "line-1",
+            "receipt_line_text": "Jumbo Passata Rust",
+            "retailer_code": "Jumbo",
+            "quantity_label": "",
+        }
+
+        def fake_query(query, page_size):
+            captured["query"] = query
+            return [], "test_provider"
+
+        service._query_off = fake_query
+
+        result = service.search_off_candidates(
+            {
+                "receipt_item_id": "purchase-import-line:line-1",
+                "mode": "automatic",
+            }
+        )
+
+        assert_equal(captured.get("query"), "passata", "automatische providerzoekterm gebruikt essentieel producttoken")
+        assert_equal(result["query"], "passata rust", "automatische gerapporteerde zoekterm is genormaliseerd")
+        assert_equal(result["results"], [], "automatische lege resultaatset")
+        assert_equal(result["mutated"], False, "automatische zoekactie muteert niet")
+    finally:
+        service.resolve_receipt_item = original_resolve_receipt_item
+        service._query_off = original_query_off
+
+
+def main() -> int:
+    checks = [
+        ("manual_search_contract", run_manual_search_contract),
+        ("automatic_search_contract", run_automatic_search_contract),
+    ]
+    failures = []
+
+    for name, check in checks:
+        try:
+            check()
+            print(f"PASS {name}")
+        except Exception:
+            failures.append(name)
+            print(f"FAIL {name}")
+            traceback.print_exc()
+
+    print(f"RESULT {len(checks) - len(failures)}/{len(checks)} checks passed")
+    if failures:
+        print("FAILED_CHECKS " + ", ".join(failures))
+        return 1
+
+    print("OFF_SEARCH_SERVICE_CONTRACT_GREEN")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
         "test:e2e:report": "playwright show-report",
         "guard:ssot": "python ../tools/check_r7c22_ssot_release_guard.py",
         "regression": "cd .. && backend\\.venv\\Scripts\\python.exe tools\\r7c33_receipt_validation_runner.py",
-        "test:e2e:frontend-regression": "playwright test tests/e2e/kassa.frontend-regression.spec.js tests/e2e/uitpakken.frontend-regression.spec.js tests/e2e/external-databases.frontend-regression.spec.js"
+        "test:e2e:frontend-regression": "playwright test tests/e2e/kassa.frontend-regression.spec.js tests/e2e/uitpakken.frontend-regression.spec.js tests/e2e/external-databases.frontend-regression.spec.js tests/e2e/external-databases-off.frontend-regression.spec.js tests/e2e/external-databases-unlink.frontend-regression.spec.js tests/e2e/external-databases-known-gtin.frontend-regression.spec.js tests/e2e/external-databases-no-redundant-buttons.frontend-regression.spec.js tests/e2e/product-groups.frontend-regression.spec.js tests/e2e/settings-article-groups.frontend-regression.spec.js tests/e2e/article-detail.frontend-regression.spec.js"
     },
     "dependencies": {
         "@zxing/browser": "^0.1.5",

--- a/frontend/src/app/router/AppRouter.jsx
+++ b/frontend/src/app/router/AppRouter.jsx
@@ -9,6 +9,7 @@ import KassaPage from '../../features/kassa/KassaPage.jsx'
 import StoreBatchDetailPage from '../../features/purchaseImport/StoreBatchDetailPage'
 import SettingsPage from '../../features/settings/SettingsPage'
 import SettingsArticleFieldsPage from '../../features/settings/SettingsArticleFieldsPage'
+import SettingsArticleGroupsPage from '../../features/settings/SettingsArticleGroupsPage'
 import SettingsHouseholdAutomationPage from '../../features/settings/SettingsHouseholdAutomationPage'
 import SettingsAlmostOutPage from '../../features/settings/SettingsAlmostOutPage'
 import SettingsStoreImportPage from '../../features/settings/SettingsStoreImportPage'
@@ -82,6 +83,7 @@ const router = createBrowserRouter([
   { path: '/voorraad/:articleId', element: <Protected><ArticlePage /></Protected> },
   { path: '/instellingen', element: <ProtectedSettings allowViewer={true}><SettingsPage /></ProtectedSettings> },
   { path: '/instellingen/artikeldetails/veldzichtbaarheid', element: <ProtectedSettings allowViewer={true}><SettingsArticleFieldsPage /></ProtectedSettings> },
+  { path: '/instellingen/artikelgroepen', element: <ProtectedSettings allowViewer={false}><SettingsArticleGroupsPage /></ProtectedSettings> },
   { path: '/instellingen/privacy-datadeling', element: <ProtectedSettings allowViewer={true}><SettingsPrivacyDataSharingPage /></ProtectedSettings> },
   { path: '/instellingen/huishoudautomatisering', element: <ProtectedSettings allowViewer={false}><SettingsHouseholdAutomationPage /></ProtectedSettings> },
   { path: '/instellingen/bijna-op-voorspelling', element: <ProtectedSettings allowViewer={false}><SettingsAlmostOutPage /></ProtectedSettings> },

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -139,14 +139,18 @@ function dedupeCandidates(candidates) {
   })
   return Array.from(deduped.values())
 }
-function rowKey(item) { return text(item.context_key || item.receipt_line_id || item.purchase_import_line_id || item.receipt_line_text, 'receipt-item') }
+function rowKey(item) { return text(item?.receipt_item_id, '') }
 function rawGtin(rawItem) { return gtinText(rawItem.gtin || rawItem.ean || rawItem.barcode) }
 function buildReceiptItems(rawItems) {
   const grouped = new Map()
   rawItems.forEach((rawItem) => {
     const key = rowKey(rawItem)
+    if (!key) {
+      console.error('Bonartikel zonder receipt_item_id ontvangen', rawItem)
+      return
+    }
     const itemGtin = rawGtin(rawItem)
-    const current = grouped.get(key) || { id: key, contextKey: text(rawItem.context_key, ''), receiptLineId: text(rawItem.receipt_line_id, ''), purchaseImportLineId: text(rawItem.purchase_import_line_id, ''), receiptLineText: text(rawItem.receipt_line_text), retailerCode: retailerLabel(rawItem.retailer_code), retailerCodeRaw: text(rawItem.retailer_code, ''), articleNumber: manualArticleNumberText(rawItem), receiptArticleNumber: receiptArticleNumberText(rawItem), gtin: itemGtin, quantity: text(rawItem.quantity_label), price: rawItem.price ?? '-', catalogLinked: false, status: itemGtin !== '-' ? 'GTIN / EAN bekend' : 'Nog niet verwerkt', candidates: [], hasKnownGtin: itemGtin !== '-' }
+    const current = grouped.get(key) || { id: key, receiptItemId: key, receiptItemType: text(rawItem.receipt_item_type, ''), receiptItemSourceId: text(rawItem.receipt_item_source_id, ''), contextKey: text(rawItem.context_key, ''), receiptLineId: text(rawItem.receipt_line_id, ''), purchaseImportLineId: text(rawItem.purchase_import_line_id, ''), receiptLineText: text(rawItem.receipt_line_text), retailerCode: retailerLabel(rawItem.retailer_code), retailerCodeRaw: text(rawItem.retailer_code, ''), articleNumber: manualArticleNumberText(rawItem), receiptArticleNumber: receiptArticleNumberText(rawItem), gtin: itemGtin, quantity: text(rawItem.quantity_label), price: rawItem.price ?? '-', catalogLinked: false, status: itemGtin !== '-' ? 'GTIN / EAN bekend' : 'Nog niet verwerkt', candidates: [], hasKnownGtin: itemGtin !== '-' }
     const nested = rawItem.is_receipt_item_placeholder && Array.isArray(rawItem.candidates) ? rawItem.candidates : [rawItem]
     nested.filter(Boolean).forEach((candidate) => {
       if (current.hasKnownGtin) return
@@ -180,7 +184,7 @@ function offStatusLabel(preview) {
   if (preview.status === 'skipped_known_gtin') return 'GTIN / EAN al bekend'
   return text(preview.status)
 }
-function defaultOffQuery(item) { return text(item?.bestSelectableCandidateName || item?.bestCandidateName || item?.receiptLineText, '') }
+function defaultOffQuery(item) { return text(item?.receiptLineText || item?.bestSelectableCandidateName || item?.bestCandidateName, '') }
 
 export default function ReceiptItemsOverview({ onError, onMessage }) {
   const [items, setItems] = useState([])
@@ -188,7 +192,9 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   const [selectedCandidateId, setSelectedCandidateId] = useState('')
   const [selectedItemIds, setSelectedItemIds] = useState([])
   const [isOffLoading, setIsOffLoading] = useState(false)
+  const [showSearchComplete, setShowSearchComplete] = useState(false)
   const [offPreview, setOffPreview] = useState(null)
+  const [offSearchResults, setOffSearchResults] = useState([])
   const [offError, setOffError] = useState('')
   const [offSearchText, setOffSearchText] = useState('')
   const [offSearchMode, setOffSearchMode] = useState('automatisch')
@@ -222,7 +228,7 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   useEffect(() => {
     if (!selectedItem) return
     if (filteredItems.some((item) => item.id === selectedItem.id)) return
-    setSelectedItem(null); setSelectedCandidateId(''); setOffPreview(null); setOffError(''); setOffSearchText(''); setOffSearchMode('automatisch')
+    setSelectedItem(null); setSelectedCandidateId(''); setOffPreview(null); setOffSearchResults([]); setOffError(''); setOffSearchText(''); setOffSearchMode('automatisch')
   }, [filteredItems, selectedItem])
 
   const pageCount = Math.max(1, Math.ceil(filteredItems.length / PAGE_SIZE))
@@ -231,10 +237,33 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   const emptyRows = Math.max(0, PAGE_SIZE - visibleItems.length)
   const visibleIds = visibleItems.map((item) => item.id)
   const allVisibleSelected = visibleIds.length > 0 && visibleIds.every((id) => selectedItemIds.includes(id))
-  const selectedCandidates = (selectedItem?.candidates || []).filter(isVisibleSelectionCandidate)
+  const selectedCandidates = offSearchResults.map((result) => ({
+    id: `off:${result.gtin}`,
+    candidateName: text(result.product_name),
+    brand: text(result.brand),
+    source: 'Open Food Facts',
+    externalCode: text(result.gtin),
+    score: result.automatic_rank_score ?? result.score,
+    status:
+      result.confidence === 'low'
+        ? 'Lage zekerheid'
+        : result.confidence === 'medium'
+          ? 'Middelmatige zekerheid'
+          : 'Kandidaat',
+    type: 'Universele code',
+    hasUniversalCode: true,
+    isLinkedToCatalog: false,
+    catalogLinked: false,
+    isFallbackCandidate: false,
+    isSearchHelper: false,
+    isLinkableToCatalog: false,
+    automaticRankScore: result.automatic_rank_score ?? null,
+    automaticEvidence: result.automatic_evidence ?? null,
+    raw: result,
+  }))
   const selectedCandidate = selectedCandidates.find((candidate) => candidate.id === selectedCandidateId) || null
-  const selectedCandidateCanBeLinked = Boolean(selectedCandidate && selectedCandidate.isLinkableToCatalog && !selectedCandidate.isFallbackCandidate && !selectedCandidate.isLinkedToCatalog)
-  const selectedCandidateCanBeUnlinked = Boolean(selectedCandidate && selectedCandidate.isLinkedToCatalog)
+  const selectedCandidateCanBeLinked = false
+  const selectedCandidateCanBeUnlinked = false
   const selectedItemHasKnownGtin = Boolean(selectedItem?.hasKnownGtin || hasKnownGtin(selectedItem?.gtin))
 
   function updateFilter(key, value) { setFilters((current) => ({ ...current, [key]: value })); setPage(1) }
@@ -243,7 +272,7 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   function toggleSelectedItem(itemId) { setSelectedItemIds((current) => current.includes(itemId) ? current.filter((id) => id !== itemId) : [...current, itemId]) }
   function toggleVisibleItems() { setSelectedItemIds((current) => allVisibleSelected ? current.filter((id) => !visibleIds.includes(id)) : Array.from(new Set([...current, ...visibleIds]))) }
   function goToPage(targetPage) { setPage(Math.max(1, Math.min(pageCount, targetPage))) }
-  function selectReceiptItem(item) { setSelectedItem(item); setSelectedCandidateId(''); setOffPreview(null); setOffError(''); setOffSearchText(defaultOffQuery(item)); setOffSearchMode('automatisch'); if (!item.hasKnownGtin) consultOpenFoodFactsForItem(item, defaultOffQuery(item), 'automatisch') }
+  function selectReceiptItem(item) { setSelectedItem(item); setSelectedCandidateId(''); setOffPreview(null); setOffSearchResults([]); setOffError(''); setOffSearchText(defaultOffQuery(item)); setOffSearchMode('automatisch'); if (!item.hasKnownGtin) consultOpenFoodFactsForItem(item, defaultOffQuery(item), 'automatisch') }
 
   function exportSelectedItems() {
     const selectedRows = items.filter((item) => selectedItemIds.includes(item.id))
@@ -271,15 +300,134 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   async function consultOpenFoodFactsForItem(item, queryText = defaultOffQuery(item), mode = 'automatisch') {
     if (!item || item.hasKnownGtin || hasKnownGtin(item.gtin)) return
     const query = String(queryText || '').trim()
-    if (!query) { setOffError('Vul een zoektekst in om in OFF te zoeken.'); return }
-    setIsOffLoading(true); setOffPreview(null); setOffError(''); setOffSearchMode(mode)
+    if (!query) {
+      setOffError('Vul een zoektekst in om in OFF te zoeken.')
+      return
+    }
+
+    setShowSearchComplete(false)
+    setIsOffLoading(true)
+    const searchOverlayTimer = window.setTimeout(() => {
+      setShowSearchComplete(true)
+    }, 1000)
+    setOffPreview(null)
+    setOffSearchResults([])
+    setSelectedCandidateId('')
+    setOffError('')
+    setOffSearchMode(mode)
+
     try {
-      const response = await fetchJsonWithAuth('/api/external-databases/off/save-candidates', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ receipt_line_text: item.receiptLineText, retailer_code: item.retailerCodeRaw, receipt_line_id: item.receiptLineId, purchase_import_line_id: item.purchaseImportLineId, candidate_name: query, quantity_label: item.quantity, limit: 5, source: mode === 'handmatig' ? 'manual_off_search' : 'automatic_off_search' }) })
-      const data = await response.json().catch(() => ({})); if (!response.ok) throw new Error(data?.detail || 'Open Food Facts kon niet worden geraadpleegd')
-      setOffPreview({ ...(data.preview || data), query, search_mode: mode }); await loadItems()
-    } catch (err) { setOffError(err?.message || 'Open Food Facts kon niet worden geraadpleegd') } finally { setIsOffLoading(false) }
+      const response = await fetchJsonWithAuth('/api/external-products/off/search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          receipt_item_id: item.receiptItemId || item.id,
+          ...(mode === 'handmatig' ? { query } : {}),
+          mode: mode === 'handmatig' ? 'manual' : 'automatic',
+          limit: 10,
+        }),
+      })
+
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) {
+        throw new Error(data?.detail || 'Open Food Facts kon niet worden geraadpleegd')
+      }
+
+      setOffSearchResults(Array.isArray(data?.results) ? data.results : [])
+      setOffPreview({ ...data, search_mode: mode })
+    } catch (err) {
+      setOffSearchResults([])
+      setOffError(err?.message || 'Open Food Facts kon niet worden geraadpleegd')
+    } finally {
+      window.clearTimeout(searchOverlayTimer)
+      setShowSearchComplete(false)
+      setIsOffLoading(false)
+    }
   }
+
   function runManualOffSearch() { if (selectedItem) consultOpenFoodFactsForItem(selectedItem, offSearchText, 'handmatig') }
 
-  return <div className="rz-external-receipt-overview"><div className="rz-external-databases-section-header"><h3>Bonartikelen voor externe herkenning</h3></div><div className="rz-external-databases-actions"><Button type="button" variant="secondary" disabled={!selectedItemIds.length} onClick={exportSelectedItems}>Exporteren</Button><span className="rz-external-databases-muted">Geselecteerd: {selectedItemIds.length}</span></div><div className="rz-table-scroll rz-table-scroll--wide"><Table dataTestId="external-receipt-items-table" tableClassName="rz-external-receipt-table" tableStyle={RECEIPT_TABLE_STYLE} resizableColumns><colgroup>{RECEIPT_COL_WIDTHS.map((width, index) => <col key={`receipt-col-${index}`} style={{ width }} />)}</colgroup><thead><tr className="rz-table-header"><th className="rz-check"><input type="checkbox" checked={allVisibleSelected} onChange={toggleVisibleItems} /></th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('receiptLineText')}>Bonartikel <span>{sortMark('receiptLineText')}</span></button></th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('retailerCode')}>Winkelketen <span>{sortMark('retailerCode')}</span></button></th><th className="rz-check"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('catalogLinked')}>Catalogus <span>{sortMark('catalogLinked')}</span></button></th><th>Kand. GTIN/EAN</th><th>GTIN / EAN</th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('quantity')}>Omvang / gewicht <span>{sortMark('quantity')}</span></button></th><th className="rz-num">Prijs</th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('bestCandidateName')}>Kandidaat <span>{sortMark('bestCandidateName')}</span></button></th><th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('bestCandidateScore')}>Score <span>{sortMark('bestCandidateScore')}</span></button></th><th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('candidateCount')}>Externe <span>{sortMark('candidateCount')}</span></button></th></tr><tr className="rz-external-databases-filter-row"><th></th><th><input className="rz-table-filter" value={filters.receiptLineText} onChange={(event) => updateFilter('receiptLineText', event.target.value)} placeholder="Zoek" /></th><th><input className="rz-table-filter" value={filters.retailerCode} onChange={(event) => updateFilter('retailerCode', event.target.value)} placeholder="Filter" /></th><th><select className="rz-table-filter" value={filters.catalogLinked} onChange={(event) => updateFilter('catalogLinked', event.target.value)} aria-label="Catalogus filter"><option value="all">Alle</option><option value="linked">Gekoppeld</option><option value="unlinked">Niet gekoppeld</option></select></th><th><input className="rz-table-filter" value={filters.bestCandidateCode} onChange={(event) => updateFilter('bestCandidateCode', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.gtin} onChange={(event) => updateFilter('gtin', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.quantity} onChange={(event) => updateFilter('quantity', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.price} onChange={(event) => updateFilter('price', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.bestCandidateName} onChange={(event) => updateFilter('bestCandidateName', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.bestCandidateScore} onChange={(event) => updateFilter('bestCandidateScore', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.candidateCount} onChange={(event) => updateFilter('candidateCount', event.target.value)} placeholder="Filter" /></th></tr></thead><tbody>{visibleItems.length ? visibleItems.map((item) => <tr key={item.id} className={selectedItem?.id === item.id ? 'rz-row-active' : ''} onDoubleClick={() => selectReceiptItem(item)}><td className="rz-check"><input type="checkbox" checked={selectedItemIds.includes(item.id)} onChange={() => toggleSelectedItem(item.id)} /></td><td>{item.receiptLineText}</td><td>{item.retailerCode}</td><td className="rz-check"><input type="checkbox" checked={item.catalogLinked} readOnly /></td><td>{item.bestCandidateCode || '-'}</td><td>{item.gtin}</td><td>{item.quantity}</td><td className="rz-num">{numberText(item.price)}</td><td>{item.bestCandidateName || '-'}</td><td className="rz-num">{scoreText(item.bestCandidateScore)}</td><td className="rz-num">{item.candidateCount}</td></tr>) : <tr><td colSpan="11">Geen bonartikelen beschikbaar voor externe herkenning.</td></tr>}{Array.from({ length: emptyRows }).map((_, index) => <tr key={`empty-${index}`}><td colSpan="11"></td></tr>)}</tbody></Table></div><div className="rz-external-databases-pagination" aria-label="Paginering bonartikelen"><Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => goToPage(1)}>Eerste</Button><Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => goToPage(currentPage - 1)}>Vorige</Button><span className="rz-external-databases-page-indicator">Pagina {currentPage} van {pageCount}</span><Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => goToPage(currentPage + 1)}>Volgende</Button><Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => goToPage(pageCount)}>Laatste</Button></div>{selectedItem ? <div className="rz-external-receipt-detail"><h3>Koppelen kandidaten in artikel-catalogus</h3><p>Universele kandidaten voor: {selectedItem.receiptLineText}</p><dl><dt>Winkelketen</dt><dd>{selectedItem.retailerCode}</dd><dt>Bonartikelnummer</dt><dd>{selectedItem.receiptArticleNumber}</dd><dt>Artikelnummer</dt><dd>{selectedItem.articleNumber}</dd><dt>GTIN / EAN</dt><dd>{selectedItem.gtin}</dd><dt>Status</dt><dd>{selectedItem.status}</dd></dl>{!selectedItemHasKnownGtin ? <div className="rz-external-databases-actions" data-testid="external-off-manual-search"><label className="rz-input-field"><div className="rz-label">OFF zoektekst</div><input className="rz-input" aria-label="OFF zoektekst" value={offSearchText} onChange={(event) => setOffSearchText(event.target.value)} /></label><Button type="button" variant="secondary" disabled={isOffLoading || !offSearchText.trim()} onClick={runManualOffSearch}>Zelf zoeken</Button><span className="rz-external-databases-muted">Pas de zoektekst aan als OFF geen goede kandidaat vindt.</span></div> : null}<Table dataTestId="external-receipt-item-candidates-table" tableClassName="rz-external-candidate-detail-table" tableStyle={CANDIDATE_TABLE_STYLE} resizableColumns><colgroup>{CANDIDATE_COL_WIDTHS.map((width, index) => <col key={`candidate-col-${index}`} style={{ width }} />)}</colgroup><thead><tr className="rz-table-header"><th>Keuze</th><th>Kandidaat</th><th>Merk</th><th>Bron</th><th>GTIN / EAN</th><th className="rz-num">Score</th><th>Status</th></tr></thead><tbody>{selectedCandidates.length ? selectedCandidates.map((candidate) => <tr key={candidate.id} className={selectedCandidateId === candidate.id ? 'rz-row-selected' : ''}><td className="rz-check"><input type="radio" name="external-candidate" checked={selectedCandidateId === candidate.id} disabled={!candidate.isLinkableToCatalog && !candidate.isLinkedToCatalog} onChange={() => setSelectedCandidateId(candidate.id)} /></td><td>{candidate.candidateName}</td><td>{candidate.brand}</td><td>{candidate.source}</td><td>{candidate.externalCode}</td><td className="rz-num">{scoreText(candidate.score)}</td><td>{candidate.status}</td></tr>) : <tr><td colSpan="7">Geen universele kandidaten met score 0,500 of hoger voor dit bonartikel.</td></tr>}</tbody></Table><div className="rz-external-databases-actions"><Button type="button" disabled={!selectedCandidateCanBeLinked} onClick={processSelectedCandidate}>Koppel artikel</Button><Button type="button" variant="secondary" disabled={!selectedCandidateCanBeUnlinked} onClick={unlinkSelectedCandidate}>Ontkoppel artikel</Button><span className="rz-external-databases-muted">{selectedItemHasKnownGtin ? 'GTIN/EAN is al bekend; OFF-kandidaten worden niet automatisch toegevoegd.' : (isOffLoading ? 'OFF wordt geraadpleegd...' : 'OFF wordt automatisch geraadpleegd bij openen van dit detail; gebruik Zelf zoeken om de zoektekst handmatig aan te passen.')}</span></div>{offError ? <div className="rz-inline-feedback">{offError}</div> : null}{offPreview ? <div className="rz-external-databases-preview-meta" data-testid="external-off-preview-meta"><span>OFF-status: {offStatusLabel(offPreview)}</span><span>Provider: {text(offPreview.provider)}</span><span>Zoektype: {offSearchMode}</span><span>Zoektekst: {offPreview.query || offSearchText || '-'}</span><span>Productmutatie: nee</span></div> : null}</div> : null}</div>
+  return <div className="rz-external-receipt-overview">
+    <style>{`
+      @keyframes rz-search-progress-pulse {
+        0%, 100% {
+          color: #b9e8c8;
+          text-shadow: 0 0 10px rgba(21, 94, 57, 0.18);
+          opacity: 0.72;
+        }
+        50% {
+          color: #155e39;
+          text-shadow: 0 0 26px rgba(21, 94, 57, 0.42);
+          opacity: 1;
+        }
+      }
+
+      .rz-search-complete-overlay {
+        position: fixed;
+        inset: 0;
+        z-index: 10000;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(245, 252, 247, 0.72);
+        pointer-events: auto;
+        cursor: wait;
+      }
+
+      .rz-search-progress-indicator {
+        position: fixed;
+        left: 50%;
+        top: 50%;
+        width: 220px;
+        height: 220px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 18px 28px;
+        border: 2px solid rgba(21, 94, 57, 0.32);
+        border-radius: 50%;
+        background: rgba(245, 252, 247, 0.96);
+        box-shadow: 0 12px 34px rgba(21, 94, 57, 0.24);
+        transform: translate(-50%, -50%);
+      }
+
+      .rz-search-complete-letter {
+        font-size: 132px;
+        line-height: 0.88;
+        font-weight: 700;
+        font-family: Arial, sans-serif;
+        animation: rz-search-progress-pulse 2.4s ease-in-out infinite;
+      }
+
+      .rz-search-complete-label {
+        margin-top: 14px;
+        color: #155e39;
+        font-size: 16px;
+        font-weight: 600;
+        white-space: nowrap;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .rz-search-complete-letter {
+          animation: none;
+          color: #155e39;
+          opacity: 1;
+        }
+      }
+    `}</style>
+    {showSearchComplete ? (
+      <div
+        className="rz-search-complete-overlay"
+        role="status"
+        aria-live="polite"
+        aria-label="Zoekactie wordt uitgevoerd"
+        aria-busy="true"
+      >
+        <div className="rz-search-progress-indicator">
+          <span className="rz-search-complete-letter" aria-hidden="true">R</span>
+          <span className="rz-search-complete-label">Zoekactie wordt uitgevoerd</span>
+        </div>
+      </div>
+    ) : null}<div className="rz-external-databases-section-header"><h3>Bonartikelen voor externe herkenning</h3></div><div className="rz-external-databases-actions"><Button type="button" variant="secondary" disabled={!selectedItemIds.length} onClick={exportSelectedItems}>Exporteren</Button><span className="rz-external-databases-muted">Geselecteerd: {selectedItemIds.length}</span></div><div className="rz-table-scroll rz-table-scroll--wide"><Table dataTestId="external-receipt-items-table" tableClassName="rz-external-receipt-table" tableStyle={RECEIPT_TABLE_STYLE} resizableColumns><colgroup>{RECEIPT_COL_WIDTHS.map((width, index) => <col key={`receipt-col-${index}`} style={{ width }} />)}</colgroup><thead><tr className="rz-table-header"><th className="rz-check"><input type="checkbox" checked={allVisibleSelected} onChange={toggleVisibleItems} /></th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('receiptLineText')}>Bonartikel <span>{sortMark('receiptLineText')}</span></button></th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('retailerCode')}>Winkelketen <span>{sortMark('retailerCode')}</span></button></th><th className="rz-check"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('catalogLinked')}>Catalogus <span>{sortMark('catalogLinked')}</span></button></th><th>Kand. GTIN/EAN</th><th>GTIN / EAN</th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('quantity')}>Omvang / gewicht <span>{sortMark('quantity')}</span></button></th><th className="rz-num">Prijs</th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('bestCandidateName')}>Kandidaat <span>{sortMark('bestCandidateName')}</span></button></th><th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('bestCandidateScore')}>Score <span>{sortMark('bestCandidateScore')}</span></button></th><th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('candidateCount')}>Externe <span>{sortMark('candidateCount')}</span></button></th></tr><tr className="rz-external-databases-filter-row"><th></th><th><input className="rz-table-filter" value={filters.receiptLineText} onChange={(event) => updateFilter('receiptLineText', event.target.value)} placeholder="Zoek" /></th><th><input className="rz-table-filter" value={filters.retailerCode} onChange={(event) => updateFilter('retailerCode', event.target.value)} placeholder="Filter" /></th><th><select className="rz-table-filter" value={filters.catalogLinked} onChange={(event) => updateFilter('catalogLinked', event.target.value)} aria-label="Catalogus filter"><option value="all">Alle</option><option value="linked">Gekoppeld</option><option value="unlinked">Niet gekoppeld</option></select></th><th><input className="rz-table-filter" value={filters.bestCandidateCode} onChange={(event) => updateFilter('bestCandidateCode', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.gtin} onChange={(event) => updateFilter('gtin', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.quantity} onChange={(event) => updateFilter('quantity', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.price} onChange={(event) => updateFilter('price', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.bestCandidateName} onChange={(event) => updateFilter('bestCandidateName', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.bestCandidateScore} onChange={(event) => updateFilter('bestCandidateScore', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.candidateCount} onChange={(event) => updateFilter('candidateCount', event.target.value)} placeholder="Filter" /></th></tr></thead><tbody>{visibleItems.length ? visibleItems.map((item) => <tr key={item.id} className={selectedItem?.id === item.id ? 'rz-row-active' : ''} onDoubleClick={() => selectReceiptItem(item)}><td className="rz-check"><input type="checkbox" checked={selectedItemIds.includes(item.id)} onChange={() => toggleSelectedItem(item.id)} /></td><td>{item.receiptLineText}</td><td>{item.retailerCode}</td><td className="rz-check"><input type="checkbox" checked={item.catalogLinked} readOnly /></td><td>{item.bestCandidateCode || '-'}</td><td>{item.gtin}</td><td>{item.quantity}</td><td className="rz-num">{numberText(item.price)}</td><td>{item.bestCandidateName || '-'}</td><td className="rz-num">{scoreText(item.bestCandidateScore)}</td><td className="rz-num">{item.candidateCount}</td></tr>) : <tr><td colSpan="11">Geen bonartikelen beschikbaar voor externe herkenning.</td></tr>}{Array.from({ length: emptyRows }).map((_, index) => <tr key={`empty-${index}`}><td colSpan="11"></td></tr>)}</tbody></Table></div><div className="rz-external-databases-pagination" aria-label="Paginering bonartikelen"><Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => goToPage(1)}>Eerste</Button><Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => goToPage(currentPage - 1)}>Vorige</Button><span className="rz-external-databases-page-indicator">Pagina {currentPage} van {pageCount}</span><Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => goToPage(currentPage + 1)}>Volgende</Button><Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => goToPage(pageCount)}>Laatste</Button></div>{selectedItem ? <div className="rz-external-receipt-detail"><h3>Koppelen kandidaten in artikel-catalogus</h3><p>Universele kandidaten voor: {selectedItem.receiptLineText}</p><dl><dt>Winkelketen</dt><dd>{selectedItem.retailerCode}</dd><dt>Bonartikelnummer</dt><dd>{selectedItem.receiptArticleNumber}</dd><dt>Artikelnummer</dt><dd>{selectedItem.articleNumber}</dd><dt>GTIN / EAN</dt><dd>{selectedItem.gtin}</dd><dt>Status</dt><dd>{selectedItem.status}</dd></dl>{!selectedItemHasKnownGtin ? <div className="rz-external-databases-actions" data-testid="external-off-manual-search"><label className="rz-input-field"><div className="rz-label">OFF zoektekst</div><input className="rz-input" aria-label="OFF zoektekst" value={offSearchText} onChange={(event) => setOffSearchText(event.target.value)} /></label><Button type="button" variant="secondary" disabled={isOffLoading || !offSearchText.trim()} onClick={runManualOffSearch}>Zelf zoeken</Button><span className="rz-external-databases-muted">Pas de zoektekst aan als OFF geen goede kandidaat vindt.</span></div> : null}<Table dataTestId="external-receipt-item-candidates-table" tableClassName="rz-external-candidate-detail-table" tableStyle={CANDIDATE_TABLE_STYLE} resizableColumns><colgroup>{CANDIDATE_COL_WIDTHS.map((width, index) => <col key={`candidate-col-${index}`} style={{ width }} />)}</colgroup><thead><tr className="rz-table-header"><th>Keuze</th><th>Kandidaat</th><th>Merk</th><th>Bron</th><th>GTIN / EAN</th><th className="rz-num">Score</th><th>Status</th></tr></thead><tbody>{selectedCandidates.length ? selectedCandidates.map((candidate) => <tr key={candidate.id} className={selectedCandidateId === candidate.id ? 'rz-row-selected' : ''}><td className="rz-check"><input type="radio" name="external-candidate" checked={selectedCandidateId === candidate.id} disabled={!candidate.isLinkableToCatalog && !candidate.isLinkedToCatalog} onChange={() => setSelectedCandidateId(candidate.id)} /></td><td>{candidate.candidateName}</td><td>{candidate.brand}</td><td>{candidate.source}</td><td>{candidate.externalCode}</td><td className="rz-num">{scoreText(candidate.score)}</td><td>{candidate.status}</td></tr>) : <tr><td colSpan="7">Geen universele kandidaten met score 0,500 of hoger voor dit bonartikel.</td></tr>}</tbody></Table><div className="rz-external-databases-actions"><Button type="button" disabled={!selectedCandidateCanBeLinked} onClick={processSelectedCandidate}>Koppel artikel</Button><Button type="button" variant="secondary" disabled={!selectedCandidateCanBeUnlinked} onClick={unlinkSelectedCandidate}>Ontkoppel artikel</Button><span className="rz-external-databases-muted">{selectedItemHasKnownGtin ? 'GTIN/EAN is al bekend; OFF-kandidaten worden niet automatisch toegevoegd.' : (isOffLoading ? 'OFF wordt geraadpleegd...' : 'OFF wordt automatisch geraadpleegd bij openen van dit detail; gebruik Zelf zoeken om de zoektekst handmatig aan te passen.')}</span></div>{offError ? <div className="rz-inline-feedback">{offError}</div> : null}{offPreview ? <div className="rz-external-databases-preview-meta" data-testid="external-off-preview-meta"><span>OFF-status: {offStatusLabel(offPreview)}</span><span>Provider: {text(offPreview.provider)}</span><span>Zoektype: {offSearchMode}</span><span>Zoektekst: {offPreview.query || offSearchText || '-'}</span><span>Productmutatie: nee</span></div> : null}</div> : null}</div>
 }

--- a/frontend/src/features/settings/SettingsArticleGroupsPage.jsx
+++ b/frontend/src/features/settings/SettingsArticleGroupsPage.jsx
@@ -3,12 +3,12 @@ import AppShell from '../../app/AppShell'
 import Card from '../../ui/Card'
 import Button from '../../ui/Button'
 import Table from '../../ui/Table'
-import { buildTableWidth } from '../../ui/resizableTable'
+import { buildTableWidth, ResizableHeaderCell, useResizableColumnWidths } from '../../ui/resizableTable.jsx'
 import { fetchJsonWithAuth, readStoredAuthContext } from '../../lib/authSession'
 
 const UNASSIGNED_LABEL = 'Niet ingedeeld'
 const initialGroupForm = { name: '', active: true }
-const initialGroupFilters = { name: '', actiefJa: false, articles: '' }
+const initialGroupFilters = { name: '', active: false, articles: '' }
 const initialArticleFilters = { article: '', group: '' }
 const groupTableColumns = [
   { key: 'select', width: 48 },
@@ -21,8 +21,8 @@ const articleTableColumns = [
   { key: 'article', width: 420 },
   { key: 'group', width: 320 },
 ]
-const groupColumnWidths = Object.fromEntries(groupTableColumns.map(({ key, width }) => [key, width]))
-const articleColumnWidths = Object.fromEntries(articleTableColumns.map(({ key, width }) => [key, width]))
+const groupColumnDefaults = Object.fromEntries(groupTableColumns.map(({ key, width }) => [key, width]))
+const articleColumnDefaults = Object.fromEntries(articleTableColumns.map(({ key, width }) => [key, width]))
 const greenCheckboxStyle = { accentColor: '#1A3E2B', width: 16, height: 16 }
 
 function getActiveHouseholdId() {
@@ -165,6 +165,8 @@ export default function SettingsArticleGroupsPage() {
   const [showArticleActionModal, setShowArticleActionModal] = useState(false)
   const [showPendingModal, setShowPendingModal] = useState(false)
   const pendingNavigationRef = useRef(null)
+  const { widths: groupColumnWidths, startResize: startGroupResize } = useResizableColumnWidths(groupColumnDefaults)
+  const { widths: articleColumnWidths, startResize: startArticleResize } = useResizableColumnWidths(articleColumnDefaults)
 
   async function loadData() {
     setIsLoading(true)
@@ -200,24 +202,20 @@ export default function SettingsArticleGroupsPage() {
   const groupArticleCounts = useMemo(() => countArticlesByGroup(articles), [articles])
   const selectedGroup = useMemo(() => sortedGroups.find((item) => String(item.id) === String(selectedGroupId)) || null, [sortedGroups, selectedGroupId])
 
-  const groupDirtyCount = useMemo(() => {
-    return groups.reduce((count, item) => {
-      const draft = groupDrafts[String(item.id)]
-      if (!draft) return count
-      if (String(draft.name || '').trim() !== String(item.name || '').trim()) return count + 1
-      if (Boolean(draft.active) !== (String(item.status || 'active') !== 'inactive')) return count + 1
-      return count
-    }, 0)
-  }, [groups, groupDrafts])
+  const groupDirtyCount = useMemo(() => groups.reduce((count, item) => {
+    const draft = groupDrafts[String(item.id)]
+    if (!draft) return count
+    if (String(draft.name || '').trim() !== String(item.name || '').trim()) return count + 1
+    if (Boolean(draft.active) !== (String(item.status || 'active') !== 'inactive')) return count + 1
+    return count
+  }, 0), [groups, groupDrafts])
 
-  const articleDirtyCount = useMemo(() => {
-    return articles.reduce((count, item) => {
-      const draft = articleDrafts[String(item.id)]
-      if (!draft) return count
-      if (String(draft.article_group_id || '') !== String(item.article_group_id || '')) return count + 1
-      return count
-    }, 0)
-  }, [articles, articleDrafts])
+  const articleDirtyCount = useMemo(() => articles.reduce((count, item) => {
+    const draft = articleDrafts[String(item.id)]
+    if (!draft) return count
+    if (String(draft.article_group_id || '') !== String(item.article_group_id || '')) return count + 1
+    return count
+  }, 0), [articles, articleDrafts])
 
   const hasPendingChanges = groupDirtyCount > 0 || articleDirtyCount > 0
 
@@ -251,15 +249,13 @@ export default function SettingsArticleGroupsPage() {
     return () => document.removeEventListener('click', handleDocumentClick, true)
   }, [hasPendingChanges])
 
-  const filteredGroups = useMemo(() => {
-    return sortedGroups.filter((item) => {
-      const draft = groupDrafts[String(item.id)] || { name: item.name, active: String(item.status || 'active') !== 'inactive' }
-      const nameOk = !groupFilters.name || String(draft?.name || '').toLowerCase().includes(groupFilters.name.toLowerCase())
-      const activeOk = !groupFilters.actiefJa || Boolean(draft?.active)
-      const countOk = !groupFilters.articles || String(Number(groupArticleCounts[String(item.id)] || 0)).includes(groupFilters.articles)
-      return nameOk && activeOk && countOk
-    })
-  }, [sortedGroups, groupFilters, groupDrafts, groupArticleCounts])
+  const filteredGroups = useMemo(() => sortedGroups.filter((item) => {
+    const draft = groupDrafts[String(item.id)] || { name: item.name, active: String(item.status || 'active') !== 'inactive' }
+    const nameOk = !groupFilters.name || String(draft?.name || '').toLowerCase().includes(groupFilters.name.toLowerCase())
+    const activeOk = !groupFilters.active || Boolean(draft?.active)
+    const countOk = !groupFilters.articles || String(Number(groupArticleCounts[String(item.id)] || 0)).includes(groupFilters.articles)
+    return nameOk && activeOk && countOk
+  }), [sortedGroups, groupFilters, groupDrafts, groupArticleCounts])
 
   const visibleArticles = useMemo(() => {
     if (!selectedGroupId) return articles
@@ -545,37 +541,41 @@ export default function SettingsArticleGroupsPage() {
     setShowPendingModal(false)
   }
 
+  const groupTableWidth = buildTableWidth(groupColumnWidths)
+  const articleTableWidth = buildTableWidth(articleColumnWidths)
+
   return (
     <AppShell title="Artikelgroepen" showExit={false}>
       <Card className="rz-settings-spaces-card">
         <div style={{ display: 'grid', gap: 24, width: '100%' }} data-testid="settings-article-groups-page">
           <div>
             <h2 style={{ margin: 0, fontSize: 20 }}>Beheer Artikelgroepen</h2>
-            <p style={{ margin: '8px 0 0 0', color: '#667085' }}>Beheer je eigen indeling van voorraadartikelen. Rezzerv maakt geen groepen automatisch aan.</p>
           </div>
 
           <section style={{ display: 'grid', gap: 18 }}>
             <div style={{ fontWeight: 700, color: '#0f172a' }}>Artikelgroepen</div>
-            <Table wrapperClassName="rz-stock-table-wrapper" tableClassName="rz-stock-table" tableStyle={{ tableLayout: 'fixed', width: buildTableWidth(groupColumnWidths), minWidth: buildTableWidth(groupColumnWidths) }}>
+            <Table wrapperClassName="rz-stock-table-wrapper" tableClassName="rz-stock-table" tableStyle={{ tableLayout: 'fixed', width: groupTableWidth, minWidth: groupTableWidth }}>
               <colgroup>
-                <col style={{ width: '48px' }} />
-                <col style={{ width: 'auto' }} />
-                <col style={{ width: '140px' }} />
-                <col style={{ width: '180px' }} />
+                <col style={{ width: `${groupColumnWidths.select}px` }} />
+                <col style={{ width: `${groupColumnWidths.name}px` }} />
+                <col style={{ width: `${groupColumnWidths.active}px` }} />
+                <col style={{ width: `${groupColumnWidths.articles}px` }} />
               </colgroup>
               <thead>
                 <tr className="rz-table-header">
-                  <th><input type="checkbox" style={greenCheckboxStyle} checked={allFilteredGroupsSelected} onChange={toggleAllFilteredGroups} aria-label="Selecteer alle zichtbare Artikelgroepen" /></th>
-                  <th>Artikelgroep</th>
-                  <th className="rz-num">Actief</th>
-                  <th className="rz-num">Aantal artikelen</th>
+                  <ResizableHeaderCell columnKey="select" widths={groupColumnWidths} onStartResize={startGroupResize}>
+                    <input type="checkbox" style={greenCheckboxStyle} checked={allFilteredGroupsSelected} onChange={toggleAllFilteredGroups} aria-label="Selecteer alle zichtbare Artikelgroepen" />
+                  </ResizableHeaderCell>
+                  <ResizableHeaderCell columnKey="name" widths={groupColumnWidths} onStartResize={startGroupResize}>Artikelgroep</ResizableHeaderCell>
+                  <ResizableHeaderCell columnKey="active" widths={groupColumnWidths} onStartResize={startGroupResize} className="rz-num">Actief</ResizableHeaderCell>
+                  <ResizableHeaderCell columnKey="articles" widths={groupColumnWidths} onStartResize={startGroupResize} className="rz-num">Aantal artikelen</ResizableHeaderCell>
                 </tr>
                 <tr className="rz-table-filters">
                   <th />
                   <th><input className="rz-input rz-inline-input" value={groupFilters.name} onChange={(event) => setGroupFilters((current) => ({ ...current, name: event.target.value }))} placeholder="Filter" aria-label="Filter op Artikelgroep" /></th>
                   <th className="rz-num">
                     <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', minHeight: 20, width: '100%' }}>
-                      <input type="checkbox" className="rz-filter-checkbox" style={greenCheckboxStyle} checked={groupFilters.actiefJa} onChange={(event) => setGroupFilters((current) => ({ ...current, actiefJa: event.target.checked }))} aria-label="Filter actieve Artikelgroepen" title="Alleen actieve Artikelgroepen tonen" />
+                      <input type="checkbox" className="rz-filter-checkbox" style={greenCheckboxStyle} checked={groupFilters.active} onChange={(event) => setGroupFilters((current) => ({ ...current, active: event.target.checked }))} aria-label="Filter actieve Artikelgroepen" title="Alleen actieve Artikelgroepen tonen" />
                     </div>
                   </th>
                   <th><input className="rz-input rz-inline-input" value={groupFilters.articles} onChange={(event) => setGroupFilters((current) => ({ ...current, articles: event.target.value }))} placeholder="Filter" aria-label="Filter op aantal artikelen" /></th>
@@ -609,19 +609,21 @@ export default function SettingsArticleGroupsPage() {
           </section>
 
           <section style={{ display: 'grid', gap: 18 }}>
-            <div style={{ fontWeight: 700, color: '#0f172a' }}>Voorraadartikelen{selectedGroup ? ` in ${selectedGroup.name}` : ''}</div>
+            <div style={{ fontWeight: 700, color: '#0f172a' }}>Voorraadartikelen{selectedGroup ? ` van ${selectedGroup.name}` : ''}</div>
             <p style={{ margin: 0, color: '#667085' }}>Koppelen is handmatig. Barcodeherkenning, externe databases en Uitpakken wijzigen deze koppeling niet.</p>
-            <Table wrapperClassName="rz-stock-table-wrapper" tableClassName="rz-stock-table" tableStyle={{ tableLayout: 'fixed', width: buildTableWidth(articleColumnWidths), minWidth: buildTableWidth(articleColumnWidths) }}>
+            <Table wrapperClassName="rz-stock-table-wrapper" tableClassName="rz-stock-table" tableStyle={{ tableLayout: 'fixed', width: articleTableWidth, minWidth: articleTableWidth }}>
               <colgroup>
-                <col style={{ width: '48px' }} />
-                <col style={{ width: 'auto' }} />
-                <col style={{ width: '320px' }} />
+                <col style={{ width: `${articleColumnWidths.select}px` }} />
+                <col style={{ width: `${articleColumnWidths.article}px` }} />
+                <col style={{ width: `${articleColumnWidths.group}px` }} />
               </colgroup>
               <thead>
                 <tr className="rz-table-header">
-                  <th><input type="checkbox" style={greenCheckboxStyle} checked={allFilteredArticlesSelected} onChange={toggleAllFilteredArticles} aria-label="Selecteer alle zichtbare artikelen" /></th>
-                  <th>Artikel</th>
-                  <th>Artikelgroep</th>
+                  <ResizableHeaderCell columnKey="select" widths={articleColumnWidths} onStartResize={startArticleResize}>
+                    <input type="checkbox" style={greenCheckboxStyle} checked={allFilteredArticlesSelected} onChange={toggleAllFilteredArticles} aria-label="Selecteer alle zichtbare artikelen" />
+                  </ResizableHeaderCell>
+                  <ResizableHeaderCell columnKey="article" widths={articleColumnWidths} onStartResize={startArticleResize}>Artikel</ResizableHeaderCell>
+                  <ResizableHeaderCell columnKey="group" widths={articleColumnWidths} onStartResize={startArticleResize}>Artikelgroep</ResizableHeaderCell>
                 </tr>
                 <tr className="rz-table-filters">
                   <th />

--- a/frontend/src/features/settings/SettingsArticleGroupsPage.jsx
+++ b/frontend/src/features/settings/SettingsArticleGroupsPage.jsx
@@ -1,0 +1,226 @@
+import { useEffect, useMemo, useState } from 'react'
+import AppShell from '../../app/AppShell'
+import Card from '../../ui/Card'
+import Button from '../../ui/Button'
+import { fetchJsonWithAuth, readStoredAuthContext } from '../../lib/authSession'
+
+const UNASSIGNED_LABEL = 'Niet ingedeeld'
+
+function getActiveHouseholdId() {
+  return String(readStoredAuthContext()?.active_household_id || '1').trim() || '1'
+}
+
+function extractErrorMessage(payload, fallback) {
+  if (typeof payload === 'string' && payload.trim()) return payload.trim()
+  if (payload && typeof payload === 'object') {
+    if (typeof payload.detail === 'string' && payload.detail.trim()) return payload.detail.trim()
+    if (typeof payload.error === 'string' && payload.error.trim()) return payload.error.trim()
+    if (typeof payload.message === 'string' && payload.message.trim()) return payload.message.trim()
+  }
+  return fallback
+}
+
+async function requestJson(url, options = {}) {
+  const response = await fetchJsonWithAuth(url, options)
+  const data = await response.json().catch(() => ({}))
+  if (!response.ok) throw new Error(extractErrorMessage(data, 'Verzoek mislukt'))
+  return data
+}
+
+export default function SettingsArticleGroupsPage() {
+  const householdId = useMemo(() => getActiveHouseholdId(), [])
+  const [groups, setGroups] = useState([])
+  const [articles, setArticles] = useState([])
+  const [newName, setNewName] = useState('')
+  const [editing, setEditing] = useState({})
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSaving, setIsSaving] = useState(false)
+  const [message, setMessage] = useState('')
+  const [error, setError] = useState('')
+
+  async function loadData() {
+    setIsLoading(true)
+    setError('')
+    try {
+      const [groupsData, articlesData] = await Promise.all([
+        requestJson(`/api/article-groups?household_id=${encodeURIComponent(householdId)}`),
+        requestJson(`/api/article-groups/household-articles?household_id=${encodeURIComponent(householdId)}`),
+      ])
+      setGroups(Array.isArray(groupsData?.items) ? groupsData.items : [])
+      setArticles(Array.isArray(articlesData?.items) ? articlesData.items : [])
+      setEditing({})
+    } catch (loadError) {
+      setError(loadError.message || 'Artikelgroepen konden niet worden geladen')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadData()
+  }, [])
+
+  async function handleCreateGroup(event) {
+    event.preventDefault()
+    const name = String(newName || '').trim()
+    if (!name) {
+      setError('Artikelgroepnaam is verplicht')
+      return
+    }
+    setIsSaving(true)
+    setError('')
+    setMessage('')
+    try {
+      await requestJson('/api/article-groups', {
+        method: 'POST',
+        body: JSON.stringify({ household_id: householdId, name }),
+      })
+      setNewName('')
+      setMessage('Artikelgroep toegevoegd')
+      await loadData()
+    } catch (createError) {
+      setError(createError.message || 'Artikelgroep toevoegen mislukt')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function handleRenameGroup(group) {
+    const name = String(editing[group.id] ?? group.name ?? '').trim()
+    if (!name) {
+      setError('Artikelgroepnaam is verplicht')
+      return
+    }
+    setIsSaving(true)
+    setError('')
+    setMessage('')
+    try {
+      await requestJson(`/api/article-groups/${encodeURIComponent(group.id)}`, {
+        method: 'PUT',
+        body: JSON.stringify({ household_id: householdId, name }),
+      })
+      setMessage('Artikelgroep bijgewerkt')
+      await loadData()
+    } catch (renameError) {
+      setError(renameError.message || 'Artikelgroep bijwerken mislukt')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function handleDeleteGroup(group) {
+    setIsSaving(true)
+    setError('')
+    setMessage('')
+    try {
+      const result = await requestJson(`/api/article-groups/${encodeURIComponent(group.id)}?household_id=${encodeURIComponent(householdId)}`, {
+        method: 'DELETE',
+      })
+      setMessage(result?.deactivated ? 'Artikelgroep was in gebruik en is gedeactiveerd' : 'Artikelgroep verwijderd')
+      await loadData()
+    } catch (deleteError) {
+      setError(deleteError.message || 'Artikelgroep verwijderen mislukt')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function handleAssignArticle(article, groupId) {
+    setIsSaving(true)
+    setError('')
+    setMessage('')
+    try {
+      await requestJson(`/api/household-articles/${encodeURIComponent(article.id)}/article-group`, {
+        method: 'PUT',
+        body: JSON.stringify({ household_id: householdId, article_group_id: groupId || null }),
+      })
+      setMessage('Artikelgroepkoppeling bijgewerkt')
+      await loadData()
+    } catch (assignError) {
+      setError(assignError.message || 'Artikelgroep koppelen mislukt')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <AppShell title="Instellingen" showExit={false}>
+      <Card>
+        <div style={{ display: 'grid', gap: '22px' }} data-testid="settings-article-groups-page">
+          <div>
+            <h2 style={{ margin: '0 0 8px 0', fontSize: '20px' }}>Artikelgroepen</h2>
+            <p style={{ margin: 0, color: '#667085' }}>Beheer je eigen indeling van voorraadartikelen. Rezzerv maakt geen groepen automatisch aan.</p>
+          </div>
+
+          {error ? <div className="rz-inline-feedback rz-inline-feedback--error">{error}</div> : null}
+          {message ? <div className="rz-inline-feedback rz-inline-feedback--success">{message}</div> : null}
+
+          <form onSubmit={handleCreateGroup} style={{ display: 'flex', gap: '12px', flexWrap: 'wrap', alignItems: 'center' }}>
+            <input
+              className="rz-input"
+              value={newName}
+              placeholder="Nieuwe artikelgroep"
+              onChange={(event) => setNewName(event.target.value)}
+              disabled={isSaving}
+              style={{ minWidth: '260px' }}
+            />
+            <Button type="submit" disabled={isSaving}>Toevoegen</Button>
+          </form>
+
+          <section style={{ display: 'grid', gap: '12px' }}>
+            <h3 style={{ margin: 0, fontSize: '16px' }}>Groepen</h3>
+            {isLoading ? <div>Artikelgroepen laden…</div> : null}
+            {!isLoading && !groups.length ? <div className="rz-empty-state">Nog geen Artikelgroepen. Artikelen zonder groep worden getoond als “{UNASSIGNED_LABEL}”.</div> : null}
+            {groups.map((group) => (
+              <div key={group.id} style={{ display: 'flex', gap: '12px', alignItems: 'center', flexWrap: 'wrap' }}>
+                <input
+                  className="rz-input"
+                  value={editing[group.id] ?? group.name ?? ''}
+                  onChange={(event) => setEditing((current) => ({ ...current, [group.id]: event.target.value }))}
+                  disabled={isSaving}
+                  style={{ minWidth: '260px' }}
+                />
+                <Button variant="secondary" onClick={() => handleRenameGroup(group)} disabled={isSaving}>Opslaan</Button>
+                <Button variant="secondary" onClick={() => handleDeleteGroup(group)} disabled={isSaving}>Verwijderen</Button>
+              </div>
+            ))}
+          </section>
+
+          <section style={{ display: 'grid', gap: '12px' }}>
+            <h3 style={{ margin: 0, fontSize: '16px' }}>Voorraadartikelen koppelen</h3>
+            <p style={{ margin: 0, color: '#667085' }}>Koppelen is handmatig. Barcodeherkenning, externe databases en Uitpakken wijzigen deze koppeling niet.</p>
+            {!isLoading && !articles.length ? <div className="rz-empty-state">Geen huishoudelijke voorraadartikelen gevonden.</div> : null}
+            {articles.length ? (
+              <table className="rz-table" style={{ width: '100%' }}>
+                <thead>
+                  <tr>
+                    <th>Artikel</th>
+                    <th>Artikelgroep</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {articles.map((article) => (
+                    <tr key={article.id}>
+                      <td>{article.article_name || 'Onbekend artikel'}</td>
+                      <td>
+                        <select
+                          className="rz-input"
+                          value={article.article_group_id || ''}
+                          disabled={isSaving}
+                          onChange={(event) => handleAssignArticle(article, event.target.value || null)}
+                        >
+                          <option value="">{UNASSIGNED_LABEL}</option>
+                          {groups.map((group) => <option key={group.id} value={group.id}>{group.name}</option>)}
+                        </select>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : null}
+          </section>
+        </div>
+      </Card>
+    </AppShell>
+  )
+}

--- a/frontend/src/features/settings/SettingsArticleGroupsPage.jsx
+++ b/frontend/src/features/settings/SettingsArticleGroupsPage.jsx
@@ -8,14 +8,13 @@ import { buildTableWidth, ResizableHeaderCell, useResizableColumnWidths } from '
 import { fetchJsonWithAuth, readStoredAuthContext } from '../../lib/authSession'
 
 const UNASSIGNED_LABEL = 'Niet ingedeeld'
-const initialGroupForm = { name: '', active: true }
-const initialGroupFilters = { name: '', active: false, articles: '' }
+const initialGroupForm = { name: '' }
+const initialGroupFilters = { name: '', articles: '' }
 const initialArticleFilters = { article: '', group: '' }
 const groupTableColumns = [
   { key: 'select', width: 48 },
-  { key: 'name', width: 420 },
-  { key: 'active', width: 140 },
-  { key: 'articles', width: 180 },
+  { key: 'name', width: 500 },
+  { key: 'articles', width: 220 },
 ]
 const articleTableColumns = [
   { key: 'select', width: 48 },
@@ -75,10 +74,6 @@ function ArticleGroupModal({ open, form, onChange, onClose, onSubmit, busy }) {
             <div className="rz-label">Artikelgroep naam</div>
             <input className="rz-input" autoFocus value={form.name} onChange={(event) => onChange({ ...form, name: event.target.value })} placeholder="Bijvoorbeeld: Zuivel" />
           </label>
-          <label style={{ display: 'flex', alignItems: 'center', gap: 10, color: '#0f172a', fontWeight: 600 }}>
-            <input type="checkbox" style={greenCheckboxStyle} checked={Boolean(form.active)} onChange={(event) => onChange({ ...form, active: event.target.checked })} />
-            Actief
-          </label>
         </div>
         <div className="rz-modal-actions">
           <Button type="button" variant="secondary" onClick={onClose} disabled={busy}>Annuleren</Button>
@@ -98,7 +93,7 @@ function ActionModal({ open, title, noun, selectedCount, onClose, onDelete, onAr
         <p className="rz-modal-text">Je hebt {selectedCount} {noun}{selectedCount === 1 ? '' : 'en'} geselecteerd. Kies wat je wilt doen.</p>
         <div className="rz-modal-actions">
           <Button type="button" variant="secondary" onClick={onClose} disabled={busy}>Annuleren</Button>
-          <Button type="button" variant="secondary" onClick={onArchive} disabled={busy}>{busy ? 'Bezig…' : 'Archiveren'}</Button>
+          {onArchive ? <Button type="button" variant="secondary" onClick={onArchive} disabled={busy}>{busy ? 'Bezig…' : 'Archiveren'}</Button> : null}
           <Button type="button" onClick={onDelete} disabled={busy}>{busy ? 'Bezig…' : 'Verwijderen'}</Button>
         </div>
       </div>
@@ -146,8 +141,26 @@ function PendingChangesModal({ open, onSave, onDiscard, onCancel, busy }) {
   )
 }
 
+function BulkAssignConfirmationModal({ open, selectedCount, groupName, onCancel, onSave, busy }) {
+  if (!open) return null
+  return (
+    <div className="rz-modal-backdrop" role="presentation">
+      <div className="rz-modal-card" role="dialog" aria-modal="true" aria-labelledby="article-group-bulk-confirm-title">
+        <h3 id="article-group-bulk-confirm-title" className="rz-modal-title">Bevestiging</h3>
+        <p className="rz-modal-text">
+          {selectedCount} voorraadartikel{selectedCount === 1 ? '' : 'en'} toewijzen aan Artikelgroep {groupName}.
+        </p>
+        <div className="rz-modal-actions">
+          <Button type="button" variant="secondary" onClick={onCancel} disabled={busy}>Annuleren</Button>
+          <Button type="button" onClick={onSave} disabled={busy}>{busy ? 'Opslaan…' : 'Opslaan'}</Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 function groupDraftMapFromItems(items) {
-  return Object.fromEntries(items.map((item) => [String(item.id), { name: String(item.name || ''), active: String(item.status || 'active') !== 'inactive' }]))
+  return Object.fromEntries(items.map((item) => [String(item.id), { name: String(item.name || '') }]))
 }
 
 function articleDraftMapFromItems(items) {
@@ -188,6 +201,7 @@ export default function SettingsArticleGroupsPage() {
   const [showGroupActionModal, setShowGroupActionModal] = useState(false)
   const [showArticleActionModal, setShowArticleActionModal] = useState(false)
   const [showAssignArticleGroupModal, setShowAssignArticleGroupModal] = useState(false)
+  const [showBulkAssignConfirmationModal, setShowBulkAssignConfirmationModal] = useState(false)
   const [bulkAssignGroupId, setBulkAssignGroupId] = useState('')
   const [showPendingModal, setShowPendingModal] = useState(false)
   const { widths: groupColumnWidths, startResize: startGroupResize } = useResizableColumnWidths(groupColumnDefaults)
@@ -220,14 +234,19 @@ export default function SettingsArticleGroupsPage() {
   }, [])
 
   const sortedGroups = useMemo(() => [...groups].sort((a, b) => String(a?.name || '').localeCompare(String(b?.name || ''), 'nl')), [groups])
-  const groupArticleCounts = useMemo(() => countArticlesByGroup(articles), [articles])
+  const groupArticleCounts = useMemo(
+    () => countArticlesByGroup(articles.map((item) => ({
+      ...item,
+      article_group_id: articleDrafts[String(item.id)]?.article_group_id ?? item.article_group_id,
+    }))),
+    [articles, articleDrafts],
+  )
   const selectedGroup = useMemo(() => sortedGroups.find((item) => String(item.id) === String(selectedGroupId)) || null, [sortedGroups, selectedGroupId])
 
   const groupDirtyCount = useMemo(() => groups.reduce((count, item) => {
     const draft = groupDrafts[String(item.id)]
     if (!draft) return count
     if (String(draft.name || '').trim() !== String(item.name || '').trim()) return count + 1
-    if (Boolean(draft.active) !== (String(item.status || 'active') !== 'inactive')) return count + 1
     return count
   }, 0), [groups, groupDrafts])
 
@@ -257,11 +276,10 @@ export default function SettingsArticleGroupsPage() {
   }, [blocker.state])
 
   const filteredGroups = useMemo(() => sortedGroups.filter((item) => {
-    const draft = groupDrafts[String(item.id)] || { name: item.name, active: String(item.status || 'active') !== 'inactive' }
+    const draft = groupDrafts[String(item.id)] || { name: item.name }
     const nameOk = !groupFilters.name || String(draft?.name || '').toLowerCase().includes(groupFilters.name.toLowerCase())
-    const activeOk = !groupFilters.active || Boolean(draft?.active)
     const countOk = !groupFilters.articles || String(Number(groupArticleCounts[String(item.id)] || 0)).includes(groupFilters.articles)
-    return nameOk && activeOk && countOk
+    return nameOk && countOk
   }), [sortedGroups, groupFilters, groupDrafts, groupArticleCounts])
 
   const visibleArticles = useMemo(() => {
@@ -281,11 +299,20 @@ export default function SettingsArticleGroupsPage() {
       })
   }, [visibleArticles, articleFilters, articleDrafts, groups])
 
-  const allFilteredGroupsSelected = filteredGroups.length > 0 && filteredGroups.every((item) => selectedGroupIds.includes(String(item.id)))
+  const deletableFilteredGroups = useMemo(
+    () => filteredGroups.filter((item) => Number(groupArticleCounts[String(item.id)] || 0) === 0),
+    [filteredGroups, groupArticleCounts],
+  )
+  const selectedDeletableGroupIds = useMemo(
+    () => selectedGroupIds.filter((id) => Number(groupArticleCounts[String(id)] || 0) === 0),
+    [selectedGroupIds, groupArticleCounts],
+  )
+  const allFilteredGroupsSelected = deletableFilteredGroups.length > 0 && deletableFilteredGroups.every((item) => selectedGroupIds.includes(String(item.id)))
   const allFilteredArticlesSelected = filteredArticles.length > 0 && filteredArticles.every((item) => selectedArticleIds.includes(String(item.id)))
 
   function toggleSelectedGroup(id) {
     const key = String(id)
+    if (Number(groupArticleCounts[key] || 0) > 0) return
     setSelectedGroupIds((current) => current.includes(key) ? current.filter((value) => value !== key) : [...current, key])
   }
 
@@ -296,12 +323,12 @@ export default function SettingsArticleGroupsPage() {
 
   function toggleAllFilteredGroups() {
     if (allFilteredGroupsSelected) {
-      const filteredSet = new Set(filteredGroups.map((item) => String(item.id)))
+      const filteredSet = new Set(deletableFilteredGroups.map((item) => String(item.id)))
       setSelectedGroupIds((current) => current.filter((id) => !filteredSet.has(id)))
       return
     }
-    const merged = new Set(selectedGroupIds)
-    filteredGroups.forEach((item) => merged.add(String(item.id)))
+    const merged = new Set(selectedGroupIds.filter((id) => Number(groupArticleCounts[String(id)] || 0) === 0))
+    deletableFilteredGroups.forEach((item) => merged.add(String(item.id)))
     setSelectedGroupIds(Array.from(merged))
   }
 
@@ -334,10 +361,33 @@ export default function SettingsArticleGroupsPage() {
 
   function applyBulkAssignArticleGroup() {
     if (!selectedArticleIds.length) return
-    selectedArticleIds.forEach((id) => updateArticleDraft(id, { article_group_id: bulkAssignGroupId || '' }))
-    const groupName = bulkAssignGroupId ? (sortedGroups.find((group) => String(group.id) === String(bulkAssignGroupId))?.name || 'gekozen Artikelgroep') : UNASSIGNED_LABEL
     setShowAssignArticleGroupModal(false)
-    setMessage(`${selectedArticleIds.length} voorraadartikel${selectedArticleIds.length === 1 ? '' : 'en'} klaargezet voor Artikelgroep ${groupName}. Kies Wijzigingen opslaan om te bewaren.`)
+    setShowBulkAssignConfirmationModal(true)
+  }
+
+  async function confirmBulkAssignArticleGroup() {
+    if (!selectedArticleIds.length) return
+    setIsSaving(true)
+    setError('')
+    setMessage('')
+    const groupName = bulkAssignGroupId ? (sortedGroups.find((group) => String(group.id) === String(bulkAssignGroupId))?.name || 'gekozen Artikelgroep') : UNASSIGNED_LABEL
+    try {
+      for (const id of selectedArticleIds) {
+        await requestJson(`/api/household-articles/${encodeURIComponent(id)}/article-group`, {
+          method: 'PUT',
+          body: JSON.stringify({ household_id: householdId, article_group_id: bulkAssignGroupId || null }),
+        })
+      }
+      const savedCount = selectedArticleIds.length
+      await loadData()
+      setSelectedArticleIds([])
+      setShowBulkAssignConfirmationModal(false)
+      setMessage(`${savedCount} voorraadartikel${savedCount === 1 ? '' : 'en'} toegewezen aan Artikelgroep ${groupName}.`)
+    } catch (saveError) {
+      setError(saveError?.message || 'Toewijzen aan Artikelgroep mislukt.')
+    } finally {
+      setIsSaving(false)
+    }
   }
 
   function updateGroupDraft(id, patch) {
@@ -360,7 +410,7 @@ export default function SettingsArticleGroupsPage() {
   async function savePendingChanges() {
     const changedGroups = groups.filter((item) => {
       const draft = groupDrafts[String(item.id)]
-      return draft && (String(draft.name || '').trim() !== String(item.name || '').trim() || Boolean(draft.active) !== (String(item.status || 'active') !== 'inactive'))
+      return draft && String(draft.name || '').trim() !== String(item.name || '').trim()
     })
     const changedArticles = articles.filter((item) => {
       const draft = articleDrafts[String(item.id)]
@@ -388,7 +438,7 @@ export default function SettingsArticleGroupsPage() {
         const draft = groupDrafts[String(item.id)]
         await requestJson(`/api/article-groups/${encodeURIComponent(item.id)}`, {
           method: 'PUT',
-          body: JSON.stringify({ household_id: householdId, name: String(draft.name || '').trim(), status: draft.active ? 'active' : 'inactive' }),
+          body: JSON.stringify({ household_id: householdId, name: String(draft.name || '').trim() }),
         })
       }
       for (const item of changedArticles) {
@@ -433,7 +483,7 @@ export default function SettingsArticleGroupsPage() {
   }
 
   async function deleteSelectedGroups() {
-    const selectedItems = groups.filter((item) => selectedGroupIds.includes(String(item.id)))
+    const selectedItems = groups.filter((item) => selectedDeletableGroupIds.includes(String(item.id)))
     if (!selectedItems.length) return
     setIsSaving(true)
     setError('')
@@ -466,33 +516,6 @@ export default function SettingsArticleGroupsPage() {
     }
   }
 
-  async function archiveSelectedGroups() {
-    const selectedItems = groups.filter((item) => selectedGroupIds.includes(String(item.id)))
-    if (!selectedItems.length) return
-    setIsSaving(true)
-    setError('')
-    setMessage('')
-    let archivedCount = 0
-    try {
-      for (const item of selectedItems) {
-        const draft = groupDrafts[String(item.id)] || item
-        await requestJson(`/api/article-groups/${encodeURIComponent(item.id)}`, {
-          method: 'PUT',
-          body: JSON.stringify({ household_id: householdId, name: String(draft.name || item.name || '').trim(), status: 'inactive' }),
-        })
-        archivedCount += 1
-      }
-      await loadData()
-      setSelectedGroupIds([])
-      setMessage(`${archivedCount} Artikelgroep${archivedCount === 1 ? '' : 'en'} gearchiveerd.`)
-    } catch (archiveError) {
-      setError(archiveError?.message || 'Artikelgroepen archiveren mislukt.')
-    } finally {
-      setIsSaving(false)
-      setShowGroupActionModal(false)
-    }
-  }
-
   function clearSelectedArticleGroups() {
     if (!selectedArticleIds.length) return
     selectedArticleIds.forEach((id) => updateArticleDraft(id, { article_group_id: '' }))
@@ -506,9 +529,9 @@ export default function SettingsArticleGroupsPage() {
   }
 
   function exportGroupsCsv() {
-    const rows = [['Artikelgroep', 'Actief', 'Aantal artikelen'], ...filteredGroups.map((item) => {
-      const draft = groupDrafts[String(item.id)] || { name: item.name, active: String(item.status || 'active') !== 'inactive' }
-      return [draft.name, draft.active ? 'Ja' : 'Nee', Number(groupArticleCounts[String(item.id)] || 0)]
+    const rows = [['Artikelgroep', 'Aantal artikelen'], ...filteredGroups.map((item) => {
+      const draft = groupDrafts[String(item.id)] || { name: item.name }
+      return [draft.name, Number(groupArticleCounts[String(item.id)] || 0)]
     })]
     const csv = rows.map((row) => row.map(csvEscape).join(',')).join('\n')
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
@@ -575,7 +598,6 @@ export default function SettingsArticleGroupsPage() {
               <colgroup>
                 <col style={{ width: `${groupColumnWidths.select}px` }} />
                 <col style={{ width: `${groupColumnWidths.name}px` }} />
-                <col style={{ width: `${groupColumnWidths.active}px` }} />
                 <col style={{ width: `${groupColumnWidths.articles}px` }} />
               </colgroup>
               <thead>
@@ -584,34 +606,29 @@ export default function SettingsArticleGroupsPage() {
                     <input type="checkbox" style={greenCheckboxStyle} checked={allFilteredGroupsSelected} onChange={toggleAllFilteredGroups} aria-label="Selecteer alle zichtbare Artikelgroepen" />
                   </ResizableHeaderCell>
                   <ResizableHeaderCell columnKey="name" widths={groupColumnWidths} onStartResize={startGroupResize}>Artikelgroep</ResizableHeaderCell>
-                  <ResizableHeaderCell columnKey="active" widths={groupColumnWidths} onStartResize={startGroupResize} className="rz-num">Actief</ResizableHeaderCell>
                   <ResizableHeaderCell columnKey="articles" widths={groupColumnWidths} onStartResize={startGroupResize} className="rz-num">Aantal artikelen</ResizableHeaderCell>
                 </tr>
                 <tr className="rz-table-filters">
                   <th />
                   <th><input className="rz-input rz-inline-input" value={groupFilters.name} onChange={(event) => setGroupFilters((current) => ({ ...current, name: event.target.value }))} placeholder="Filter" aria-label="Filter op Artikelgroep" /></th>
-                  <th className="rz-num">
-                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', minHeight: 20, width: '100%' }}>
-                      <input type="checkbox" className="rz-filter-checkbox" style={greenCheckboxStyle} checked={groupFilters.active} onChange={(event) => setGroupFilters((current) => ({ ...current, active: event.target.checked }))} aria-label="Filter actieve Artikelgroepen" title="Alleen actieve Artikelgroepen tonen" />
-                    </div>
-                  </th>
                   <th><input className="rz-input rz-inline-input" value={groupFilters.articles} onChange={(event) => setGroupFilters((current) => ({ ...current, articles: event.target.value }))} placeholder="Filter" aria-label="Filter op aantal artikelen" /></th>
                 </tr>
               </thead>
               <tbody>
                 {isLoading ? (
-                  <tr><td colSpan={4}>Artikelgroepen laden…</td></tr>
+                  <tr><td colSpan={3}>Artikelgroepen laden…</td></tr>
                 ) : filteredGroups.length === 0 ? (
-                  <tr><td colSpan={4}>Nog geen Artikelgroepen. Artikelen zonder groep worden getoond als “{UNASSIGNED_LABEL}”.</td></tr>
+                  <tr><td colSpan={3}>Nog geen Artikelgroepen. Artikelen zonder groep worden getoond als “{UNASSIGNED_LABEL}”.</td></tr>
                 ) : filteredGroups.map((item) => {
-                  const selected = selectedGroupIds.includes(String(item.id))
+                  const linkedArticleCount = Number(groupArticleCounts[String(item.id)] || 0)
+                  const canDeleteGroup = linkedArticleCount === 0
+                  const selected = canDeleteGroup && selectedGroupIds.includes(String(item.id))
                   const detailSelected = String(selectedGroupId) === String(item.id)
-                  const draft = groupDrafts[String(item.id)] || { name: item.name, active: String(item.status || 'active') !== 'inactive' }
+                  const draft = groupDrafts[String(item.id)] || { name: item.name }
                   return (
-                    <tr key={item.id} className={selected || detailSelected ? 'rz-row-selected' : ''} onDoubleClick={() => setSelectedGroupId(String(item.id))} title="Dubbelklik om artikelen van deze Artikelgroep te tonen">
-                      <td><input type="checkbox" style={greenCheckboxStyle} checked={selected} onChange={() => toggleSelectedGroup(item.id)} aria-label={`Selecteer ${item.name}`} /></td>
+                    <tr key={item.id} className={selected || detailSelected ? 'rz-row-selected' : ''} onDoubleClick={() => setSelectedGroupId(String(item.id))} title={canDeleteGroup ? 'Dubbelklik om artikelen van deze Artikelgroep te tonen' : 'Deze Artikelgroep kan niet worden verwijderd zolang er artikelen aan gekoppeld zijn'}>
+                      <td><input type="checkbox" style={greenCheckboxStyle} checked={selected} disabled={!canDeleteGroup} onChange={() => toggleSelectedGroup(item.id)} aria-label={canDeleteGroup ? `Selecteer ${item.name}` : `${item.name} kan niet worden verwijderd; ${linkedArticleCount} artikel${linkedArticleCount === 1 ? '' : 'en'} gekoppeld`} /></td>
                       <td><input className="rz-input rz-inline-input" value={draft.name} onChange={(event) => updateGroupDraft(item.id, { name: event.target.value })} aria-label={`Artikelgroepnaam ${item.name}`} /></td>
-                      <td className="rz-num"><input type="checkbox" style={greenCheckboxStyle} checked={Boolean(draft.active)} onChange={(event) => updateGroupDraft(item.id, { active: event.target.checked })} aria-label={`Actief ${item.name}`} /></td>
                       <td className="rz-num">{Number(groupArticleCounts[String(item.id)] || 0)}</td>
                     </tr>
                   )
@@ -619,14 +636,13 @@ export default function SettingsArticleGroupsPage() {
               </tbody>
             </Table>
             <div className="rz-stock-table-actions" style={{ justifyContent: 'flex-end', gap: 12, flexWrap: 'wrap' }}>
-              <Button type="button" variant="secondary" onClick={exportGroupsCsv} disabled={isLoading || selectedGroupIds.length === 0 || isSaving}>Exporteren</Button>
-              <Button type="button" variant="secondary" onClick={() => setShowGroupActionModal(true)} disabled={isSaving || selectedGroupIds.length === 0}>Verwijderen</Button>
+              <Button type="button" variant="secondary" onClick={() => setShowGroupActionModal(true)} disabled={isSaving || selectedDeletableGroupIds.length === 0}>Verwijderen</Button>
               <Button type="button" onClick={openCreateGroup} disabled={isSaving}>Toevoegen Artikelgroep</Button>
             </div>
           </section>
 
           <section style={{ display: 'grid', gap: 18 }}>
-            <div style={{ fontWeight: 700, color: '#0f172a' }}>Voorraadartikelen{selectedGroup ? ` van ${selectedGroup.name}` : ''}</div>
+            <div style={{ fontWeight: 700, color: '#0f172a' }}>Artikelen{selectedGroup ? ` van ${selectedGroup.name}` : ''}</div>
             <p style={{ margin: 0, color: '#667085' }}>Koppelen is handmatig. Barcodeherkenning, externe databases en Uitpakken wijzigen deze koppeling niet.</p>
             <Table wrapperClassName="rz-stock-table-wrapper" tableClassName="rz-stock-table" tableStyle={{ tableLayout: 'fixed', width: articleTableWidth, minWidth: articleTableWidth }}>
               <colgroup>
@@ -686,9 +702,17 @@ export default function SettingsArticleGroupsPage() {
       <FeedbackOverlay type="error" message={error} onClose={() => setError('')} />
       <FeedbackOverlay type="success" message={message} onClose={() => setMessage('')} />
       <ArticleGroupModal open={groupModalOpen} form={groupForm} onChange={setGroupForm} onClose={() => setGroupModalOpen(false)} onSubmit={handleSaveGroup} busy={isSaving} />
-      <ActionModal open={showGroupActionModal} title="Geselecteerde Artikelgroepen verwerken" noun="Artikelgroep" selectedCount={selectedGroupIds.length} onClose={() => setShowGroupActionModal(false)} onDelete={deleteSelectedGroups} onArchive={archiveSelectedGroups} busy={isSaving} />
+      <ActionModal open={showGroupActionModal} title="Geselecteerde Artikelgroepen verwijderen" noun="Artikelgroep" selectedCount={selectedGroupIds.length} onClose={() => setShowGroupActionModal(false)} onDelete={deleteSelectedGroups} busy={isSaving} />
       <ActionModal open={showArticleActionModal} title="Geselecteerde artikelkoppelingen verwerken" noun="artikel" selectedCount={selectedArticleIds.length} onClose={() => setShowArticleActionModal(false)} onDelete={clearSelectedArticleGroups} onArchive={archiveSelectedArticlesNoop} busy={isSaving} />
       <BulkAssignArticleGroupModal open={showAssignArticleGroupModal} selectedCount={selectedArticleIds.length} groups={sortedGroups} value={bulkAssignGroupId} onChange={setBulkAssignGroupId} onClose={() => setShowAssignArticleGroupModal(false)} onApply={applyBulkAssignArticleGroup} busy={isSaving} />
+      <BulkAssignConfirmationModal
+        open={showBulkAssignConfirmationModal}
+        selectedCount={selectedArticleIds.length}
+        groupName={bulkAssignGroupId ? (sortedGroups.find((group) => String(group.id) === String(bulkAssignGroupId))?.name || 'gekozen Artikelgroep') : UNASSIGNED_LABEL}
+        onCancel={() => setShowBulkAssignConfirmationModal(false)}
+        onSave={confirmBulkAssignArticleGroup}
+        busy={isSaving}
+      />
       <PendingChangesModal open={showPendingModal} onSave={confirmSaveAndContinue} onDiscard={confirmDiscardAndContinue} onCancel={cancelPendingDialog} busy={isSaving} />
     </AppShell>
   )

--- a/frontend/src/features/settings/SettingsArticleGroupsPage.jsx
+++ b/frontend/src/features/settings/SettingsArticleGroupsPage.jsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { useBlocker } from 'react-router-dom'
 import AppShell from '../../app/AppShell'
 import Card from '../../ui/Card'
 import Button from '../../ui/Button'
@@ -189,7 +190,6 @@ export default function SettingsArticleGroupsPage() {
   const [showAssignArticleGroupModal, setShowAssignArticleGroupModal] = useState(false)
   const [bulkAssignGroupId, setBulkAssignGroupId] = useState('')
   const [showPendingModal, setShowPendingModal] = useState(false)
-  const pendingNavigationRef = useRef(null)
   const { widths: groupColumnWidths, startResize: startGroupResize } = useResizableColumnWidths(groupColumnDefaults)
   const { widths: articleColumnWidths, startResize: startArticleResize } = useResizableColumnWidths(articleColumnDefaults)
 
@@ -207,11 +207,7 @@ export default function SettingsArticleGroupsPage() {
       setArticles(nextArticles)
       setGroupDrafts(groupDraftMapFromItems(nextGroups))
       setArticleDrafts(articleDraftMapFromItems(nextArticles))
-      setSelectedGroupId((current) => {
-        if (current && nextGroups.some((item) => String(item.id) === String(current))) return current
-        const first = [...nextGroups].sort((a, b) => String(a?.name || '').localeCompare(String(b?.name || ''), 'nl'))[0]
-        return first ? String(first.id) : ''
-      })
+      setSelectedGroupId((current) => current && nextGroups.some((item) => String(item.id) === String(current)) ? current : '')
     } catch (loadError) {
       setError(loadError?.message || 'Artikelgroepen konden niet worden geladen')
     } finally {
@@ -243,6 +239,7 @@ export default function SettingsArticleGroupsPage() {
   }, 0), [articles, articleDrafts])
 
   const hasPendingChanges = groupDirtyCount > 0 || articleDirtyCount > 0
+  const blocker = useBlocker(hasPendingChanges)
 
   useEffect(() => {
     const handleBeforeUnload = (event) => {
@@ -256,23 +253,8 @@ export default function SettingsArticleGroupsPage() {
   }, [hasPendingChanges])
 
   useEffect(() => {
-    const handleDocumentClick = (event) => {
-      if (!hasPendingChanges) return
-      const anchor = event.target instanceof Element ? event.target.closest('a[href]') : null
-      if (!anchor) return
-      const href = anchor.getAttribute('href')
-      if (!href || href.startsWith('#') || href.startsWith('javascript:')) return
-      if (anchor.target === '_blank' || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
-      const next = new URL(anchor.href, window.location.origin)
-      const current = new URL(window.location.href)
-      if (next.pathname === current.pathname && next.search === current.search && next.hash === current.hash) return
-      event.preventDefault()
-      pendingNavigationRef.current = () => { window.location.href = next.href }
-      setShowPendingModal(true)
-    }
-    document.addEventListener('click', handleDocumentClick, true)
-    return () => document.removeEventListener('click', handleDocumentClick, true)
-  }, [hasPendingChanges])
+    if (blocker.state === 'blocked') setShowPendingModal(true)
+  }, [blocker.state])
 
   const filteredGroups = useMemo(() => sortedGroups.filter((item) => {
     const draft = groupDrafts[String(item.id)] || { name: item.name, active: String(item.status || 'active') !== 'inactive' }
@@ -561,26 +543,19 @@ export default function SettingsArticleGroupsPage() {
   async function confirmSaveAndContinue() {
     const ok = await savePendingChanges()
     if (!ok) return
-    if (pendingNavigationRef.current) {
-      const navigate = pendingNavigationRef.current
-      pendingNavigationRef.current = null
-      navigate()
-    }
+    setShowPendingModal(false)
+    if (blocker.state === 'blocked') blocker.proceed()
   }
 
   function confirmDiscardAndContinue() {
     discardPendingChanges()
     setShowPendingModal(false)
-    if (pendingNavigationRef.current) {
-      const navigate = pendingNavigationRef.current
-      pendingNavigationRef.current = null
-      navigate()
-    }
+    if (blocker.state === 'blocked') blocker.proceed()
   }
 
   function cancelPendingDialog() {
-    pendingNavigationRef.current = null
     setShowPendingModal(false)
+    if (blocker.state === 'blocked') blocker.reset()
   }
 
   const groupTableWidth = buildTableWidth(groupColumnWidths)
@@ -705,10 +680,6 @@ export default function SettingsArticleGroupsPage() {
             </div>
           </section>
 
-          <div className="rz-stock-table-actions" style={{ justifyContent: 'flex-end', gap: 12, flexWrap: 'wrap' }}>
-            <Button type="button" variant="secondary" onClick={() => { discardPendingChanges(); setShowPendingModal(false) }} disabled={isSaving || !hasPendingChanges}>Wijzigingen annuleren</Button>
-            <Button type="button" onClick={savePendingChanges} disabled={isSaving || !hasPendingChanges}>{isSaving ? 'Opslaan…' : 'Wijzigingen opslaan'}</Button>
-          </div>
         </div>
       </Card>
 

--- a/frontend/src/features/settings/SettingsArticleGroupsPage.jsx
+++ b/frontend/src/features/settings/SettingsArticleGroupsPage.jsx
@@ -105,6 +105,29 @@ function ActionModal({ open, title, noun, selectedCount, onClose, onDelete, onAr
   )
 }
 
+function BulkAssignArticleGroupModal({ open, selectedCount, groups, value, onChange, onClose, onApply, busy }) {
+  if (!open) return null
+  return (
+    <div className="rz-modal-backdrop" role="presentation">
+      <div className="rz-modal-card" role="dialog" aria-modal="true" aria-labelledby="article-group-bulk-assign-title">
+        <h3 id="article-group-bulk-assign-title" className="rz-modal-title">Toewijzen aan artikelgroep</h3>
+        <p className="rz-modal-text">Je wijst {selectedCount} geselecteerde voorraadartikel{selectedCount === 1 ? '' : 'en'} toe aan één Artikelgroep.</p>
+        <label className="rz-input-field">
+          <div className="rz-label">Artikelgroep</div>
+          <select className="rz-input" autoFocus value={value} onChange={(event) => onChange(event.target.value)}>
+            <option value="">{UNASSIGNED_LABEL}</option>
+            {groups.map((group) => <option key={group.id} value={group.id}>{group.name}</option>)}
+          </select>
+        </label>
+        <div className="rz-modal-actions">
+          <Button type="button" variant="secondary" onClick={onClose} disabled={busy}>Annuleren</Button>
+          <Button type="button" onClick={onApply} disabled={busy}>{busy ? 'Toewijzen…' : 'Toewijzen'}</Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 function PendingChangesModal({ open, onSave, onDiscard, onCancel, busy }) {
   if (!open) return null
   return (
@@ -163,6 +186,8 @@ export default function SettingsArticleGroupsPage() {
   const [selectedGroupId, setSelectedGroupId] = useState('')
   const [showGroupActionModal, setShowGroupActionModal] = useState(false)
   const [showArticleActionModal, setShowArticleActionModal] = useState(false)
+  const [showAssignArticleGroupModal, setShowAssignArticleGroupModal] = useState(false)
+  const [bulkAssignGroupId, setBulkAssignGroupId] = useState('')
   const [showPendingModal, setShowPendingModal] = useState(false)
   const pendingNavigationRef = useRef(null)
   const { widths: groupColumnWidths, startResize: startGroupResize } = useResizableColumnWidths(groupColumnDefaults)
@@ -314,6 +339,23 @@ export default function SettingsArticleGroupsPage() {
     setError('')
     setGroupForm(initialGroupForm)
     setGroupModalOpen(true)
+  }
+
+  function openBulkAssignArticleGroup() {
+    if (!selectedArticleIds.length) return
+    setMessage('')
+    setError('')
+    const preferredGroupId = selectedGroupId && sortedGroups.some((group) => String(group.id) === String(selectedGroupId)) ? String(selectedGroupId) : ''
+    setBulkAssignGroupId(preferredGroupId)
+    setShowAssignArticleGroupModal(true)
+  }
+
+  function applyBulkAssignArticleGroup() {
+    if (!selectedArticleIds.length) return
+    selectedArticleIds.forEach((id) => updateArticleDraft(id, { article_group_id: bulkAssignGroupId || '' }))
+    const groupName = bulkAssignGroupId ? (sortedGroups.find((group) => String(group.id) === String(bulkAssignGroupId))?.name || 'gekozen Artikelgroep') : UNASSIGNED_LABEL
+    setShowAssignArticleGroupModal(false)
+    setMessage(`${selectedArticleIds.length} voorraadartikel${selectedArticleIds.length === 1 ? '' : 'en'} klaargezet voor Artikelgroep ${groupName}. Kies Wijzigingen opslaan om te bewaren.`)
   }
 
   function updateGroupDraft(id, patch) {
@@ -658,6 +700,7 @@ export default function SettingsArticleGroupsPage() {
             </Table>
             <div className="rz-stock-table-actions" style={{ justifyContent: 'flex-end', gap: 12, flexWrap: 'wrap' }}>
               <Button type="button" variant="secondary" onClick={exportArticleLinksCsv} disabled={isLoading || selectedArticleIds.length === 0 || isSaving}>Exporteren</Button>
+              <Button type="button" variant="secondary" onClick={openBulkAssignArticleGroup} disabled={isLoading || selectedArticleIds.length === 0 || isSaving || sortedGroups.length === 0}>Toewijzen aan artikelgroep</Button>
               <Button type="button" variant="secondary" onClick={() => setShowArticleActionModal(true)} disabled={isSaving || selectedArticleIds.length === 0}>Verwijderen</Button>
             </div>
           </section>
@@ -674,6 +717,7 @@ export default function SettingsArticleGroupsPage() {
       <ArticleGroupModal open={groupModalOpen} form={groupForm} onChange={setGroupForm} onClose={() => setGroupModalOpen(false)} onSubmit={handleSaveGroup} busy={isSaving} />
       <ActionModal open={showGroupActionModal} title="Geselecteerde Artikelgroepen verwerken" noun="Artikelgroep" selectedCount={selectedGroupIds.length} onClose={() => setShowGroupActionModal(false)} onDelete={deleteSelectedGroups} onArchive={archiveSelectedGroups} busy={isSaving} />
       <ActionModal open={showArticleActionModal} title="Geselecteerde artikelkoppelingen verwerken" noun="artikel" selectedCount={selectedArticleIds.length} onClose={() => setShowArticleActionModal(false)} onDelete={clearSelectedArticleGroups} onArchive={archiveSelectedArticlesNoop} busy={isSaving} />
+      <BulkAssignArticleGroupModal open={showAssignArticleGroupModal} selectedCount={selectedArticleIds.length} groups={sortedGroups} value={bulkAssignGroupId} onChange={setBulkAssignGroupId} onClose={() => setShowAssignArticleGroupModal(false)} onApply={applyBulkAssignArticleGroup} busy={isSaving} />
       <PendingChangesModal open={showPendingModal} onSave={confirmSaveAndContinue} onDiscard={confirmDiscardAndContinue} onCancel={cancelPendingDialog} busy={isSaving} />
     </AppShell>
   )

--- a/frontend/src/features/settings/SettingsArticleGroupsPage.jsx
+++ b/frontend/src/features/settings/SettingsArticleGroupsPage.jsx
@@ -1,10 +1,29 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import AppShell from '../../app/AppShell'
 import Card from '../../ui/Card'
 import Button from '../../ui/Button'
+import Table from '../../ui/Table'
+import { buildTableWidth } from '../../ui/resizableTable'
 import { fetchJsonWithAuth, readStoredAuthContext } from '../../lib/authSession'
 
 const UNASSIGNED_LABEL = 'Niet ingedeeld'
+const initialGroupForm = { name: '', active: true }
+const initialGroupFilters = { name: '', actiefJa: false, articles: '' }
+const initialArticleFilters = { article: '', group: '' }
+const groupTableColumns = [
+  { key: 'select', width: 48 },
+  { key: 'name', width: 420 },
+  { key: 'active', width: 140 },
+  { key: 'articles', width: 180 },
+]
+const articleTableColumns = [
+  { key: 'select', width: 48 },
+  { key: 'article', width: 420 },
+  { key: 'group', width: 320 },
+]
+const groupColumnWidths = Object.fromEntries(groupTableColumns.map(({ key, width }) => [key, width]))
+const articleColumnWidths = Object.fromEntries(articleTableColumns.map(({ key, width }) => [key, width]))
+const greenCheckboxStyle = { accentColor: '#1A3E2B', width: 16, height: 16 }
 
 function getActiveHouseholdId() {
   return String(readStoredAuthContext()?.active_household_id || '1').trim() || '1'
@@ -27,16 +46,125 @@ async function requestJson(url, options = {}) {
   return data
 }
 
+function FeedbackOverlay({ type = 'info', message, onClose }) {
+  if (!message) return null
+  const isError = type === 'error'
+  const title = isError ? 'Melding' : 'Bevestiging'
+  return (
+    <div className="rz-modal-backdrop" role="presentation">
+      <div className="rz-modal-card" role="dialog" aria-modal="true" aria-labelledby="article-groups-feedback-title">
+        <h3 id="article-groups-feedback-title" className="rz-modal-title">{title}</h3>
+        <p className="rz-modal-text">{message}</p>
+        <div className="rz-modal-actions">
+          <Button type="button" onClick={onClose}>OK</Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ArticleGroupModal({ open, form, onChange, onClose, onSubmit, busy }) {
+  if (!open) return null
+  return (
+    <div className="rz-modal-backdrop" role="presentation">
+      <div className="rz-modal-card" role="dialog" aria-modal="true" aria-labelledby="article-group-modal-title">
+        <h3 id="article-group-modal-title" className="rz-modal-title">Nieuwe Artikelgroep</h3>
+        <div style={{ display: 'grid', gap: 16 }}>
+          <label className="rz-input-field">
+            <div className="rz-label">Artikelgroep naam</div>
+            <input className="rz-input" autoFocus value={form.name} onChange={(event) => onChange({ ...form, name: event.target.value })} placeholder="Bijvoorbeeld: Zuivel" />
+          </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 10, color: '#0f172a', fontWeight: 600 }}>
+            <input type="checkbox" style={greenCheckboxStyle} checked={Boolean(form.active)} onChange={(event) => onChange({ ...form, active: event.target.checked })} />
+            Actief
+          </label>
+        </div>
+        <div className="rz-modal-actions">
+          <Button type="button" variant="secondary" onClick={onClose} disabled={busy}>Annuleren</Button>
+          <Button type="button" onClick={onSubmit} disabled={busy}>{busy ? 'Opslaan…' : 'Opslaan'}</Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ActionModal({ open, title, noun, selectedCount, onClose, onDelete, onArchive, busy }) {
+  if (!open) return null
+  return (
+    <div className="rz-modal-backdrop" role="presentation">
+      <div className="rz-modal-card" role="dialog" aria-modal="true" aria-labelledby="article-group-action-modal-title">
+        <h3 id="article-group-action-modal-title" className="rz-modal-title">{title}</h3>
+        <p className="rz-modal-text">Je hebt {selectedCount} {noun}{selectedCount === 1 ? '' : 'en'} geselecteerd. Kies wat je wilt doen.</p>
+        <div className="rz-modal-actions">
+          <Button type="button" variant="secondary" onClick={onClose} disabled={busy}>Annuleren</Button>
+          <Button type="button" variant="secondary" onClick={onArchive} disabled={busy}>{busy ? 'Bezig…' : 'Archiveren'}</Button>
+          <Button type="button" onClick={onDelete} disabled={busy}>{busy ? 'Bezig…' : 'Verwijderen'}</Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function PendingChangesModal({ open, onSave, onDiscard, onCancel, busy }) {
+  if (!open) return null
+  return (
+    <div className="rz-modal-backdrop" role="presentation">
+      <div className="rz-modal-card" role="dialog" aria-modal="true" aria-labelledby="article-group-pending-modal-title">
+        <h3 id="article-group-pending-modal-title" className="rz-modal-title">Wijzigingen bewaren?</h3>
+        <p className="rz-modal-text">Er zijn nog niet-opgeslagen wijzigingen in Artikelgroepen en/of artikelkoppelingen. Kies of je deze wilt opslaan of annuleren.</p>
+        <div className="rz-modal-actions">
+          <Button type="button" variant="secondary" onClick={onCancel} disabled={busy}>Terug naar scherm</Button>
+          <Button type="button" variant="secondary" onClick={onDiscard} disabled={busy}>Wijzigingen annuleren</Button>
+          <Button type="button" onClick={onSave} disabled={busy}>{busy ? 'Opslaan…' : 'Wijzigingen opslaan'}</Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function groupDraftMapFromItems(items) {
+  return Object.fromEntries(items.map((item) => [String(item.id), { name: String(item.name || ''), active: String(item.status || 'active') !== 'inactive' }]))
+}
+
+function articleDraftMapFromItems(items) {
+  return Object.fromEntries(items.map((item) => [String(item.id), { article_group_id: item.article_group_id ? String(item.article_group_id) : '' }]))
+}
+
+function countArticlesByGroup(items) {
+  return items.reduce((counts, item) => {
+    const key = item.article_group_id ? String(item.article_group_id) : ''
+    counts[key] = (counts[key] || 0) + 1
+    return counts
+  }, {})
+}
+
+function csvEscape(value) {
+  const text = String(value ?? '')
+  if (!text.includes(',') && !text.includes('"') && !text.includes('\n')) return text
+  return `"${text.replace(/"/g, '""')}"`
+}
+
 export default function SettingsArticleGroupsPage() {
   const householdId = useMemo(() => getActiveHouseholdId(), [])
   const [groups, setGroups] = useState([])
   const [articles, setArticles] = useState([])
-  const [newName, setNewName] = useState('')
-  const [editing, setEditing] = useState({})
+  const [groupDrafts, setGroupDrafts] = useState({})
+  const [articleDrafts, setArticleDrafts] = useState({})
   const [isLoading, setIsLoading] = useState(true)
   const [isSaving, setIsSaving] = useState(false)
   const [message, setMessage] = useState('')
   const [error, setError] = useState('')
+  const [groupModalOpen, setGroupModalOpen] = useState(false)
+  const [groupForm, setGroupForm] = useState(initialGroupForm)
+  const [groupFilters, setGroupFilters] = useState(initialGroupFilters)
+  const [articleFilters, setArticleFilters] = useState(initialArticleFilters)
+  const [selectedGroupIds, setSelectedGroupIds] = useState([])
+  const [selectedArticleIds, setSelectedArticleIds] = useState([])
+  const [selectedGroupId, setSelectedGroupId] = useState('')
+  const [showGroupActionModal, setShowGroupActionModal] = useState(false)
+  const [showArticleActionModal, setShowArticleActionModal] = useState(false)
+  const [showPendingModal, setShowPendingModal] = useState(false)
+  const pendingNavigationRef = useRef(null)
 
   async function loadData() {
     setIsLoading(true)
@@ -46,11 +174,19 @@ export default function SettingsArticleGroupsPage() {
         requestJson(`/api/article-groups?household_id=${encodeURIComponent(householdId)}`),
         requestJson(`/api/article-groups/household-articles?household_id=${encodeURIComponent(householdId)}`),
       ])
-      setGroups(Array.isArray(groupsData?.items) ? groupsData.items : [])
-      setArticles(Array.isArray(articlesData?.items) ? articlesData.items : [])
-      setEditing({})
+      const nextGroups = Array.isArray(groupsData?.items) ? groupsData.items : []
+      const nextArticles = Array.isArray(articlesData?.items) ? articlesData.items : []
+      setGroups(nextGroups)
+      setArticles(nextArticles)
+      setGroupDrafts(groupDraftMapFromItems(nextGroups))
+      setArticleDrafts(articleDraftMapFromItems(nextArticles))
+      setSelectedGroupId((current) => {
+        if (current && nextGroups.some((item) => String(item.id) === String(current))) return current
+        const first = [...nextGroups].sort((a, b) => String(a?.name || '').localeCompare(String(b?.name || ''), 'nl'))[0]
+        return first ? String(first.id) : ''
+      })
     } catch (loadError) {
-      setError(loadError.message || 'Artikelgroepen konden niet worden geladen')
+      setError(loadError?.message || 'Artikelgroepen konden niet worden geladen')
     } finally {
       setIsLoading(false)
     }
@@ -60,167 +196,483 @@ export default function SettingsArticleGroupsPage() {
     loadData()
   }, [])
 
-  async function handleCreateGroup(event) {
-    event.preventDefault()
-    const name = String(newName || '').trim()
+  const sortedGroups = useMemo(() => [...groups].sort((a, b) => String(a?.name || '').localeCompare(String(b?.name || ''), 'nl')), [groups])
+  const groupArticleCounts = useMemo(() => countArticlesByGroup(articles), [articles])
+  const selectedGroup = useMemo(() => sortedGroups.find((item) => String(item.id) === String(selectedGroupId)) || null, [sortedGroups, selectedGroupId])
+
+  const groupDirtyCount = useMemo(() => {
+    return groups.reduce((count, item) => {
+      const draft = groupDrafts[String(item.id)]
+      if (!draft) return count
+      if (String(draft.name || '').trim() !== String(item.name || '').trim()) return count + 1
+      if (Boolean(draft.active) !== (String(item.status || 'active') !== 'inactive')) return count + 1
+      return count
+    }, 0)
+  }, [groups, groupDrafts])
+
+  const articleDirtyCount = useMemo(() => {
+    return articles.reduce((count, item) => {
+      const draft = articleDrafts[String(item.id)]
+      if (!draft) return count
+      if (String(draft.article_group_id || '') !== String(item.article_group_id || '')) return count + 1
+      return count
+    }, 0)
+  }, [articles, articleDrafts])
+
+  const hasPendingChanges = groupDirtyCount > 0 || articleDirtyCount > 0
+
+  useEffect(() => {
+    const handleBeforeUnload = (event) => {
+      if (!hasPendingChanges) return undefined
+      event.preventDefault()
+      event.returnValue = ''
+      return ''
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [hasPendingChanges])
+
+  useEffect(() => {
+    const handleDocumentClick = (event) => {
+      if (!hasPendingChanges) return
+      const anchor = event.target instanceof Element ? event.target.closest('a[href]') : null
+      if (!anchor) return
+      const href = anchor.getAttribute('href')
+      if (!href || href.startsWith('#') || href.startsWith('javascript:')) return
+      if (anchor.target === '_blank' || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
+      const next = new URL(anchor.href, window.location.origin)
+      const current = new URL(window.location.href)
+      if (next.pathname === current.pathname && next.search === current.search && next.hash === current.hash) return
+      event.preventDefault()
+      pendingNavigationRef.current = () => { window.location.href = next.href }
+      setShowPendingModal(true)
+    }
+    document.addEventListener('click', handleDocumentClick, true)
+    return () => document.removeEventListener('click', handleDocumentClick, true)
+  }, [hasPendingChanges])
+
+  const filteredGroups = useMemo(() => {
+    return sortedGroups.filter((item) => {
+      const draft = groupDrafts[String(item.id)] || { name: item.name, active: String(item.status || 'active') !== 'inactive' }
+      const nameOk = !groupFilters.name || String(draft?.name || '').toLowerCase().includes(groupFilters.name.toLowerCase())
+      const activeOk = !groupFilters.actiefJa || Boolean(draft?.active)
+      const countOk = !groupFilters.articles || String(Number(groupArticleCounts[String(item.id)] || 0)).includes(groupFilters.articles)
+      return nameOk && activeOk && countOk
+    })
+  }, [sortedGroups, groupFilters, groupDrafts, groupArticleCounts])
+
+  const visibleArticles = useMemo(() => {
+    if (!selectedGroupId) return articles
+    return articles.filter((item) => String(item.article_group_id || '') === String(selectedGroupId || ''))
+  }, [articles, selectedGroupId])
+
+  const filteredArticles = useMemo(() => {
+    return [...visibleArticles]
+      .sort((a, b) => String(a?.article_name || '').localeCompare(String(b?.article_name || ''), 'nl'))
+      .filter((item) => {
+        const draft = articleDrafts[String(item.id)] || { article_group_id: item.article_group_id || '' }
+        const groupName = draft.article_group_id ? (groups.find((group) => String(group.id) === String(draft.article_group_id))?.name || '') : UNASSIGNED_LABEL
+        const articleOk = !articleFilters.article || String(item?.article_name || '').toLowerCase().includes(articleFilters.article.toLowerCase())
+        const groupOk = !articleFilters.group || String(groupName || '').toLowerCase().includes(articleFilters.group.toLowerCase())
+        return articleOk && groupOk
+      })
+  }, [visibleArticles, articleFilters, articleDrafts, groups])
+
+  const allFilteredGroupsSelected = filteredGroups.length > 0 && filteredGroups.every((item) => selectedGroupIds.includes(String(item.id)))
+  const allFilteredArticlesSelected = filteredArticles.length > 0 && filteredArticles.every((item) => selectedArticleIds.includes(String(item.id)))
+
+  function toggleSelectedGroup(id) {
+    const key = String(id)
+    setSelectedGroupIds((current) => current.includes(key) ? current.filter((value) => value !== key) : [...current, key])
+  }
+
+  function toggleSelectedArticle(id) {
+    const key = String(id)
+    setSelectedArticleIds((current) => current.includes(key) ? current.filter((value) => value !== key) : [...current, key])
+  }
+
+  function toggleAllFilteredGroups() {
+    if (allFilteredGroupsSelected) {
+      const filteredSet = new Set(filteredGroups.map((item) => String(item.id)))
+      setSelectedGroupIds((current) => current.filter((id) => !filteredSet.has(id)))
+      return
+    }
+    const merged = new Set(selectedGroupIds)
+    filteredGroups.forEach((item) => merged.add(String(item.id)))
+    setSelectedGroupIds(Array.from(merged))
+  }
+
+  function toggleAllFilteredArticles() {
+    if (allFilteredArticlesSelected) {
+      const filteredSet = new Set(filteredArticles.map((item) => String(item.id)))
+      setSelectedArticleIds((current) => current.filter((id) => !filteredSet.has(id)))
+      return
+    }
+    const merged = new Set(selectedArticleIds)
+    filteredArticles.forEach((item) => merged.add(String(item.id)))
+    setSelectedArticleIds(Array.from(merged))
+  }
+
+  function openCreateGroup() {
+    setMessage('')
+    setError('')
+    setGroupForm(initialGroupForm)
+    setGroupModalOpen(true)
+  }
+
+  function updateGroupDraft(id, patch) {
+    const key = String(id)
+    setGroupDrafts((current) => ({ ...current, [key]: { ...(current[key] || {}), ...patch } }))
+  }
+
+  function updateArticleDraft(id, patch) {
+    const key = String(id)
+    setArticleDrafts((current) => ({ ...current, [key]: { ...(current[key] || {}), ...patch } }))
+  }
+
+  function discardPendingChanges() {
+    setGroupDrafts(groupDraftMapFromItems(groups))
+    setArticleDrafts(articleDraftMapFromItems(articles))
+    setMessage('Wijzigingen geannuleerd.')
+    setError('')
+  }
+
+  async function savePendingChanges() {
+    const changedGroups = groups.filter((item) => {
+      const draft = groupDrafts[String(item.id)]
+      return draft && (String(draft.name || '').trim() !== String(item.name || '').trim() || Boolean(draft.active) !== (String(item.status || 'active') !== 'inactive'))
+    })
+    const changedArticles = articles.filter((item) => {
+      const draft = articleDrafts[String(item.id)]
+      return draft && String(draft.article_group_id || '') !== String(item.article_group_id || '')
+    })
+
+    for (const item of changedGroups) {
+      const draft = groupDrafts[String(item.id)]
+      if (!String(draft?.name || '').trim()) {
+        setError('Elke Artikelgroep moet een naam hebben voordat je opslaat.')
+        return false
+      }
+    }
+
+    if (!changedGroups.length && !changedArticles.length) {
+      setShowPendingModal(false)
+      return true
+    }
+
+    setIsSaving(true)
+    setError('')
+    setMessage('')
+    try {
+      for (const item of changedGroups) {
+        const draft = groupDrafts[String(item.id)]
+        await requestJson(`/api/article-groups/${encodeURIComponent(item.id)}`, {
+          method: 'PUT',
+          body: JSON.stringify({ household_id: householdId, name: String(draft.name || '').trim(), status: draft.active ? 'active' : 'inactive' }),
+        })
+      }
+      for (const item of changedArticles) {
+        const draft = articleDrafts[String(item.id)]
+        await requestJson(`/api/household-articles/${encodeURIComponent(item.id)}/article-group`, {
+          method: 'PUT',
+          body: JSON.stringify({ household_id: householdId, article_group_id: draft.article_group_id || null }),
+        })
+      }
+      await loadData()
+      setSelectedArticleIds([])
+      setMessage(`${changedGroups.length + changedArticles.length} wijziging${changedGroups.length + changedArticles.length === 1 ? '' : 'en'} opgeslagen.`)
+      setShowPendingModal(false)
+      return true
+    } catch (saveError) {
+      setError(saveError?.message || 'Wijzigingen opslaan mislukt.')
+      return false
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function handleSaveGroup() {
+    const name = String(groupForm.name || '').trim()
     if (!name) {
-      setError('Artikelgroepnaam is verplicht')
+      setError('Artikelgroepnaam is verplicht.')
       return
     }
     setIsSaving(true)
     setError('')
     setMessage('')
     try {
-      await requestJson('/api/article-groups', {
-        method: 'POST',
-        body: JSON.stringify({ household_id: householdId, name }),
-      })
-      setNewName('')
-      setMessage('Artikelgroep toegevoegd')
+      await requestJson('/api/article-groups', { method: 'POST', body: JSON.stringify({ household_id: householdId, name }) })
+      setMessage('Artikelgroep opgeslagen.')
+      setGroupModalOpen(false)
       await loadData()
-    } catch (createError) {
-      setError(createError.message || 'Artikelgroep toevoegen mislukt')
+    } catch (saveError) {
+      setError(saveError?.message || 'Artikelgroep opslaan mislukt.')
     } finally {
       setIsSaving(false)
     }
   }
 
-  async function handleRenameGroup(group) {
-    const name = String(editing[group.id] ?? group.name ?? '').trim()
-    if (!name) {
-      setError('Artikelgroepnaam is verplicht')
-      return
-    }
+  async function deleteSelectedGroups() {
+    const selectedItems = groups.filter((item) => selectedGroupIds.includes(String(item.id)))
+    if (!selectedItems.length) return
     setIsSaving(true)
     setError('')
     setMessage('')
+    let deletedCount = 0
+    let deactivatedCount = 0
+    const blocked = []
     try {
-      await requestJson(`/api/article-groups/${encodeURIComponent(group.id)}`, {
-        method: 'PUT',
-        body: JSON.stringify({ household_id: householdId, name }),
-      })
-      setMessage('Artikelgroep bijgewerkt')
+      for (const item of selectedItems) {
+        try {
+          const result = await requestJson(`/api/article-groups/${encodeURIComponent(item.id)}?household_id=${encodeURIComponent(householdId)}`, { method: 'DELETE' })
+          if (result?.deactivated) deactivatedCount += 1
+          else if (result?.deleted) deletedCount += 1
+          else blocked.push(item.name)
+        } catch {
+          blocked.push(item.name)
+        }
+      }
       await loadData()
-    } catch (renameError) {
-      setError(renameError.message || 'Artikelgroep bijwerken mislukt')
+      setSelectedGroupIds([])
+      const parts = []
+      if (deletedCount) parts.push(`${deletedCount} Artikelgroep${deletedCount === 1 ? '' : 'en'} verwijderd`)
+      if (deactivatedCount) parts.push(`${deactivatedCount} Artikelgroep${deactivatedCount === 1 ? '' : 'en'} gearchiveerd omdat deze in gebruik was`)
+      if (blocked.length) parts.push(`${blocked.length} Artikelgroep${blocked.length === 1 ? '' : 'en'} niet verwerkt`)
+      if (parts.length) setMessage(`${parts.join('. ')}.`)
+      else setError('Geen Artikelgroepen verwijderd.')
     } finally {
       setIsSaving(false)
+      setShowGroupActionModal(false)
     }
   }
 
-  async function handleDeleteGroup(group) {
+  async function archiveSelectedGroups() {
+    const selectedItems = groups.filter((item) => selectedGroupIds.includes(String(item.id)))
+    if (!selectedItems.length) return
     setIsSaving(true)
     setError('')
     setMessage('')
+    let archivedCount = 0
     try {
-      const result = await requestJson(`/api/article-groups/${encodeURIComponent(group.id)}?household_id=${encodeURIComponent(householdId)}`, {
-        method: 'DELETE',
-      })
-      setMessage(result?.deactivated ? 'Artikelgroep was in gebruik en is gedeactiveerd' : 'Artikelgroep verwijderd')
+      for (const item of selectedItems) {
+        const draft = groupDrafts[String(item.id)] || item
+        await requestJson(`/api/article-groups/${encodeURIComponent(item.id)}`, {
+          method: 'PUT',
+          body: JSON.stringify({ household_id: householdId, name: String(draft.name || item.name || '').trim(), status: 'inactive' }),
+        })
+        archivedCount += 1
+      }
       await loadData()
-    } catch (deleteError) {
-      setError(deleteError.message || 'Artikelgroep verwijderen mislukt')
+      setSelectedGroupIds([])
+      setMessage(`${archivedCount} Artikelgroep${archivedCount === 1 ? '' : 'en'} gearchiveerd.`)
+    } catch (archiveError) {
+      setError(archiveError?.message || 'Artikelgroepen archiveren mislukt.')
     } finally {
       setIsSaving(false)
+      setShowGroupActionModal(false)
     }
   }
 
-  async function handleAssignArticle(article, groupId) {
-    setIsSaving(true)
-    setError('')
-    setMessage('')
-    try {
-      await requestJson(`/api/household-articles/${encodeURIComponent(article.id)}/article-group`, {
-        method: 'PUT',
-        body: JSON.stringify({ household_id: householdId, article_group_id: groupId || null }),
-      })
-      setMessage('Artikelgroepkoppeling bijgewerkt')
-      await loadData()
-    } catch (assignError) {
-      setError(assignError.message || 'Artikelgroep koppelen mislukt')
-    } finally {
-      setIsSaving(false)
+  function clearSelectedArticleGroups() {
+    if (!selectedArticleIds.length) return
+    selectedArticleIds.forEach((id) => updateArticleDraft(id, { article_group_id: '' }))
+    setShowArticleActionModal(false)
+    setMessage(`${selectedArticleIds.length} artikel${selectedArticleIds.length === 1 ? '' : 'en'} klaargezet als ${UNASSIGNED_LABEL}. Kies Wijzigingen opslaan om te bewaren.`)
+  }
+
+  function archiveSelectedArticlesNoop() {
+    setShowArticleActionModal(false)
+    clearSelectedArticleGroups()
+  }
+
+  function exportGroupsCsv() {
+    const rows = [['Artikelgroep', 'Actief', 'Aantal artikelen'], ...filteredGroups.map((item) => {
+      const draft = groupDrafts[String(item.id)] || { name: item.name, active: String(item.status || 'active') !== 'inactive' }
+      return [draft.name, draft.active ? 'Ja' : 'Nee', Number(groupArticleCounts[String(item.id)] || 0)]
+    })]
+    const csv = rows.map((row) => row.map(csvEscape).join(',')).join('\n')
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = 'rezzerv-artikelgroepen.csv'
+    document.body.appendChild(anchor)
+    anchor.click()
+    anchor.remove()
+    URL.revokeObjectURL(url)
+  }
+
+  function exportArticleLinksCsv() {
+    const rows = [['Artikel', 'Artikelgroep'], ...filteredArticles.map((item) => {
+      const draft = articleDrafts[String(item.id)] || { article_group_id: item.article_group_id || '' }
+      const groupName = draft.article_group_id ? (groups.find((group) => String(group.id) === String(draft.article_group_id))?.name || '') : UNASSIGNED_LABEL
+      return [item.article_name || 'Onbekend artikel', groupName]
+    })]
+    const csv = rows.map((row) => row.map(csvEscape).join(',')).join('\n')
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = 'rezzerv-artikelgroep-koppelingen.csv'
+    document.body.appendChild(anchor)
+    anchor.click()
+    anchor.remove()
+    URL.revokeObjectURL(url)
+  }
+
+  async function confirmSaveAndContinue() {
+    const ok = await savePendingChanges()
+    if (!ok) return
+    if (pendingNavigationRef.current) {
+      const navigate = pendingNavigationRef.current
+      pendingNavigationRef.current = null
+      navigate()
     }
+  }
+
+  function confirmDiscardAndContinue() {
+    discardPendingChanges()
+    setShowPendingModal(false)
+    if (pendingNavigationRef.current) {
+      const navigate = pendingNavigationRef.current
+      pendingNavigationRef.current = null
+      navigate()
+    }
+  }
+
+  function cancelPendingDialog() {
+    pendingNavigationRef.current = null
+    setShowPendingModal(false)
   }
 
   return (
-    <AppShell title="Instellingen" showExit={false}>
-      <Card>
-        <div style={{ display: 'grid', gap: '22px' }} data-testid="settings-article-groups-page">
+    <AppShell title="Artikelgroepen" showExit={false}>
+      <Card className="rz-settings-spaces-card">
+        <div style={{ display: 'grid', gap: 24, width: '100%' }} data-testid="settings-article-groups-page">
           <div>
-            <h2 style={{ margin: '0 0 8px 0', fontSize: '20px' }}>Artikelgroepen</h2>
-            <p style={{ margin: 0, color: '#667085' }}>Beheer je eigen indeling van voorraadartikelen. Rezzerv maakt geen groepen automatisch aan.</p>
+            <h2 style={{ margin: 0, fontSize: 20 }}>Beheer Artikelgroepen</h2>
+            <p style={{ margin: '8px 0 0 0', color: '#667085' }}>Beheer je eigen indeling van voorraadartikelen. Rezzerv maakt geen groepen automatisch aan.</p>
           </div>
 
-          {error ? <div className="rz-inline-feedback rz-inline-feedback--error">{error}</div> : null}
-          {message ? <div className="rz-inline-feedback rz-inline-feedback--success">{message}</div> : null}
-
-          <form onSubmit={handleCreateGroup} style={{ display: 'flex', gap: '12px', flexWrap: 'wrap', alignItems: 'center' }}>
-            <input
-              className="rz-input"
-              value={newName}
-              placeholder="Nieuwe artikelgroep"
-              onChange={(event) => setNewName(event.target.value)}
-              disabled={isSaving}
-              style={{ minWidth: '260px' }}
-            />
-            <Button type="submit" disabled={isSaving}>Toevoegen</Button>
-          </form>
-
-          <section style={{ display: 'grid', gap: '12px' }}>
-            <h3 style={{ margin: 0, fontSize: '16px' }}>Groepen</h3>
-            {isLoading ? <div>Artikelgroepen laden…</div> : null}
-            {!isLoading && !groups.length ? <div className="rz-empty-state">Nog geen Artikelgroepen. Artikelen zonder groep worden getoond als “{UNASSIGNED_LABEL}”.</div> : null}
-            {groups.map((group) => (
-              <div key={group.id} style={{ display: 'flex', gap: '12px', alignItems: 'center', flexWrap: 'wrap' }}>
-                <input
-                  className="rz-input"
-                  value={editing[group.id] ?? group.name ?? ''}
-                  onChange={(event) => setEditing((current) => ({ ...current, [group.id]: event.target.value }))}
-                  disabled={isSaving}
-                  style={{ minWidth: '260px' }}
-                />
-                <Button variant="secondary" onClick={() => handleRenameGroup(group)} disabled={isSaving}>Opslaan</Button>
-                <Button variant="secondary" onClick={() => handleDeleteGroup(group)} disabled={isSaving}>Verwijderen</Button>
-              </div>
-            ))}
+          <section style={{ display: 'grid', gap: 18 }}>
+            <div style={{ fontWeight: 700, color: '#0f172a' }}>Artikelgroepen</div>
+            <Table wrapperClassName="rz-stock-table-wrapper" tableClassName="rz-stock-table" tableStyle={{ tableLayout: 'fixed', width: buildTableWidth(groupColumnWidths), minWidth: buildTableWidth(groupColumnWidths) }}>
+              <colgroup>
+                <col style={{ width: '48px' }} />
+                <col style={{ width: 'auto' }} />
+                <col style={{ width: '140px' }} />
+                <col style={{ width: '180px' }} />
+              </colgroup>
+              <thead>
+                <tr className="rz-table-header">
+                  <th><input type="checkbox" style={greenCheckboxStyle} checked={allFilteredGroupsSelected} onChange={toggleAllFilteredGroups} aria-label="Selecteer alle zichtbare Artikelgroepen" /></th>
+                  <th>Artikelgroep</th>
+                  <th className="rz-num">Actief</th>
+                  <th className="rz-num">Aantal artikelen</th>
+                </tr>
+                <tr className="rz-table-filters">
+                  <th />
+                  <th><input className="rz-input rz-inline-input" value={groupFilters.name} onChange={(event) => setGroupFilters((current) => ({ ...current, name: event.target.value }))} placeholder="Filter" aria-label="Filter op Artikelgroep" /></th>
+                  <th className="rz-num">
+                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', minHeight: 20, width: '100%' }}>
+                      <input type="checkbox" className="rz-filter-checkbox" style={greenCheckboxStyle} checked={groupFilters.actiefJa} onChange={(event) => setGroupFilters((current) => ({ ...current, actiefJa: event.target.checked }))} aria-label="Filter actieve Artikelgroepen" title="Alleen actieve Artikelgroepen tonen" />
+                    </div>
+                  </th>
+                  <th><input className="rz-input rz-inline-input" value={groupFilters.articles} onChange={(event) => setGroupFilters((current) => ({ ...current, articles: event.target.value }))} placeholder="Filter" aria-label="Filter op aantal artikelen" /></th>
+                </tr>
+              </thead>
+              <tbody>
+                {isLoading ? (
+                  <tr><td colSpan={4}>Artikelgroepen laden…</td></tr>
+                ) : filteredGroups.length === 0 ? (
+                  <tr><td colSpan={4}>Nog geen Artikelgroepen. Artikelen zonder groep worden getoond als “{UNASSIGNED_LABEL}”.</td></tr>
+                ) : filteredGroups.map((item) => {
+                  const selected = selectedGroupIds.includes(String(item.id))
+                  const detailSelected = String(selectedGroupId) === String(item.id)
+                  const draft = groupDrafts[String(item.id)] || { name: item.name, active: String(item.status || 'active') !== 'inactive' }
+                  return (
+                    <tr key={item.id} className={selected || detailSelected ? 'rz-row-selected' : ''} onDoubleClick={() => setSelectedGroupId(String(item.id))} title="Dubbelklik om artikelen van deze Artikelgroep te tonen">
+                      <td><input type="checkbox" style={greenCheckboxStyle} checked={selected} onChange={() => toggleSelectedGroup(item.id)} aria-label={`Selecteer ${item.name}`} /></td>
+                      <td><input className="rz-input rz-inline-input" value={draft.name} onChange={(event) => updateGroupDraft(item.id, { name: event.target.value })} aria-label={`Artikelgroepnaam ${item.name}`} /></td>
+                      <td className="rz-num"><input type="checkbox" style={greenCheckboxStyle} checked={Boolean(draft.active)} onChange={(event) => updateGroupDraft(item.id, { active: event.target.checked })} aria-label={`Actief ${item.name}`} /></td>
+                      <td className="rz-num">{Number(groupArticleCounts[String(item.id)] || 0)}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </Table>
+            <div className="rz-stock-table-actions" style={{ justifyContent: 'flex-end', gap: 12, flexWrap: 'wrap' }}>
+              <Button type="button" variant="secondary" onClick={exportGroupsCsv} disabled={isLoading || selectedGroupIds.length === 0 || isSaving}>Exporteren</Button>
+              <Button type="button" variant="secondary" onClick={() => setShowGroupActionModal(true)} disabled={isSaving || selectedGroupIds.length === 0}>Verwijderen</Button>
+              <Button type="button" onClick={openCreateGroup} disabled={isSaving}>Toevoegen Artikelgroep</Button>
+            </div>
           </section>
 
-          <section style={{ display: 'grid', gap: '12px' }}>
-            <h3 style={{ margin: 0, fontSize: '16px' }}>Voorraadartikelen koppelen</h3>
+          <section style={{ display: 'grid', gap: 18 }}>
+            <div style={{ fontWeight: 700, color: '#0f172a' }}>Voorraadartikelen{selectedGroup ? ` in ${selectedGroup.name}` : ''}</div>
             <p style={{ margin: 0, color: '#667085' }}>Koppelen is handmatig. Barcodeherkenning, externe databases en Uitpakken wijzigen deze koppeling niet.</p>
-            {!isLoading && !articles.length ? <div className="rz-empty-state">Geen huishoudelijke voorraadartikelen gevonden.</div> : null}
-            {articles.length ? (
-              <table className="rz-table" style={{ width: '100%' }}>
-                <thead>
-                  <tr>
-                    <th>Artikel</th>
-                    <th>Artikelgroep</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {articles.map((article) => (
-                    <tr key={article.id}>
-                      <td>{article.article_name || 'Onbekend artikel'}</td>
+            <Table wrapperClassName="rz-stock-table-wrapper" tableClassName="rz-stock-table" tableStyle={{ tableLayout: 'fixed', width: buildTableWidth(articleColumnWidths), minWidth: buildTableWidth(articleColumnWidths) }}>
+              <colgroup>
+                <col style={{ width: '48px' }} />
+                <col style={{ width: 'auto' }} />
+                <col style={{ width: '320px' }} />
+              </colgroup>
+              <thead>
+                <tr className="rz-table-header">
+                  <th><input type="checkbox" style={greenCheckboxStyle} checked={allFilteredArticlesSelected} onChange={toggleAllFilteredArticles} aria-label="Selecteer alle zichtbare artikelen" /></th>
+                  <th>Artikel</th>
+                  <th>Artikelgroep</th>
+                </tr>
+                <tr className="rz-table-filters">
+                  <th />
+                  <th><input className="rz-input rz-inline-input" value={articleFilters.article} onChange={(event) => setArticleFilters((current) => ({ ...current, article: event.target.value }))} placeholder="Filter" aria-label="Filter op artikel" /></th>
+                  <th><input className="rz-input rz-inline-input" value={articleFilters.group} onChange={(event) => setArticleFilters((current) => ({ ...current, group: event.target.value }))} placeholder="Filter" aria-label="Filter op Artikelgroep" /></th>
+                </tr>
+              </thead>
+              <tbody>
+                {isLoading ? (
+                  <tr><td colSpan={3}>Voorraadartikelen laden…</td></tr>
+                ) : !articles.length ? (
+                  <tr><td colSpan={3}>Geen huishoudelijke voorraadartikelen gevonden.</td></tr>
+                ) : filteredArticles.length === 0 ? (
+                  <tr><td colSpan={3}>Geen voorraadartikelen voor deze selectie.</td></tr>
+                ) : filteredArticles.map((item) => {
+                  const selected = selectedArticleIds.includes(String(item.id))
+                  const draft = articleDrafts[String(item.id)] || { article_group_id: item.article_group_id || '' }
+                  return (
+                    <tr key={item.id} className={selected ? 'rz-row-selected' : ''}>
+                      <td><input type="checkbox" style={greenCheckboxStyle} checked={selected} onChange={() => toggleSelectedArticle(item.id)} aria-label={`Selecteer ${item.article_name || 'Onbekend artikel'}`} /></td>
+                      <td>{item.article_name || 'Onbekend artikel'}</td>
                       <td>
-                        <select
-                          className="rz-input"
-                          value={article.article_group_id || ''}
-                          disabled={isSaving}
-                          onChange={(event) => handleAssignArticle(article, event.target.value || null)}
-                        >
+                        <select className="rz-input rz-inline-input" value={draft.article_group_id || ''} onChange={(event) => updateArticleDraft(item.id, { article_group_id: event.target.value })} aria-label={`Artikelgroep ${item.article_name || 'Onbekend artikel'}`}>
                           <option value="">{UNASSIGNED_LABEL}</option>
-                          {groups.map((group) => <option key={group.id} value={group.id}>{group.name}</option>)}
+                          {sortedGroups.map((group) => <option key={group.id} value={group.id}>{group.name}</option>)}
                         </select>
                       </td>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            ) : null}
+                  )
+                })}
+              </tbody>
+            </Table>
+            <div className="rz-stock-table-actions" style={{ justifyContent: 'flex-end', gap: 12, flexWrap: 'wrap' }}>
+              <Button type="button" variant="secondary" onClick={exportArticleLinksCsv} disabled={isLoading || selectedArticleIds.length === 0 || isSaving}>Exporteren</Button>
+              <Button type="button" variant="secondary" onClick={() => setShowArticleActionModal(true)} disabled={isSaving || selectedArticleIds.length === 0}>Verwijderen</Button>
+            </div>
           </section>
+
+          <div className="rz-stock-table-actions" style={{ justifyContent: 'flex-end', gap: 12, flexWrap: 'wrap' }}>
+            <Button type="button" variant="secondary" onClick={() => { discardPendingChanges(); setShowPendingModal(false) }} disabled={isSaving || !hasPendingChanges}>Wijzigingen annuleren</Button>
+            <Button type="button" onClick={savePendingChanges} disabled={isSaving || !hasPendingChanges}>{isSaving ? 'Opslaan…' : 'Wijzigingen opslaan'}</Button>
+          </div>
         </div>
       </Card>
+
+      <FeedbackOverlay type="error" message={error} onClose={() => setError('')} />
+      <FeedbackOverlay type="success" message={message} onClose={() => setMessage('')} />
+      <ArticleGroupModal open={groupModalOpen} form={groupForm} onChange={setGroupForm} onClose={() => setGroupModalOpen(false)} onSubmit={handleSaveGroup} busy={isSaving} />
+      <ActionModal open={showGroupActionModal} title="Geselecteerde Artikelgroepen verwerken" noun="Artikelgroep" selectedCount={selectedGroupIds.length} onClose={() => setShowGroupActionModal(false)} onDelete={deleteSelectedGroups} onArchive={archiveSelectedGroups} busy={isSaving} />
+      <ActionModal open={showArticleActionModal} title="Geselecteerde artikelkoppelingen verwerken" noun="artikel" selectedCount={selectedArticleIds.length} onClose={() => setShowArticleActionModal(false)} onDelete={clearSelectedArticleGroups} onArchive={archiveSelectedArticlesNoop} busy={isSaving} />
+      <PendingChangesModal open={showPendingModal} onSave={confirmSaveAndContinue} onDiscard={confirmDiscardAndContinue} onCancel={cancelPendingDialog} busy={isSaving} />
     </AppShell>
   )
 }

--- a/frontend/src/features/settings/SettingsPage.jsx
+++ b/frontend/src/features/settings/SettingsPage.jsx
@@ -44,6 +44,13 @@ export default function SettingsPage() {
             </div>
             <div aria-hidden="true">→</div>
           </Link>
+          <Link to="/instellingen/artikelgroepen" style={getTileStyle(isViewer)} aria-disabled={isViewer ? 'true' : 'false'} onClick={isViewer ? handleDisabledClick : undefined}>
+            <div>
+              <div style={{ fontWeight: 600 }}>Artikelgroepen</div>
+              <div style={{ color: isViewer ? '#0f5b32' : '#667085', fontSize: '14px' }}>{isViewer ? 'Alleen Admin kan Artikelgroepen beheren.' : 'Beheer je eigen indeling van voorraadartikelen'}</div>
+            </div>
+            <div aria-hidden="true">→</div>
+          </Link>
           <Link to="/instellingen/privacy-datadeling" style={getTileStyle(false)}>
             <div>
               <div style={{ fontWeight: 600 }}>Privacy &amp; Datadeling</div>

--- a/frontend/src/features/stores/StoreBatchDetailPage.jsx
+++ b/frontend/src/features/stores/StoreBatchDetailPage.jsx
@@ -132,33 +132,6 @@ function firstTextValue(...values) {
   return ''
 }
 
-function selectedHouseholdArticle(draft, articleOptions) {
-  return (articleOptions || []).find((option) => String(option.id) === String(draft?.articleId || ''))
-}
-
-function householdArticleHierarchyTitle(line, draft, articleOptions) {
-  const article = selectedHouseholdArticle(draft, articleOptions)
-  const category = firstTextValue(
-    article?.category_name,
-    article?.category?.name,
-    article?.category,
-    article?.article_group,
-    article?.group_name,
-    article?.type
-  ) || 'Nog niet ingedeeld'
-  const name = firstTextValue(
-    line?.resolved_household_article_name,
-    article?.custom_name,
-    article?.name,
-    articleLabel(article)
-  ) || 'Nog niet gekoppeld'
-
-  return [
-    'Niveau 1: Huishouden',
-    `Niveau 2: ${category}`,
-    `Niveau 3: ${name}`,
-  ].join('\n')
-}
 
 function buildActiveLocationOptions(spacesData, sublocationsData) {
   const activeSpaces = Array.isArray(spacesData?.items) ? spacesData.items.filter((item) => Boolean(item?.active)) : []
@@ -270,6 +243,7 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
   const [locationPickerSearch, setLocationPickerSearch] = useState('')
   const [locationPickerMode, setLocationPickerMode] = useState('single')
   const [activeLocationSpaceId, setActiveLocationSpaceId] = useState('')
+  const [pendingDefaultLocationChoice, setPendingDefaultLocationChoice] = useState(null)
   const locationHoverTimerRef = useRef(null)
 
   useDismissOnComponentClick([() => setStatus(''), () => setError(''), () => setProcessFeedback('')], Boolean(status || error || processFeedback))
@@ -503,14 +477,45 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
     }
 
     const hasArticle = Boolean(String(pickerEntry.draft?.articleId || pickerEntry.line?.matched_household_article_id || '').trim())
-    const defaultLocationPolicy = hasArticle && nextLocationId
-      ? (window.confirm('Deze locatie voortaan als standaardlocatie voor dit artikel gebruiken?\n\nOK = voortaan standaard\nAnnuleren = alleen deze bonregel')
-          ? 'article_default'
-          : 'line_only')
-      : 'line_only'
 
-    await persistLineDraft(pickerEntry.line, { locationId: nextLocationId }, { defaultLocationPolicy })
+    if (hasArticle && nextLocationId) {
+      setPendingDefaultLocationChoice({
+        lineId: pickerEntry.line.id,
+        locationId: nextLocationId,
+      })
+      closeLocationPicker()
+      return
+    }
+
+    await persistLineDraft(
+      pickerEntry.line,
+      { locationId: nextLocationId },
+      { defaultLocationPolicy: 'line_only' }
+    )
     closeLocationPicker()
+  }
+
+  async function confirmDefaultLocationChoice(defaultLocationPolicy) {
+    const pendingChoice = pendingDefaultLocationChoice
+    if (!pendingChoice) return
+
+    const pendingEntry = lineUiStates.find(
+      (entry) => String(entry.line.id) === String(pendingChoice.lineId)
+    )
+
+    setPendingDefaultLocationChoice(null)
+
+    if (!pendingEntry) return
+
+    await persistLineDraft(
+      pendingEntry.line,
+      { locationId: pendingChoice.locationId },
+      { defaultLocationPolicy }
+    )
+  }
+
+  function cancelDefaultLocationChoice() {
+    setPendingDefaultLocationChoice(null)
   }
 
   async function persistLineDraft(line, patch = {}, options = {}) {
@@ -1092,7 +1097,7 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
                         </button>
                       </td>
                       <td className="rz-num rz-store-batch-col-quantity"><div className="rz-store-amount">{formatQuantity(line.quantity_raw, line.unit_raw)}</div></td>
-                      <td className="rz-store-batch-col-linked" title={householdArticleHierarchyTitle(line, draft, articleOptions)}>
+                      <td className="rz-store-batch-col-linked">
                         <div data-testid={`receipt-line-article-select-${line.id}`}><StoreArticleSelector
                           lineId={line.id}
                           lineName={line.article_name_raw}
@@ -1114,6 +1119,51 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
               </tbody>
             </Table>
 
+          {pendingDefaultLocationChoice ? (
+            <div
+              className="rz-modal-backdrop"
+              role="presentation"
+              onClick={cancelDefaultLocationChoice}
+            >
+              <div
+                className="rz-modal-card"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="default-location-choice-title"
+                onClick={(event) => event.stopPropagation()}
+              >
+                <h3 id="default-location-choice-title" className="rz-modal-title">
+                  Standaardlocatie instellen
+                </h3>
+                <p className="rz-modal-text">
+                  Wil je deze locatie voortaan als standaardlocatie voor dit artikel gebruiken?
+                </p>
+                <div className="rz-modal-actions">
+                  <Button
+                    variant="secondary"
+                    type="button"
+                    onClick={cancelDefaultLocationChoice}
+                  >
+                    Annuleren
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    type="button"
+                    onClick={() => confirmDefaultLocationChoice('line_only')}
+                  >
+                    Alleen voor deze bonregel
+                  </Button>
+                  <Button
+                    variant="primary"
+                    type="button"
+                    onClick={() => confirmDefaultLocationChoice('article_default')}
+                  >
+                    Als standaardlocatie gebruiken
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ) : null}
           {processResultOverlay ? (
             <div className="rz-modal-backdrop" role="presentation" onClick={() => setProcessResultOverlay('')}>
               <div

--- a/frontend/src/pages/Voorraad.jsx
+++ b/frontend/src/pages/Voorraad.jsx
@@ -566,6 +566,51 @@ async function fetchInventoryRows() {
   return mergeInventoryRows(data.rows)
 }
 
+async function fetchArticleGroupAssignments() {
+  const response = await fetch(`/api/article-groups/household-articles?_ts=${Date.now()}`, {
+    cache: 'no-store',
+    headers: getAuthHeaders(),
+  })
+  if (!response.ok) return { byId: new Map(), byName: new Map() }
+
+  const data = await response.json().catch(() => ({}))
+  const items = Array.isArray(data?.items) ? data.items : []
+  const byId = new Map()
+  const byName = new Map()
+
+  items.forEach((item) => {
+    const assignment = {
+      articleGroupId: item?.article_group_id || null,
+      articleGroupName: item?.article_group_name || 'Niet ingedeeld',
+    }
+
+    const id = String(item?.id || item?.household_article_id || '').trim()
+    if (id) byId.set(id, assignment)
+
+    const name = normalizeName(item?.article_name || item?.name || '')
+    if (name) byName.set(name, assignment)
+  })
+
+  return { byId, byName }
+}
+
+function applyArticleGroupsToRows(rows = [], assignments = { byId: new Map(), byName: new Map() }) {
+  const byId = assignments?.byId instanceof Map ? assignments.byId : new Map()
+  const byName = assignments?.byName instanceof Map ? assignments.byName : new Map()
+
+  return rows.map((row) => {
+    const id = String(row?.householdArticleId || row?.detailId || '').trim()
+    const name = normalizeName(row?.huishoudnaam || row?.artikel || '')
+    const assignment = byId.get(id) || byName.get(name) || null
+    const articleGroupName = assignment?.articleGroupName || row?.articleGroupName || 'Niet ingedeeld'
+
+    return {
+      ...row,
+      artikelgroep: articleGroupName,
+      articleGroupName,
+    }
+  })
+}
 async function saveInventoryRow(row) {
   const inventoryId = String(row?.inventoryId || row?.detailId || '').trim()
   if (!inventoryId) throw new Error('Voorraadregel kan niet worden opgeslagen zonder inventory-id')
@@ -598,12 +643,11 @@ async function saveInventoryRow(row) {
 const initialData = [];
 
 const editableColumns = [
-  { key: "huishoudnaam", label: "Huishoudnaam", type: "text", width: "22%" },
-  { key: "productnaam", label: "Productnaam", type: "text", width: "22%" },
-  { key: "artikelgroep", label: "Artikelgroep", type: "text", width: "16%" },
-  { key: "aantal", label: "Aantal", type: "number", width: "10%" },
-  { key: "locatie", label: "Locatie", type: "text", width: "15%" },
-  { key: "sublocatie", label: "Sublocatie", type: "text", width: "15%" }
+  { key: "huishoudnaam", label: "Voorraadartikel", type: "text", width: "28%" },
+  { key: "artikelgroep", label: "Artikelgroep", type: "text", width: "20%" },
+  { key: "aantal", label: "Aantal", type: "number", width: "13%" },
+  { key: "locatie", label: "Locatie", type: "text", width: "19.5%" },
+  { key: "sublocatie", label: "Sublocatie", type: "text", width: "19.5%" }
 ];
 
 function isColumnEditable(row, key) {
@@ -650,7 +694,6 @@ export default function Voorraad() {
   }
   const [filters, setFilters] = useState({
     huishoudnaam: "",
-    productnaam: "",
     artikelgroep: "",
     aantal: "",
     locatie: "",
@@ -658,13 +701,12 @@ export default function Voorraad() {
   });
   const [tableSort, setTableSort] = useState({ key: "huishoudnaam", direction: "asc" });
   const inventoryTableColumns = useMemo(() => ([
-    { key: "select", width: 48 },
-    { key: "huishoudnaam", width: 250 },
-    { key: "productnaam", width: 250 },
-    { key: "artikelgroep", width: 190 },
+    { key: "select", width: 44 },
+    { key: "huishoudnaam", width: 260 },
+    { key: "artikelgroep", width: 180 },
     { key: "aantal", width: 120 },
-    { key: "locatie", width: 220 },
-    { key: "sublocatie", width: 220 },
+    { key: "locatie", width: 160 },
+    { key: "sublocatie", width: 160 },
   ]), []);
   const inventoryColumnDefaults = useMemo(() => Object.fromEntries(inventoryTableColumns.map(({ key, width }) => [key, width])), [inventoryTableColumns]);
   const { widths: inventoryColumnWidths, startResize: startInventoryResize } = useResizableColumnWidths(inventoryColumnDefaults);
@@ -1145,7 +1187,7 @@ export default function Voorraad() {
 
     if (column.key === "artikelgroep") {
       return (
-        <div className="rz-inline-cell rz-inline-label" title={row?.artikelgroep || 'Niet ingedeeld'}>
+        <div className="rz-inline-cell rz-inline-label" style={{ fontWeight: 400 }} title={row?.artikelgroep || 'Niet ingedeeld'}>
           {row?.artikelgroep || 'Niet ingedeeld'}
         </div>
       )
@@ -1180,7 +1222,7 @@ export default function Voorraad() {
                 <colgroup>
                   <col style={{ width: `${inventoryColumnWidths.select}px` }} />
                   <col style={{ width: `${inventoryColumnWidths.huishoudnaam}px` }} />
-                  <col style={{ width: `${inventoryColumnWidths.productnaam}px` }} />
+                  <col style={{ width: `${inventoryColumnWidths.artikelgroep}px` }} />
                   <col style={{ width: `${inventoryColumnWidths.aantal}px` }} />
                   <col style={{ width: `${inventoryColumnWidths.locatie}px` }} />
                   <col style={{ width: `${inventoryColumnWidths.sublocatie}px` }} />
@@ -1196,8 +1238,8 @@ export default function Voorraad() {
                         aria-label="Selecteer alle zichtbare artikelen"
                       />
                     </ResizableHeaderCell>
-                    <ResizableHeaderCell columnKey="huishoudnaam" widths={inventoryColumnWidths} onStartResize={startInventoryResize} sortable isSorted={tableSort.key === "huishoudnaam"} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { huishoudnaam: "asc", productnaam: "asc", artikelgroep: "asc", aantal: "desc", locatie: "asc", sublocatie: "asc" }))}>Huishoudnaam</ResizableHeaderCell>
-                    <ResizableHeaderCell columnKey="productnaam" widths={inventoryColumnWidths} onStartResize={startInventoryResize} sortable isSorted={tableSort.key === "productnaam"} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { huishoudnaam: "asc", productnaam: "asc", artikelgroep: "asc", aantal: "desc", locatie: "asc", sublocatie: "asc" }))}>Productnaam</ResizableHeaderCell>
+                    <ResizableHeaderCell columnKey="huishoudnaam" widths={inventoryColumnWidths} onStartResize={startInventoryResize} sortable isSorted={tableSort.key === "huishoudnaam"} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { huishoudnaam: "asc", productnaam: "asc", artikelgroep: "asc", aantal: "desc", locatie: "asc", sublocatie: "asc" }))}>Voorraadartikel</ResizableHeaderCell>
+                    <ResizableHeaderCell columnKey="artikelgroep" widths={inventoryColumnWidths} onStartResize={startInventoryResize} sortable isSorted={tableSort.key === "artikelgroep"} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { huishoudnaam: "asc", productnaam: "asc", artikelgroep: "asc", aantal: "desc", locatie: "asc", sublocatie: "asc" }))}><span style={{ fontWeight: 400 }}>Artikelgroep</span></ResizableHeaderCell>
                     <ResizableHeaderCell columnKey="aantal" widths={inventoryColumnWidths} onStartResize={startInventoryResize} className="rz-num" sortable isSorted={tableSort.key === "aantal"} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { huishoudnaam: "asc", productnaam: "asc", artikelgroep: "asc", aantal: "desc", locatie: "asc", sublocatie: "asc" }))}>Aantal</ResizableHeaderCell>
                     <ResizableHeaderCell columnKey="locatie" widths={inventoryColumnWidths} onStartResize={startInventoryResize} sortable isSorted={tableSort.key === "locatie"} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { huishoudnaam: "asc", productnaam: "asc", artikelgroep: "asc", aantal: "desc", locatie: "asc", sublocatie: "asc" }))}>Locatie</ResizableHeaderCell>
                     <ResizableHeaderCell columnKey="sublocatie" widths={inventoryColumnWidths} onStartResize={startInventoryResize} sortable isSorted={tableSort.key === "sublocatie"} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { huishoudnaam: "asc", productnaam: "asc", artikelgroep: "asc", aantal: "desc", locatie: "asc", sublocatie: "asc" }))}>Sublocatie</ResizableHeaderCell>
@@ -1211,16 +1253,7 @@ export default function Voorraad() {
                         value={filters.huishoudnaam}
                         onChange={(e) => handleFilterChange("huishoudnaam", e.target.value)}
                         placeholder="Filter"
-                        aria-label="Filter op huishoudnaam"
-                      />
-                    </th>
-                    <th>
-                      <input
-                        className="rz-input rz-inline-input"
-                        value={filters.productnaam}
-                        onChange={(e) => handleFilterChange("productnaam", e.target.value)}
-                        placeholder="Filter"
-                        aria-label="Filter op productnaam"
+                        aria-label="Filter op voorraadartikel"
                       />
                     </th>
                     <th>

--- a/frontend/src/pages/Voorraad.jsx
+++ b/frontend/src/pages/Voorraad.jsx
@@ -502,6 +502,8 @@ function mergeInventoryRows(liveRows = []) {
         productnaam: row?.product_name || artikel,
         householdArticleName: row?.household_article_name || '',
         productName: row?.product_name || artikel,
+        householdArticleId: row?.household_article_id || '',
+        articleGroupName: row?.article_group_name || '',
         aantal,
         locatie,
         sublocatie,
@@ -537,6 +539,9 @@ function mergeInventoryRows(liveRows = []) {
       productnaam: row.productnaam || row.artikel,
       householdArticleName: row.householdArticleName || '',
       productName: row.productName || row.artikel,
+      householdArticleId: row.householdArticleId || '',
+      artikelgroep: row.articleGroupName || 'Niet ingedeeld',
+      articleGroupName: row.articleGroupName || 'Niet ingedeeld',
       aantal: row.aantal,
       locatie: hasMultipleLocations ? 'Meerdere locaties' : (locations[0] || ''),
       sublocatie: hasMultipleSublocations ? 'Meerdere sublocaties' : ((sublocations[0] || '').split('__')[1] || ''),
@@ -593,11 +598,12 @@ async function saveInventoryRow(row) {
 const initialData = [];
 
 const editableColumns = [
-  { key: "huishoudnaam", label: "Huishoudnaam", type: "text", width: "24%" },
-  { key: "productnaam", label: "Productnaam", type: "text", width: "24%" },
-  { key: "aantal", label: "Aantal", type: "number", width: "12%" },
-  { key: "locatie", label: "Locatie", type: "text", width: "20%" },
-  { key: "sublocatie", label: "Sublocatie", type: "text", width: "20%" }
+  { key: "huishoudnaam", label: "Huishoudnaam", type: "text", width: "22%" },
+  { key: "productnaam", label: "Productnaam", type: "text", width: "22%" },
+  { key: "artikelgroep", label: "Artikelgroep", type: "text", width: "16%" },
+  { key: "aantal", label: "Aantal", type: "number", width: "10%" },
+  { key: "locatie", label: "Locatie", type: "text", width: "15%" },
+  { key: "sublocatie", label: "Sublocatie", type: "text", width: "15%" }
 ];
 
 function isColumnEditable(row, key) {
@@ -629,18 +635,23 @@ export default function Voorraad() {
   }, [rows])
 
   const reloadInventoryRows = async () => {
-    const loadedRows = await fetchInventoryRows()
-    const loadedOptions = await fetchLocationOptions().catch(() => buildLocationOptionState([]))
-    const mergedLocationOptions = mergeLocationOptionStates(loadedOptions, buildLocationOptionStateFromRows(loadedRows))
+    const [loadedRows, articleGroupAssignments, loadedOptions] = await Promise.all([
+      fetchInventoryRows(),
+      fetchArticleGroupAssignments(),
+      fetchLocationOptions().catch(() => buildLocationOptionState([])),
+    ])
+    const rowsWithArticleGroups = applyArticleGroupsToRows(loadedRows, articleGroupAssignments)
+    const mergedLocationOptions = mergeLocationOptionStates(loadedOptions, buildLocationOptionStateFromRows(rowsWithArticleGroups))
     setLocalZeroRows([])
-    setRows(loadedRows)
+    setRows(rowsWithArticleGroups)
     setLocationOptions(mergedLocationOptions)
-    setLoadError(loadedRows.length ? '' : 'Nog geen live voorraad beschikbaar.')
-    return loadedRows
+    setLoadError(rowsWithArticleGroups.length ? '' : 'Nog geen live voorraad beschikbaar.')
+    return rowsWithArticleGroups
   }
   const [filters, setFilters] = useState({
     huishoudnaam: "",
     productnaam: "",
+    artikelgroep: "",
     aantal: "",
     locatie: "",
     sublocatie: ""
@@ -650,6 +661,7 @@ export default function Voorraad() {
     { key: "select", width: 48 },
     { key: "huishoudnaam", width: 250 },
     { key: "productnaam", width: 250 },
+    { key: "artikelgroep", width: 190 },
     { key: "aantal", width: 120 },
     { key: "locatie", width: 220 },
     { key: "sublocatie", width: 220 },
@@ -710,14 +722,15 @@ export default function Voorraad() {
 
   useEffect(() => {
     let cancelled = false;
-    Promise.all([fetchInventoryRows(), fetchLocationOptions().catch(() => buildLocationOptionState([]))])
-      .then(([loadedRows, loadedOptions]) => {
+    Promise.all([fetchInventoryRows(), fetchArticleGroupAssignments(), fetchLocationOptions().catch(() => buildLocationOptionState([]))])
+      .then(([loadedRows, articleGroupAssignments, loadedOptions]) => {
         if (!cancelled) {
-          const mergedLocationOptions = mergeLocationOptionStates(loadedOptions, buildLocationOptionStateFromRows(loadedRows))
+          const rowsWithArticleGroups = applyArticleGroupsToRows(loadedRows, articleGroupAssignments)
+          const mergedLocationOptions = mergeLocationOptionStates(loadedOptions, buildLocationOptionStateFromRows(rowsWithArticleGroups))
           setLocalZeroRows([]);
-          setRows(loadedRows);
+          setRows(rowsWithArticleGroups);
           setLocationOptions(mergedLocationOptions);
-          setLoadError(loadedRows.length ? "" : "Nog geen live voorraad beschikbaar.");
+          setLoadError(rowsWithArticleGroups.length ? "" : "Nog geen live voorraad beschikbaar.");
         }
       })
       .catch(() => {
@@ -776,6 +789,7 @@ export default function Voorraad() {
     return sortItems(filtered, tableSort, {
       huishoudnaam: (row) => row.huishoudnaam || row.artikel || '',
       productnaam: (row) => row.productnaam || '',
+      artikelgroep: (row) => row.artikelgroep || 'Niet ingedeeld',
       aantal: (row) => Number(row.aantal ?? 0),
       locatie: (row) => row.locatie || '',
       sublocatie: (row) => row.sublocatie || '',
@@ -1129,6 +1143,14 @@ export default function Voorraad() {
       )
     }
 
+    if (column.key === "artikelgroep") {
+      return (
+        <div className="rz-inline-cell rz-inline-label" title={row?.artikelgroep || 'Niet ingedeeld'}>
+          {row?.artikelgroep || 'Niet ingedeeld'}
+        </div>
+      )
+    }
+
     return (
       <button
         type="button"
@@ -1174,11 +1196,11 @@ export default function Voorraad() {
                         aria-label="Selecteer alle zichtbare artikelen"
                       />
                     </ResizableHeaderCell>
-                    <ResizableHeaderCell columnKey="huishoudnaam" widths={inventoryColumnWidths} onStartResize={startInventoryResize} sortable isSorted={tableSort.key === "huishoudnaam"} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { huishoudnaam: "asc", productnaam: "asc", aantal: "desc", locatie: "asc", sublocatie: "asc" }))}>Huishoudnaam</ResizableHeaderCell>
-                    <ResizableHeaderCell columnKey="productnaam" widths={inventoryColumnWidths} onStartResize={startInventoryResize} sortable isSorted={tableSort.key === "productnaam"} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { huishoudnaam: "asc", productnaam: "asc", aantal: "desc", locatie: "asc", sublocatie: "asc" }))}>Productnaam</ResizableHeaderCell>
-                    <ResizableHeaderCell columnKey="aantal" widths={inventoryColumnWidths} onStartResize={startInventoryResize} className="rz-num" sortable isSorted={tableSort.key === "aantal"} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { huishoudnaam: "asc", productnaam: "asc", aantal: "desc", locatie: "asc", sublocatie: "asc" }))}>Aantal</ResizableHeaderCell>
-                    <ResizableHeaderCell columnKey="locatie" widths={inventoryColumnWidths} onStartResize={startInventoryResize} sortable isSorted={tableSort.key === "locatie"} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { huishoudnaam: "asc", productnaam: "asc", aantal: "desc", locatie: "asc", sublocatie: "asc" }))}>Locatie</ResizableHeaderCell>
-                    <ResizableHeaderCell columnKey="sublocatie" widths={inventoryColumnWidths} onStartResize={startInventoryResize} sortable isSorted={tableSort.key === "sublocatie"} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { huishoudnaam: "asc", productnaam: "asc", aantal: "desc", locatie: "asc", sublocatie: "asc" }))}>Sublocatie</ResizableHeaderCell>
+                    <ResizableHeaderCell columnKey="huishoudnaam" widths={inventoryColumnWidths} onStartResize={startInventoryResize} sortable isSorted={tableSort.key === "huishoudnaam"} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { huishoudnaam: "asc", productnaam: "asc", artikelgroep: "asc", aantal: "desc", locatie: "asc", sublocatie: "asc" }))}>Huishoudnaam</ResizableHeaderCell>
+                    <ResizableHeaderCell columnKey="productnaam" widths={inventoryColumnWidths} onStartResize={startInventoryResize} sortable isSorted={tableSort.key === "productnaam"} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { huishoudnaam: "asc", productnaam: "asc", artikelgroep: "asc", aantal: "desc", locatie: "asc", sublocatie: "asc" }))}>Productnaam</ResizableHeaderCell>
+                    <ResizableHeaderCell columnKey="aantal" widths={inventoryColumnWidths} onStartResize={startInventoryResize} className="rz-num" sortable isSorted={tableSort.key === "aantal"} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { huishoudnaam: "asc", productnaam: "asc", artikelgroep: "asc", aantal: "desc", locatie: "asc", sublocatie: "asc" }))}>Aantal</ResizableHeaderCell>
+                    <ResizableHeaderCell columnKey="locatie" widths={inventoryColumnWidths} onStartResize={startInventoryResize} sortable isSorted={tableSort.key === "locatie"} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { huishoudnaam: "asc", productnaam: "asc", artikelgroep: "asc", aantal: "desc", locatie: "asc", sublocatie: "asc" }))}>Locatie</ResizableHeaderCell>
+                    <ResizableHeaderCell columnKey="sublocatie" widths={inventoryColumnWidths} onStartResize={startInventoryResize} sortable isSorted={tableSort.key === "sublocatie"} sortDirection={tableSort.direction} onSort={(key) => setTableSort((current) => nextSortState(current, key, { huishoudnaam: "asc", productnaam: "asc", artikelgroep: "asc", aantal: "desc", locatie: "asc", sublocatie: "asc" }))}>Sublocatie</ResizableHeaderCell>
                   </tr>
 
                   <tr className="rz-table-filters">
@@ -1199,6 +1221,15 @@ export default function Voorraad() {
                         onChange={(e) => handleFilterChange("productnaam", e.target.value)}
                         placeholder="Filter"
                         aria-label="Filter op productnaam"
+                      />
+                    </th>
+                    <th>
+                      <input
+                        className="rz-input rz-inline-input"
+                        value={filters.artikelgroep}
+                        onChange={(e) => handleFilterChange("artikelgroep", e.target.value)}
+                        placeholder="Filter"
+                        aria-label="Filter op artikelgroep"
                       />
                     </th>
                     <th className="rz-num">
@@ -1270,7 +1301,7 @@ export default function Voorraad() {
 
                   {filteredRows.length === 0 && (
                     <tr>
-                      <td colSpan={6}>{loadError || "Nog geen live voorraad beschikbaar."}</td>
+                      <td colSpan={7}>{loadError || "Nog geen live voorraad beschikbaar."}</td>
                     </tr>
                   )}
                 </tbody>

--- a/frontend/src/pages/Voorraad.jsx
+++ b/frontend/src/pages/Voorraad.jsx
@@ -594,6 +594,57 @@ async function fetchArticleGroupAssignments() {
   return { byId, byName }
 }
 
+async function fetchArticleGroupOptions() {
+  const householdId = String(readStoredAuthContext()?.active_household_id || '').trim()
+  const query = new URLSearchParams({ _ts: String(Date.now()) })
+  if (householdId) query.set('household_id', householdId)
+
+  const response = await fetch(`/api/article-groups?${query.toString()}`, {
+    cache: 'no-store',
+    headers: getAuthHeaders(),
+  })
+  if (!response.ok) throw new Error('Artikelgroepen konden niet worden geladen')
+
+  const data = await response.json().catch(() => ({}))
+  return (Array.isArray(data?.items) ? data.items : [])
+    .filter((item) => String(item?.status || 'active').toLowerCase() !== 'inactive')
+    .map((item) => ({
+      id: String(item?.id || '').trim(),
+      name: String(item?.name || '').trim(),
+    }))
+    .filter((item) => item.id && item.name)
+    .sort((a, b) => a.name.localeCompare(b.name, 'nl'))
+}
+
+async function saveArticleGroupAssignment(row, articleGroupId) {
+  const householdArticleId = String(row?.householdArticleId || '').trim()
+  if (!householdArticleId) throw new Error('Voorraadregel mist een gekoppeld huishoudartikel')
+  const householdId = String(readStoredAuthContext()?.active_household_id || '').trim() || null
+  const response = await fetch(`/api/household-articles/${encodeURIComponent(householdArticleId)}/article-group`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+    body: JSON.stringify({
+      article_group_id: articleGroupId || null,
+      household_id: householdId,
+    }),
+  })
+  const data = await response.json().catch(() => ({}))
+  if (!response.ok) throw new Error(extractApiMessage(data, 'Artikelgroep kon niet worden opgeslagen'))
+  return data
+}
+
+async function createArticleGroup(name) {
+  const householdId = String(readStoredAuthContext()?.active_household_id || '').trim() || null
+  const response = await fetch('/api/article-groups', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+    body: JSON.stringify({ household_id: householdId, name }),
+  })
+  const data = await response.json().catch(() => ({}))
+  if (!response.ok) throw new Error(extractApiMessage(data, 'Artikelgroep kon niet worden toegevoegd'))
+  return data
+}
+
 function applyArticleGroupsToRows(rows = [], assignments = { byId: new Map(), byName: new Map() }) {
   const byId = assignments?.byId instanceof Map ? assignments.byId : new Map()
   const byName = assignments?.byName instanceof Map ? assignments.byName : new Map()
@@ -607,6 +658,7 @@ function applyArticleGroupsToRows(rows = [], assignments = { byId: new Map(), by
     return {
       ...row,
       artikelgroep: articleGroupName,
+      articleGroupId: assignment?.articleGroupId || null,
       articleGroupName,
     }
   })
@@ -679,15 +731,17 @@ export default function Voorraad() {
   }, [rows])
 
   const reloadInventoryRows = async () => {
-    const [loadedRows, articleGroupAssignments, loadedOptions] = await Promise.all([
+    const [loadedRows, articleGroupAssignments, loadedArticleGroups, loadedOptions] = await Promise.all([
       fetchInventoryRows(),
       fetchArticleGroupAssignments(),
+      fetchArticleGroupOptions(),
       fetchLocationOptions().catch(() => buildLocationOptionState([])),
     ])
     const rowsWithArticleGroups = applyArticleGroupsToRows(loadedRows, articleGroupAssignments)
     const mergedLocationOptions = mergeLocationOptionStates(loadedOptions, buildLocationOptionStateFromRows(rowsWithArticleGroups))
     setLocalZeroRows([])
     setRows(rowsWithArticleGroups)
+    setArticleGroupOptions(loadedArticleGroups)
     setLocationOptions(mergedLocationOptions)
     setLoadError(rowsWithArticleGroups.length ? '' : 'Nog geen live voorraad beschikbaar.')
     return rowsWithArticleGroups
@@ -713,6 +767,10 @@ export default function Voorraad() {
   const [editingCell, setEditingCell] = useState(null);
   const [loadError, setLoadError] = useState("");
   const [saveState, setSaveState] = useState({});
+  const [articleGroupOptions, setArticleGroupOptions] = useState([]);
+  const [articleGroupCreateTarget, setArticleGroupCreateTarget] = useState(null);
+  const [newArticleGroupName, setNewArticleGroupName] = useState('');
+  const [articleGroupCreateState, setArticleGroupCreateState] = useState({ status: 'idle', message: '' });
   const [locationOptions, setLocationOptions] = useState({ locations: [], sublocationsByLocation: new Map() });
   const [showLeaveModal, setShowLeaveModal] = useState(false);
   const [showPurchaseModal, setShowPurchaseModal] = useState(false);
@@ -764,13 +822,14 @@ export default function Voorraad() {
 
   useEffect(() => {
     let cancelled = false;
-    Promise.all([fetchInventoryRows(), fetchArticleGroupAssignments(), fetchLocationOptions().catch(() => buildLocationOptionState([]))])
-      .then(([loadedRows, articleGroupAssignments, loadedOptions]) => {
+    Promise.all([fetchInventoryRows(), fetchArticleGroupAssignments(), fetchArticleGroupOptions(), fetchLocationOptions().catch(() => buildLocationOptionState([]))])
+      .then(([loadedRows, articleGroupAssignments, loadedArticleGroups, loadedOptions]) => {
         if (!cancelled) {
           const rowsWithArticleGroups = applyArticleGroupsToRows(loadedRows, articleGroupAssignments)
           const mergedLocationOptions = mergeLocationOptionStates(loadedOptions, buildLocationOptionStateFromRows(rowsWithArticleGroups))
           setLocalZeroRows([]);
           setRows(rowsWithArticleGroups);
+          setArticleGroupOptions(loadedArticleGroups);
           setLocationOptions(mergedLocationOptions);
           setLoadError(rowsWithArticleGroups.length ? "" : "Nog geen live voorraad beschikbaar.");
         }
@@ -1084,6 +1143,98 @@ export default function Voorraad() {
     : []
   const locationOptionsEmpty = locationOptions.locations.length === 0
 
+  const isHouseholdAdmin = String(readStoredAuthContext()?.display_role || '').trim().toLowerCase() === 'admin'
+
+  const openCreateArticleGroup = (row) => {
+    if (!isHouseholdAdmin) return
+    setArticleGroupCreateTarget(row)
+    setNewArticleGroupName('')
+    setArticleGroupCreateState({ status: 'idle', message: '' })
+  }
+
+  const closeCreateArticleGroup = () => {
+    if (articleGroupCreateState.status === 'saving') return
+    setArticleGroupCreateTarget(null)
+    setNewArticleGroupName('')
+    setArticleGroupCreateState({ status: 'idle', message: '' })
+  }
+
+  const persistArticleGroup = async (row, nextGroupId) => {
+    const previousGroupId = String(row?.articleGroupId || '')
+    const previousGroupName = row?.artikelgroep || 'Niet ingedeeld'
+    const selectedGroup = articleGroupOptions.find((item) => String(item.id) === String(nextGroupId))
+    const nextGroupName = selectedGroup?.name || 'Niet ingedeeld'
+
+    setRows((prev) => prev.map((entry) => entry.id === row.id ? {
+      ...entry,
+      artikelgroep: nextGroupName,
+      articleGroupId: nextGroupId || null,
+      articleGroupName: nextGroupName,
+    } : entry))
+    setLocalZeroRows((prev) => prev.map((entry) => entry.id === row.id ? {
+      ...entry,
+      artikelgroep: nextGroupName,
+      articleGroupId: nextGroupId || null,
+      articleGroupName: nextGroupName,
+    } : entry))
+    setSaveState((prev) => ({ ...prev, [row.id]: { status: 'saving', message: '' } }))
+
+    try {
+      await saveArticleGroupAssignment({
+        ...row,
+        articleGroupId: nextGroupId || null,
+        articleGroupName: nextGroupName,
+        artikelgroep: nextGroupName,
+      }, nextGroupId)
+      setSaveState((prev) => ({ ...prev, [row.id]: { status: 'saved', message: 'Opgeslagen' } }))
+      window.setTimeout(() => {
+        setSaveState((prev) => {
+          const next = { ...prev }
+          if (next[row.id]?.status === 'saved') delete next[row.id]
+          return next
+        })
+      }, 1600)
+    } catch (error) {
+      setRows((prev) => prev.map((entry) => entry.id === row.id ? {
+        ...entry,
+        artikelgroep: previousGroupName,
+        articleGroupId: previousGroupId || null,
+        articleGroupName: previousGroupName,
+      } : entry))
+      console.error('Artikelgroep opslaan mislukt', error)
+      setSaveState((prev) => {
+        const next = { ...prev }
+        delete next[row.id]
+        return next
+      })
+    }
+  }
+
+  const handleCreateArticleGroup = async () => {
+    const name = String(newArticleGroupName || '').trim()
+    if (!name) {
+      setArticleGroupCreateState({ status: 'error', message: 'Artikelgroepnaam is verplicht.' })
+      return
+    }
+    if (!articleGroupCreateTarget || !isHouseholdAdmin) return
+
+    setArticleGroupCreateState({ status: 'saving', message: 'Opslaan...' })
+    try {
+      const created = await createArticleGroup(name)
+      const refreshedGroups = await fetchArticleGroupOptions()
+      setArticleGroupOptions(refreshedGroups)
+      const createdGroup = refreshedGroups.find((item) => String(item.id) === String(created?.id || created?.article_group_id || ''))
+        || refreshedGroups.find((item) => normalizeName(item.name) === normalizeName(name))
+      if (!createdGroup) throw new Error('Artikelgroep is toegevoegd, maar kon niet direct worden geselecteerd')
+      await persistArticleGroup(articleGroupCreateTarget, createdGroup.id)
+      setArticleGroupCreateTarget(null)
+      setNewArticleGroupName('')
+      setArticleGroupCreateState({ status: 'idle', message: '' })
+    } catch (error) {
+      setArticleGroupCreateState({ status: 'error', message: error.message || 'Artikelgroep toevoegen mislukt' })
+    }
+  }
+
   const renderCell = (row, column) => {
     const isEditing =
       editingCell &&
@@ -1186,9 +1337,31 @@ export default function Voorraad() {
     }
 
     if (column.key === "artikelgroep") {
+      const isSavingArticleGroup = saveState[row.id]?.status === 'saving'
+      const isViewer = String(readStoredAuthContext()?.display_role || '').trim().toLowerCase() === 'viewer'
       return (
-        <div className="rz-inline-cell rz-inline-label" style={{ fontWeight: 400 }} title={row?.artikelgroep || 'Niet ingedeeld'}>
-          {row?.artikelgroep || 'Niet ingedeeld'}
+        <div style={{ display: 'grid', gap: 4 }}>
+          <select
+            className="rz-input rz-inline-input"
+            value={String(row?.articleGroupId || '')}
+            disabled={isSavingArticleGroup || isViewer}
+            onChange={(event) => {
+              const nextValue = event.target.value
+              if (nextValue === '__create_article_group__') {
+                openCreateArticleGroup(row)
+                return
+              }
+              persistArticleGroup(row, nextValue)
+            }}
+            aria-label={`Artikelgroep voor ${row?.huishoudnaam || row?.artikel || 'voorraadartikel'}`}
+            title={isViewer ? 'Alleen-lezen gebruiker kan de Artikelgroep niet wijzigen' : 'Kies Artikelgroep'}
+          >
+            <option value="">Niet ingedeeld</option>
+            {articleGroupOptions.map((option) => (
+              <option key={option.id} value={option.id}>{option.name}</option>
+            ))}
+            {isHouseholdAdmin ? <option value="__create_article_group__">+ Nieuwe Artikelgroep toevoegen</option> : null}
+          </select>
         </div>
       )
     }
@@ -1348,6 +1521,52 @@ export default function Voorraad() {
           </div>
         </div>
       </div>
+
+      {articleGroupCreateTarget ? (
+        <div className="rz-modal-backdrop" role="presentation" data-testid="inventory-create-article-group-backdrop">
+          <div className="rz-modal-card" role="dialog" aria-modal="true" aria-labelledby="inventory-create-article-group-title">
+            <h3 id="inventory-create-article-group-title" className="rz-modal-title">Nieuwe Artikelgroep</h3>
+            <p className="rz-modal-text">
+              De nieuwe Artikelgroep wordt direct geselecteerd voor {articleGroupCreateTarget?.huishoudnaam || articleGroupCreateTarget?.artikel || 'het voorraadartikel'}.
+            </p>
+            <label className="rz-input-field">
+              <div className="rz-label">Artikelgroep naam</div>
+              <input
+                className="rz-input"
+                autoFocus
+                value={newArticleGroupName}
+                onChange={(event) => {
+                  setNewArticleGroupName(event.target.value)
+                  if (articleGroupCreateState.status === 'error') setArticleGroupCreateState({ status: 'idle', message: '' })
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault()
+                    handleCreateArticleGroup()
+                  }
+                  if (event.key === 'Escape') {
+                    event.preventDefault()
+                    closeCreateArticleGroup()
+                  }
+                }}
+                placeholder="Bijvoorbeeld: Zuivel"
+                disabled={articleGroupCreateState.status === 'saving'}
+              />
+            </label>
+            {articleGroupCreateState.message ? (
+              <div className={articleGroupCreateState.status === 'error' ? 'rz-inline-feedback rz-inline-feedback--error' : 'rz-inline-feedback rz-inline-feedback--success'}>
+                {articleGroupCreateState.message}
+              </div>
+            ) : null}
+            <div className="rz-modal-actions">
+              <Button type="button" variant="secondary" onClick={closeCreateArticleGroup} disabled={articleGroupCreateState.status === 'saving'}>Annuleren</Button>
+              <Button type="button" variant="primary" onClick={handleCreateArticleGroup} disabled={articleGroupCreateState.status === 'saving'}>
+                {articleGroupCreateState.status === 'saving' ? 'Opslaan…' : 'Opslaan'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
 
       {showPurchaseModal ? (
         <div className="rz-modal-backdrop" role="presentation" data-testid="inventory-incidental-purchase-backdrop">

--- a/frontend/tests/e2e/article-detail.frontend-regression.spec.js
+++ b/frontend/tests/e2e/article-detail.frontend-regression.spec.js
@@ -1,0 +1,125 @@
+import { test, expect } from '@playwright/test';
+import {
+  attachConsoleErrorCollector,
+  expectNoConsoleErrors,
+} from './helpers/rezzervAssertions.js';
+
+test.describe('Artikeldetail frontend-regressie', () => {
+  test('Stabiele artikelroute gebruikt overal de universele huishoudartikelnaam', async ({ page }) => {
+    const consoleErrors = attachConsoleErrorCollector(page);
+    const failedResponses = [];
+    page.on('response', (response) => {
+      if (response.status() >= 400) {
+        failedResponses.push(`${response.status()} ${response.request().method()} ${response.url()}`);
+      }
+    });
+    const articleId = 'household-article-mosterd';
+    const universalArticleName = 'Mosterd fijne Dijon extra lange universele artikelnaam';
+    const receiptArticleText = 'MOSTERD DIJON 250G';
+
+    await page.route('**/api/settings/article-field-visibility', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          overview: {},
+          stock: {},
+          locations: {},
+          history: {},
+          analytics: {},
+        }),
+      });
+    });
+
+    await page.route('**/api/dev/inventory-preview', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          rows: [
+            {
+              id: articleId,
+              artikel: universalArticleName,
+              locatie: 'Voorraadkast',
+              sublocatie: 'Plank 2',
+              aantal: 3,
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.route(`**/api/household-articles/${articleId}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          article_id: articleId,
+          article_name: universalArticleName,
+          brand_or_maker: 'Rezzerv testmerk',
+          article_type: 'Verbruiksartikel',
+          notes: 'Universele naam is leidend.',
+          total_quantity: 3,
+          main_location: 'Voorraadkast',
+          sub_location: 'Plank 2',
+        }),
+      });
+    });
+
+    await page.route(`**/api/household-articles/${articleId}/automation-override`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          article_id: articleId,
+          household_article_id: articleId,
+          requested_article_id: articleId,
+          mode: 'follow_household',
+          has_explicit_override: false,
+          consumable: true,
+          article_name: universalArticleName,
+        }),
+      });
+    });
+
+    await page.route(`**/api/household-articles/${articleId}/events`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [
+            {
+              id: 'event-mosterd-1',
+              event_type: 'purchase',
+              created_at: '2026-07-17T12:00:00Z',
+              old_quantity: 1,
+              new_quantity: 3,
+              quantity: 2,
+              location_label: 'Voorraadkast / Plank 2',
+              source: 'regression',
+              note: universalArticleName,
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.goto(`/voorraad/${encodeURIComponent(articleId)}`);
+
+    await expect(page).toHaveURL(new RegExp(`/voorraad/${articleId}$`));
+    await expect(page.getByTestId('article-detail-page')).toBeVisible();
+    await expect(page.getByTestId('article-detail-title')).toHaveText(
+      `Artikel details: ${universalArticleName}`,
+    );
+
+    await expect(page.getByTestId('app-header').getByText(`Artikel details: ${universalArticleName}`, { exact: true })).toBeVisible();
+    await expect(page.getByText(receiptArticleText, { exact: true })).toHaveCount(0);
+
+    for (const tabName of ['Overzicht', 'Voorraad', 'Locaties', 'Historie', 'Analyse']) {
+      await expect(page.getByRole('tab', { name: tabName, exact: true })).toBeVisible();
+    }
+
+    expect(failedResponses).toEqual([]);
+    await expectNoConsoleErrors(consoleErrors);
+  });
+});

--- a/frontend/tests/e2e/external-databases-known-gtin.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases-known-gtin.frontend-regression.spec.js
@@ -6,9 +6,9 @@ import {
 } from './helpers/rezzervAssertions.js';
 
 test.describe('Externe databases bekende GTIN regressie', () => {
-  test('Bonartikel met bestaande GTIN behoudt artikelcode en krijgt geen kandidaten', async ({ page }) => {
+  test('Bonartikel met bestaande GTIN behoudt artikelcode en start geen OFF-zoekactie', async ({ page }) => {
     const consoleErrors = attachConsoleErrorCollector(page);
-    let offSaveCalled = false;
+    let offSearchCalled = false;
 
     await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
       await route.fulfill({
@@ -17,6 +17,9 @@ test.describe('Externe databases bekende GTIN regressie', () => {
         body: JSON.stringify({
           items: [
             {
+              receipt_item_id: 'purchase-import-line:purchase-line-known-gtin-regression',
+              receipt_item_type: 'purchase_import_line',
+              receipt_item_source_id: 'purchase-line-known-gtin-regression',
               context_key: 'ctx-known-gtin-regression',
               receipt_line_id: 'receipt-line-known-gtin-regression',
               purchase_import_line_id: 'purchase-line-known-gtin-regression',
@@ -51,8 +54,8 @@ test.describe('Externe databases bekende GTIN regressie', () => {
       });
     });
 
-    await page.route('**/api/external-databases/off/save-candidates', async (route) => {
-      offSaveCalled = true;
+    await page.route('**/api/external-products/off/search', async (route) => {
+      offSearchCalled = true;
       await route.fulfill({
         status: 500,
         contentType: 'application/json',
@@ -70,22 +73,22 @@ test.describe('Externe databases bekende GTIN regressie', () => {
     const receiptTable = page.getByTestId('external-receipt-items-table');
     const receiptRow = receiptTable.locator('tbody tr', { hasText: 'Bekende GTIN regressietest' });
     await expect(receiptRow).toBeVisible();
-    await expect(receiptRow.locator('td').nth(4)).toHaveText('8710000001234');
+    await expect(receiptRow.locator('td').nth(4)).toHaveText('-');
     await expect(receiptRow.locator('td').nth(5)).toHaveText('8710000001234');
+    await expect(receiptRow.locator('td').nth(8)).toHaveText('-');
     await expect(receiptRow.locator('td').nth(9)).toHaveText('-');
-    await expect(receiptRow.locator('td').nth(10)).toHaveText('-');
-    await expect(receiptRow.locator('td').nth(11)).toHaveText('0');
+    await expect(receiptRow.locator('td').nth(10)).toHaveText('0');
 
     await receiptRow.dblclick();
 
     const candidateTable = page.getByTestId('external-receipt-item-candidates-table');
     await expect(candidateTable).toBeVisible();
-    await expect(candidateTable).toContainText('Geen externe kandidaten voor dit bonartikel.');
+    await expect(candidateTable).toContainText('Geen universele kandidaten met score 0,500 of hoger voor dit bonartikel.');
     await expect(candidateTable.getByText('Onterechte kandidaat')).toHaveCount(0);
     await expect(page.getByText('GTIN/EAN is al bekend; OFF-kandidaten worden niet automatisch toegevoegd.')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Koppel artikel', exact: true })).toBeDisabled();
     await expect(page.getByRole('button', { name: 'Ontkoppel artikel', exact: true })).toBeDisabled();
-    expect(offSaveCalled).toBe(false);
+    expect(offSearchCalled).toBe(false);
 
     await expectNoConsoleErrors(consoleErrors);
   });

--- a/frontend/tests/e2e/external-databases-off.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases-off.frontend-regression.spec.js
@@ -4,51 +4,13 @@ import {
   expectNoConsoleErrors,
 } from './helpers/rezzervAssertions.js';
 
-function receiptItemsPayload(includeOffCandidate = false, manualCandidate = false) {
-  const candidates = [
-    {
-      candidate_id: 'candidate-off-preview-existing',
-      id: 'candidate-off-preview-existing',
-      candidate_name: 'Halfvolle melk bestaand',
-      candidate_brand: 'Jumbo',
-      external_source_name: 'Open Food Facts',
-      candidate_source_name: 'Open Food Facts',
-      external_source_product_code: '8710000000000',
-      candidate_source_product_code: '8710000000000',
-      source_product_code: '8710000000000',
-      retailer_article_number: '8710000000000',
-      variant: 'Standaard',
-      score: 0.7,
-      candidate_status: 'candidate',
-      is_linked_to_catalog: false,
-      is_linkable_to_catalog: true,
-    },
-  ];
-
-  if (includeOffCandidate) {
-    candidates.push({
-      candidate_id: manualCandidate ? 'candidate-off-manual-best' : 'candidate-off-saved-best',
-      id: manualCandidate ? 'candidate-off-manual-best' : 'candidate-off-saved-best',
-      candidate_name: manualCandidate ? 'Melk halfvol handmatig' : 'Halfvolle melk',
-      candidate_brand: 'Jumbo',
-      external_source_name: 'Open Food Facts',
-      candidate_source_name: 'Open Food Facts',
-      external_source_product_code: manualCandidate ? '8710000000099' : '8710000000002',
-      candidate_source_product_code: manualCandidate ? '8710000000099' : '8710000000002',
-      source_product_code: manualCandidate ? '8710000000099' : '8710000000002',
-      retailer_article_number: manualCandidate ? '8710000000099' : '8710000000002',
-      quantity_label: '1 l',
-      variant: '1 l',
-      score: manualCandidate ? 0.91 : 0.82,
-      candidate_status: 'candidate',
-      is_linked_to_catalog: false,
-      is_linkable_to_catalog: true,
-    });
-  }
-
+function receiptItemsPayload() {
   return {
     items: [
       {
+        receipt_item_id: 'purchase-import-line:purchase-line-off-preview-regression',
+        receipt_item_type: 'purchase_import_line',
+        receipt_item_source_id: 'purchase-line-off-preview-regression',
         context_key: 'ctx-off-preview-regression',
         receipt_line_id: 'receipt-line-off-preview-regression',
         purchase_import_line_id: 'purchase-line-off-preview-regression',
@@ -69,67 +31,87 @@ function receiptItemsPayload(includeOffCandidate = false, manualCandidate = fals
         is_receipt_item_placeholder: true,
         is_linked_to_catalog: false,
         is_linkable_to_catalog: false,
-        candidates,
+        candidates: [],
+      },
+    ],
+  };
+}
+
+function automaticSearchResponse() {
+  return {
+    ok: true,
+    status: 'found',
+    provider: 'legacy_cgi',
+    query: 'halfvolle melk',
+    mode: 'automatic',
+    mutated: false,
+    creates_global_product: false,
+    creates_household_article: false,
+    creates_inventory_event: false,
+    results: [
+      {
+        gtin: '8710000000002',
+        product_name: 'Halfvolle melk',
+        brand: 'Jumbo',
+        score: 0.82,
+        automatic_rank_score: 0.93,
+        confidence: 'high',
+        automatic_evidence: {
+          phrase_hits: 1,
+          weighted_hits: 2,
+        },
+      },
+    ],
+  };
+}
+
+function manualSearchResponse() {
+  return {
+    ok: true,
+    status: 'found',
+    provider: 'legacy_cgi',
+    query: 'melk halfvol zelf zoeken',
+    mode: 'manual',
+    mutated: false,
+    creates_global_product: false,
+    creates_household_article: false,
+    creates_inventory_event: false,
+    results: [
+      {
+        gtin: '8710000000099',
+        product_name: 'Melk halfvol handmatig',
+        brand: 'Jumbo',
+        score: 0.91,
+        confidence: 'high',
       },
     ],
   };
 }
 
 test.describe('Externe databases OFF candidate flow', () => {
-  test('Detail openen raadpleegt OFF automatisch en Zelf zoeken zoekt opnieuw met aangepaste tekst', async ({ page }) => {
+  test('Detail openen zoekt automatisch read-only en Zelf zoeken vervangt de resultaatset', async ({ page }) => {
     const consoleErrors = attachConsoleErrorCollector(page);
-    let includeOffCandidate = false;
-    let manualCandidate = false;
     const offRequestBodies = [];
 
     await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(receiptItemsPayload(includeOffCandidate, manualCandidate)),
+        body: JSON.stringify(receiptItemsPayload()),
       });
     });
 
-    await page.route('**/api/external-databases/receipt-items/ensure-candidates', async (route) => {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'ok' }) });
-    });
-
-    await page.route('**/api/external-databases/off/save-candidates', async (route) => {
+    await page.route('**/api/external-products/off/search', async (route) => {
       const body = route.request().postDataJSON();
       offRequestBodies.push(body);
-      includeOffCandidate = true;
-      manualCandidate = body?.candidate_name === 'melk halfvol zelf zoeken';
+      const response = body?.mode === 'manual'
+        ? manualSearchResponse()
+        : automaticSearchResponse();
+
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({
-          ok: true,
-          source_name: 'open_food_facts',
-          context_key: 'ctx-off-preview-regression',
-          retailer_code: 'jumbo',
-          receipt_line_text: 'halfvolle melk',
-          candidate_count: 1,
-          saved_count: 1,
-          updated_count: 0,
-          skipped_count: 0,
-          saved_candidate_ids: [manualCandidate ? 'candidate-off-manual-best' : 'candidate-off-saved-best'],
-          updated_candidate_ids: [],
-          preview: {
-            ok: true,
-            source_name: 'open_food_facts',
-            mode: 'read_only_search_preview',
-            status: 'found',
-            external_source_available: true,
-            provider: 'search_a_licious',
-            result_count: 1,
-            creates_global_product: false,
-            creates_household_article: false,
-            creates_inventory_event: false,
-          },
-          creates_global_product: false,
-          creates_household_article: false,
-          creates_inventory_event: false,
-        }),
+        body: JSON.stringify(response),
       });
     });
 
@@ -138,8 +120,6 @@ test.describe('Externe databases OFF candidate flow', () => {
     await expect(page.getByText(/Application error|Uncaught|TypeError|ReferenceError/i)).toHaveCount(0);
     await expect(page.getByRole('button', { name: 'Terug' })).toHaveCount(0);
     await expect(page.getByRole('button', { name: 'Vernieuwen' })).toHaveCount(0);
-    await expect(page.getByText('Bonartikelen worden geladen...')).toHaveCount(0);
-    await expect(page.getByText('Externe databases worden geladen...')).toHaveCount(0);
 
     const receiptTable = page.getByTestId('external-receipt-items-table');
     await expect(receiptTable).toBeVisible();
@@ -150,56 +130,100 @@ test.describe('Externe databases OFF candidate flow', () => {
 
     const candidateTable = page.getByTestId('external-receipt-item-candidates-table');
     await expect(candidateTable).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Raadpleeg OFF' })).toHaveCount(0);
     await expect(page.getByRole('button', { name: 'Zelf zoeken' })).toBeVisible();
-    await expect(page.getByLabel('OFF zoektekst')).toHaveValue('Halfvolle melk bestaand');
-    await expect(page.getByRole('button', { name: 'Terug' })).toHaveCount(0);
-    await expect(page.getByRole('button', { name: 'Vernieuwen' })).toHaveCount(0);
-    await expect(page.getByText('Bonartikelen worden geladen...')).toHaveCount(0);
+    await expect(page.getByLabel('OFF zoektekst')).toHaveValue('halfvolle melk');
 
     await expect(page.getByTestId('external-off-preview-meta')).toContainText('OFF-status: Gevonden');
-    await expect(page.getByTestId('external-off-preview-meta')).toContainText('Provider: search_a_licious');
+    await expect(page.getByTestId('external-off-preview-meta')).toContainText('Provider: legacy_cgi');
+    await expect(page.getByTestId('external-off-preview-meta')).toContainText('Zoektype: automatisch');
     await expect(page.getByTestId('external-off-preview-meta')).toContainText('Productmutatie: nee');
 
-    const offCandidateRow = candidateTable.locator('tbody tr', { hasText: '8710000000002' });
-    await expect(offCandidateRow).toBeVisible();
-    await expect(offCandidateRow.getByRole('cell', { name: 'Halfvolle melk', exact: true })).toBeVisible();
-    await expect(offCandidateRow.getByRole('cell', { name: '8710000000002', exact: true })).toBeVisible();
-    await expect(page.getByTestId('external-off-candidates-table')).toHaveCount(0);
+    const automaticRow = candidateTable.locator('tbody tr', { hasText: '8710000000002' });
+    await expect(automaticRow).toBeVisible();
+    await expect(automaticRow.getByRole('cell', { name: 'Halfvolle melk', exact: true })).toBeVisible();
+    await expect(automaticRow.getByRole('cell', { name: '0,930', exact: true })).toBeVisible();
 
     await page.getByLabel('OFF zoektekst').fill('melk halfvol zelf zoeken');
     await page.getByRole('button', { name: 'Zelf zoeken' }).click();
+
     await expect(page.getByTestId('external-off-preview-meta')).toContainText('Zoektype: handmatig');
     await expect(page.getByTestId('external-off-preview-meta')).toContainText('Zoektekst: melk halfvol zelf zoeken');
-    await expect(page.getByRole('button', { name: 'Terug' })).toHaveCount(0);
-    await expect(page.getByRole('button', { name: 'Vernieuwen' })).toHaveCount(0);
-    await expect(page.getByText('Bonartikelen worden geladen...')).toHaveCount(0);
     await expect(candidateTable.locator('tbody tr', { hasText: '8710000000099' })).toBeVisible();
+    await expect(candidateTable.locator('tbody tr', { hasText: '8710000000002' })).toHaveCount(0);
 
-    const manualCandidateRow = candidateTable.locator('tbody tr', { hasText: '8710000000099' });
-    await manualCandidateRow.locator('input[type="radio"]').check();
-    await expect(page.getByRole('button', { name: 'Koppel artikel', exact: true })).toBeEnabled();
-
-    expect(offRequestBodies[0]).toMatchObject({
-      receipt_line_text: 'halfvolle melk',
-      retailer_code: 'jumbo',
-      candidate_name: 'Halfvolle melk bestaand',
-      quantity_label: '1 l',
-      receipt_line_id: 'receipt-line-off-preview-regression',
-      purchase_import_line_id: 'purchase-line-off-preview-regression',
-      limit: 5,
+    expect(offRequestBodies).toHaveLength(2);
+    expect(offRequestBodies[0]).toEqual({
+      receipt_item_id: 'purchase-import-line:purchase-line-off-preview-regression',
+      mode: 'automatic',
+      limit: 10,
     });
-    expect(offRequestBodies[1]).toMatchObject({
-      receipt_line_text: 'halfvolle melk',
-      retailer_code: 'jumbo',
-      candidate_name: 'melk halfvol zelf zoeken',
-      quantity_label: '1 l',
-      receipt_line_id: 'receipt-line-off-preview-regression',
-      purchase_import_line_id: 'purchase-line-off-preview-regression',
-      limit: 5,
-      source: 'manual_off_search',
+    expect(offRequestBodies[1]).toEqual({
+      receipt_item_id: 'purchase-import-line:purchase-line-off-preview-regression',
+      query: 'melk halfvol zelf zoeken',
+      mode: 'manual',
+      limit: 10,
     });
 
+    await expect(page.getByRole('button', { name: 'Koppel artikel', exact: true })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Ontkoppel artikel', exact: true })).toBeDisabled();
     await expectNoConsoleErrors(consoleErrors);
   });
+
+  test('Langdurige OFF-zoekactie toont na één seconde de blokkerende R en verwijdert die direct na een fout', async ({ page }) => {
+    const consoleErrors = attachConsoleErrorCollector(page);
+    let releaseSearch;
+    const searchGate = new Promise((resolve) => {
+      releaseSearch = resolve;
+    });
+
+    await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(receiptItemsPayload()),
+      });
+    });
+
+    await page.route('**/api/external-products/off/search', async (route) => {
+      await searchGate;
+      await route.fulfill({
+        status: 503,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'OFF regressiestoring' }),
+      });
+    });
+
+    await page.goto('/externe-databases');
+
+    const receiptTable = page.getByTestId('external-receipt-items-table');
+    const receiptRow = receiptTable.locator('tbody tr', { hasText: 'halfvolle melk' });
+    await expect(receiptRow).toBeVisible();
+
+    await receiptRow.dblclick();
+
+    const overlay = page.getByRole('status', { name: 'Zoekactie wordt uitgevoerd' });
+    await expect(overlay).toHaveCount(0);
+
+    await page.waitForTimeout(1100);
+    await expect(overlay).toBeVisible();
+    await expect(overlay).toHaveAttribute('aria-busy', 'true');
+    await expect(overlay.getByText('R', { exact: true })).toBeVisible();
+    await expect(overlay.getByText('Zoekactie wordt uitgevoerd', { exact: true })).toBeVisible();
+
+    releaseSearch();
+
+    await expect(overlay).toHaveCount(0);
+    await expect(page.getByText('OFF regressiestoring', { exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Zelf zoeken' })).toBeEnabled();
+    await expect(page.getByRole('button', { name: 'Koppel artikel', exact: true })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Ontkoppel artikel', exact: true })).toBeDisabled();
+
+    const unexpectedConsoleErrors = consoleErrors.filter(
+      (message) => !message.includes('Failed to load resource: the server responded with a status of 503'),
+    );
+    expect(unexpectedConsoleErrors).toEqual([]);
+  });
+
+  // OFF_ZOEKOVERLAY_REGRESSIETEST_INGEVOERD
+
 });

--- a/frontend/tests/e2e/external-databases-unlink.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases-unlink.frontend-regression.spec.js
@@ -5,73 +5,73 @@ import {
   expectRouteLoads,
 } from './helpers/rezzervAssertions.js';
 
-function receiptItemsPayload(isLinked = true) {
-  return {
-    items: [
-      {
-        context_key: 'ctx-unlink-regression',
-        receipt_line_id: 'receipt-line-unlink-regression',
-        purchase_import_line_id: 'purchase-line-unlink-regression',
-        receipt_line_text: 'Ontkoppel kandidaat regressietest',
-        retailer_code: 'lidl',
-        retailer_article_number: 'LIDL-LINKED',
-        gtin: '',
-        quantity_label: '1 stuk',
-        price: 1.23,
-        candidate_id: 'candidate-linked-unlink-regression',
-        id: 'candidate-linked-unlink-regression',
-        candidate_name: 'Gekoppelde ontkoppel kandidaat',
-        candidate_brand: 'Testmerk',
-        external_source_name: 'Open Food Facts',
-        candidate_source_name: 'Open Food Facts',
-        external_source_product_code: 'LIDL-LINKED',
-        candidate_source_product_code: 'LIDL-LINKED',
-        source_product_code: 'LIDL-LINKED',
-        variant: 'Standaard',
-        score: 0.8,
-        candidate_status: isLinked ? 'linked_to_catalog' : 'candidate',
-        is_linked_to_catalog: isLinked,
-        is_linkable_to_catalog: !isLinked,
-      },
-    ],
-  };
-}
-
 test.describe('Externe databases ontkoppelen regressie', () => {
-  test('Gekoppelde kandidaat kan vanuit detailscherm worden ontkoppeld', async ({ page }) => {
+  test('Bestaande cataloguskoppeling wordt niet vermengd met tijdelijke OFF-zoekresultaten', async ({ page }) => {
     const consoleErrors = attachConsoleErrorCollector(page);
-    let linked = true;
-    let unlinkRequestBody = null;
+    const offRequestBodies = [];
+    let unlinkCalled = false;
 
     await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(receiptItemsPayload(linked)),
+        body: JSON.stringify({
+          items: [
+            {
+              receipt_item_id: 'purchase-import-line:purchase-line-unlink-regression',
+              receipt_item_type: 'purchase_import_line',
+              receipt_item_source_id: 'purchase-line-unlink-regression',
+              context_key: 'ctx-unlink-regression',
+              receipt_line_id: 'receipt-line-unlink-regression',
+              purchase_import_line_id: 'purchase-line-unlink-regression',
+              receipt_line_text: 'Ontkoppel kandidaat regressietest',
+              retailer_code: 'lidl',
+              retailer_article_number: 'LIDL-LINKED',
+              gtin: '',
+              quantity_label: '1 stuk',
+              price: 1.23,
+              candidate_id: 'candidate-linked-unlink-regression',
+              id: 'candidate-linked-unlink-regression',
+              candidate_name: 'Gekoppelde ontkoppel kandidaat',
+              candidate_brand: 'Testmerk',
+              external_source_name: 'Open Food Facts',
+              candidate_source_name: 'Open Food Facts',
+              external_source_product_code: '8710000007777',
+              candidate_source_product_code: '8710000007777',
+              source_product_code: '8710000007777',
+              variant: 'Standaard',
+              score: 0.8,
+              candidate_status: 'linked_to_catalog',
+              is_linked_to_catalog: true,
+              is_linkable_to_catalog: false,
+            },
+          ],
+        }),
       });
     });
 
-    await page.route('**/api/external-databases/off/save-candidates', async (route) => {
+    await page.route('**/api/external-products/off/search', async (route) => {
+      offRequestBodies.push(route.request().postDataJSON());
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
           ok: true,
-          preview: {
-            ok: true,
-            status: 'no_results',
-            provider: 'search_a_licious',
-            creates_global_product: false,
-            creates_household_article: false,
-            creates_inventory_event: false,
-          },
+          status: 'no_results',
+          provider: 'legacy_cgi',
+          query: 'ontkoppel kandidaat regressietest',
+          mode: 'automatic',
+          mutated: false,
+          results: [],
+          creates_global_product: false,
+          creates_household_article: false,
+          creates_inventory_event: false,
         }),
       });
     });
 
     await page.route('**/api/external-databases/catalog/unlink', async (route) => {
-      unlinkRequestBody = route.request().postDataJSON();
-      linked = false;
+      unlinkCalled = true;
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -87,31 +87,29 @@ test.describe('Externe databases ontkoppelen regressie', () => {
     ]);
 
     const receiptTable = page.getByTestId('external-receipt-items-table');
-    await expect(receiptTable).toBeVisible();
-
     const receiptRow = receiptTable.locator('tbody tr', { hasText: 'Ontkoppel kandidaat regressietest' });
     await expect(receiptRow).toBeVisible();
     await expect(receiptRow.locator('td').nth(3).locator('input')).toBeChecked();
+
     await receiptRow.dblclick();
 
     const candidateTable = page.getByTestId('external-receipt-item-candidates-table');
     await expect(candidateTable).toBeVisible();
-
-    const linkedCandidateRow = candidateTable.locator('tbody tr', { hasText: 'Gekoppelde ontkoppel kandidaat' });
-    await expect(linkedCandidateRow).toBeVisible();
-    await expect(linkedCandidateRow).toContainText('Gekoppeld');
-    await linkedCandidateRow.locator('input[type="radio"]').check();
-
+    await expect(candidateTable).toContainText('Geen universele kandidaten met score 0,500 of hoger voor dit bonartikel.');
+    await expect(candidateTable.getByText('Gekoppelde ontkoppel kandidaat')).toHaveCount(0);
+    await expect(page.getByTestId('external-off-preview-meta')).toContainText('OFF-status: Geen resultaten');
     await expect(page.getByRole('button', { name: 'Koppel artikel', exact: true })).toBeDisabled();
-    await expect(page.getByRole('button', { name: 'Ontkoppel artikel', exact: true })).toBeEnabled();
-    await page.getByRole('button', { name: 'Ontkoppel artikel', exact: true }).click();
+    await expect(page.getByRole('button', { name: 'Ontkoppel artikel', exact: true })).toBeDisabled();
 
-    expect(unlinkRequestBody).toMatchObject({
-      context_keys: ['ctx-unlink-regression'],
-      candidate_ids: ['candidate-linked-unlink-regression'],
-    });
+    expect(offRequestBodies).toEqual([
+      {
+        receipt_item_id: 'purchase-import-line:purchase-line-unlink-regression',
+        mode: 'automatic',
+        limit: 10,
+      },
+    ]);
+    expect(unlinkCalled).toBe(false);
 
-    await expect(receiptTable.locator('tbody tr', { hasText: 'Ontkoppel kandidaat regressietest' }).locator('td').nth(3).locator('input')).not.toBeChecked();
     await expectNoConsoleErrors(consoleErrors);
   });
 });

--- a/frontend/tests/e2e/external-databases.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases.frontend-regression.spec.js
@@ -17,6 +17,25 @@ async function routeReceiptItems(page, items) {
   await page.route('**/api/external-databases/receipt-items/ensure-candidates', async (route) => {
     await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'ok' }) });
   });
+  await page.route('**/api/external-products/off/search', async (route) => {
+    const body = route.request().postDataJSON();
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        status: 'no_results',
+        provider: 'regression_mock',
+        query: body?.query || '',
+        mode: body?.mode || 'automatic',
+        mutated: false,
+        results: [],
+        creates_global_product: false,
+        creates_household_article: false,
+        creates_inventory_event: false,
+      }),
+    });
+  });
 }
 
 async function openExternalDatabases(page) {
@@ -64,6 +83,9 @@ test.describe('Externe databases frontend-regressie', () => {
     const consoleErrors = attachConsoleErrorCollector(page);
     await routeReceiptItems(page, [
       {
+        receipt_item_id: 'purchase-import-line:purchase-line-dedupe-regression',
+        receipt_item_type: 'purchase_import_line',
+        receipt_item_source_id: 'purchase-line-dedupe-regression',
         context_key: 'ctx-dedupe-regression',
         receipt_line_id: 'receipt-line-dedupe-regression',
         purchase_import_line_id: 'purchase-line-dedupe-regression',
@@ -85,6 +107,9 @@ test.describe('Externe databases frontend-regressie', () => {
         is_linkable_to_catalog: true,
       },
       {
+        receipt_item_id: 'purchase-import-line:purchase-line-dedupe-regression',
+        receipt_item_type: 'purchase_import_line',
+        receipt_item_source_id: 'purchase-line-dedupe-regression',
         context_key: 'ctx-dedupe-regression',
         receipt_line_id: 'receipt-line-dedupe-regression',
         purchase_import_line_id: 'purchase-line-dedupe-regression',
@@ -118,16 +143,20 @@ test.describe('Externe databases frontend-regressie', () => {
     await receiptRow.dblclick();
     const candidateTable = page.getByTestId('external-receipt-item-candidates-table');
     await expect(candidateTable).toBeVisible();
-    await expect(candidateTable.locator('tbody tr').filter({ has: page.locator('input[type="radio"]') })).toHaveCount(1);
-    await expect(candidateTable.getByText('8710000000001')).toBeVisible();
-    await expect(candidateTable.getByText('0,800')).toBeVisible();
+    await expect(candidateTable).toContainText('Geen universele kandidaten met score 0,500 of hoger voor dit bonartikel.');
+    await expect(candidateTable.getByText('8710000000001')).toHaveCount(0);
+    await expect(candidateTable.getByText('0,800')).toHaveCount(0);
     await expect(candidateTable.getByText('0,400')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Koppel artikel', exact: true })).toBeDisabled();
     await expectNoConsoleErrors(consoleErrors);
   });
 
   test('Bovenste tabel toont geen winkelspecifieke artikelcode als GTIN EAN', async ({ page }) => {
     const consoleErrors = attachConsoleErrorCollector(page);
     await routeReceiptItems(page, [{
+      receipt_item_id: 'purchase-import-line:purchase-line-invalid-gtin-regression',
+      receipt_item_type: 'purchase_import_line',
+      receipt_item_source_id: 'purchase-line-invalid-gtin-regression',
       context_key: 'ctx-invalid-gtin-regression', receipt_line_id: 'receipt-line-invalid-gtin-regression', purchase_import_line_id: 'purchase-line-invalid-gtin-regression', receipt_line_text: 'Winkelspecifieke code regressietest', retailer_code: 'lidl', retailer_article_number: '12345', gtin: 'ART-8710000000001', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-invalid-gtin', candidate_name: 'Rezzerv Test Product', candidate_brand: 'Testmerk', external_source_name: 'Open Food Facts', external_source_product_code: 'LIDL-00999', variant: 'Standaard', score: 0.9, candidate_status: 'candidate', is_linked_to_catalog: false, is_linkable_to_catalog: true,
     }]);
 
@@ -144,8 +173,8 @@ test.describe('Externe databases frontend-regressie', () => {
   test('Bovenste tabel gebruikt geen winkelketen-categorie pseudo-kandidaat als beste kandidaat', async ({ page }) => {
     const consoleErrors = attachConsoleErrorCollector(page);
     await routeReceiptItems(page, [
-      { context_key: 'ctx-pseudo-code-regression', receipt_line_id: 'receipt-line-pseudo-code-regression', purchase_import_line_id: 'purchase-line-pseudo-code-regression', receipt_line_text: 'Pseudo artikelcode regressietest', retailer_code: 'lidl', retailer_article_number: 'lidl:groente.zoete-aardappel', source_product_code: 'lidl:groente.zoete-aardappel', candidate_source_product_code: 'lidl:groente.zoete-aardappel', gtin: '', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-retailer-pseudo', candidate_name: 'Lidl Zoete aardappel', candidate_brand: 'Lidl Groente', external_source_name: 'lidl_catalog_enrich', external_source_product_code: 'lidl:groente.zoete-aardappel', variant: 'Groente', score: 0.95, candidate_status: 'probable_candidate', is_linked_to_catalog: false, is_linkable_to_catalog: true },
-      { context_key: 'ctx-pseudo-code-regression', receipt_line_id: 'receipt-line-pseudo-code-regression', purchase_import_line_id: 'purchase-line-pseudo-code-regression', receipt_line_text: 'Pseudo artikelcode regressietest', retailer_code: 'lidl', retailer_article_number: 'lidl:groente.zoete-aardappel', gtin: '', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-off-real', candidate_name: 'Zoete aardappel', candidate_brand: '-', external_source_name: 'Open Food Facts', external_source_product_code: '000426660609', variant: 'OFF', score: 0.642, candidate_status: 'candidate', is_linked_to_catalog: false, is_linkable_to_catalog: true },
+      { receipt_item_id: 'purchase-import-line:purchase-line-pseudo-code-regression', receipt_item_type: 'purchase_import_line', receipt_item_source_id: 'purchase-line-pseudo-code-regression', context_key: 'ctx-pseudo-code-regression', receipt_line_id: 'receipt-line-pseudo-code-regression', purchase_import_line_id: 'purchase-line-pseudo-code-regression', receipt_line_text: 'Pseudo artikelcode regressietest', retailer_code: 'lidl', retailer_article_number: 'lidl:groente.zoete-aardappel', source_product_code: 'lidl:groente.zoete-aardappel', candidate_source_product_code: 'lidl:groente.zoete-aardappel', gtin: '', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-retailer-pseudo', candidate_name: 'Lidl Zoete aardappel', candidate_brand: 'Lidl Groente', external_source_name: 'lidl_catalog_enrich', external_source_product_code: 'lidl:groente.zoete-aardappel', variant: 'Groente', score: 0.95, candidate_status: 'probable_candidate', is_linked_to_catalog: false, is_linkable_to_catalog: true },
+      { receipt_item_id: 'purchase-import-line:purchase-line-pseudo-code-regression', receipt_item_type: 'purchase_import_line', receipt_item_source_id: 'purchase-line-pseudo-code-regression', context_key: 'ctx-pseudo-code-regression', receipt_line_id: 'receipt-line-pseudo-code-regression', purchase_import_line_id: 'purchase-line-pseudo-code-regression', receipt_line_text: 'Pseudo artikelcode regressietest', retailer_code: 'lidl', retailer_article_number: 'lidl:groente.zoete-aardappel', gtin: '', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-off-real', candidate_name: 'Zoete aardappel', candidate_brand: '-', external_source_name: 'Open Food Facts', external_source_product_code: '000426660609', variant: 'OFF', score: 0.642, candidate_status: 'candidate', is_linked_to_catalog: false, is_linkable_to_catalog: true },
     ]);
 
     const receiptTable = await openExternalDatabases(page);
@@ -159,8 +188,9 @@ test.describe('Externe databases frontend-regressie', () => {
     await receiptRow.dblclick();
     const candidateTable = page.getByTestId('external-receipt-item-candidates-table');
     await expect(candidateTable).toBeVisible();
-    await expect(candidateTable).toContainText('Open Food Facts');
-    await expect(candidateTable).toContainText('000426660609');
+    await expect(candidateTable).toContainText('Geen universele kandidaten met score 0,500 of hoger voor dit bonartikel.');
+    await expect(candidateTable).not.toContainText('Open Food Facts');
+    await expect(candidateTable).not.toContainText('000426660609');
     await expect(candidateTable).not.toContainText('lidl_catalog_enrich');
     await expect(candidateTable).not.toContainText('lidl:groente.zoete-aardappel');
     await expectNoConsoleErrors(consoleErrors);
@@ -169,8 +199,8 @@ test.describe('Externe databases frontend-regressie', () => {
   test('Bovenste tabel gebruikt gekoppelde kandidaat boven hoogste score zonder kandidaatcode als bonartikelnummer te tonen', async ({ page }) => {
     const consoleErrors = attachConsoleErrorCollector(page);
     await routeReceiptItems(page, [
-      { context_key: 'ctx-linked-wins-regression', receipt_line_id: 'receipt-line-linked-wins-regression', purchase_import_line_id: 'purchase-line-linked-wins-regression', receipt_line_text: 'Gekoppelde kandidaat regressietest', retailer_code: 'lidl', retailer_article_number: '12345', gtin: '', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-highest-score-not-linked', candidate_name: 'Niet gekoppelde hoogste score', candidate_brand: 'Testmerk', external_source_name: 'Open Food Facts', external_source_product_code: 'LIDL-HIGH', variant: 'Standaard', score: 0.99, candidate_status: 'candidate', is_linked_to_catalog: false, is_linkable_to_catalog: true },
-      { context_key: 'ctx-linked-wins-regression', receipt_line_id: 'receipt-line-linked-wins-regression', purchase_import_line_id: 'purchase-line-linked-wins-regression', receipt_line_text: 'Gekoppelde kandidaat regressietest', retailer_code: 'lidl', retailer_article_number: '12345', gtin: '', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-linked-lower-score', candidate_name: 'Gekoppelde lagere score', candidate_brand: 'Testmerk', external_source_name: 'Open Food Facts', external_source_product_code: 'LIDL-LINKED', variant: 'Standaard', score: 0.50, candidate_status: 'linked_to_catalog', is_linked_to_catalog: true, is_linkable_to_catalog: false },
+      { receipt_item_id: 'purchase-import-line:purchase-line-linked-wins-regression', receipt_item_type: 'purchase_import_line', receipt_item_source_id: 'purchase-line-linked-wins-regression', context_key: 'ctx-linked-wins-regression', receipt_line_id: 'receipt-line-linked-wins-regression', purchase_import_line_id: 'purchase-line-linked-wins-regression', receipt_line_text: 'Gekoppelde kandidaat regressietest', retailer_code: 'lidl', retailer_article_number: '12345', gtin: '', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-highest-score-not-linked', candidate_name: 'Niet gekoppelde hoogste score', candidate_brand: 'Testmerk', external_source_name: 'Open Food Facts', external_source_product_code: 'LIDL-HIGH', variant: 'Standaard', score: 0.99, candidate_status: 'candidate', is_linked_to_catalog: false, is_linkable_to_catalog: true },
+      { receipt_item_id: 'purchase-import-line:purchase-line-linked-wins-regression', receipt_item_type: 'purchase_import_line', receipt_item_source_id: 'purchase-line-linked-wins-regression', context_key: 'ctx-linked-wins-regression', receipt_line_id: 'receipt-line-linked-wins-regression', purchase_import_line_id: 'purchase-line-linked-wins-regression', receipt_line_text: 'Gekoppelde kandidaat regressietest', retailer_code: 'lidl', retailer_article_number: '12345', gtin: '', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-linked-lower-score', candidate_name: 'Gekoppelde lagere score', candidate_brand: 'Testmerk', external_source_name: 'Open Food Facts', external_source_product_code: 'LIDL-LINKED', variant: 'Standaard', score: 0.50, candidate_status: 'linked_to_catalog', is_linked_to_catalog: true, is_linkable_to_catalog: false },
     ]);
 
     const receiptTable = await openExternalDatabases(page);
@@ -178,17 +208,23 @@ test.describe('Externe databases frontend-regressie', () => {
     await expect(receiptRow).toBeVisible();
     await expect(receiptRow.locator('td').nth(4)).toHaveText('-');
     await expect(receiptRow.locator('td').nth(5)).toHaveText('-');
+    await expect(receiptRow.locator('td').nth(3).locator('input')).toBeChecked();
+    await expect(receiptRow.locator('td').nth(8)).toContainText('Gekoppelde lagere score');
     await receiptRow.dblclick();
-    const linkedCandidateRow = page.getByTestId('external-receipt-item-candidates-table').locator('tbody tr', { hasText: 'Gekoppelde lagere score' });
-    await expect(linkedCandidateRow).toBeVisible();
-    await expect(linkedCandidateRow).toContainText('LIDL-LINKED');
-    await expect(linkedCandidateRow).toContainText('Gekoppeld');
+    const candidateTable = page.getByTestId('external-receipt-item-candidates-table');
+    await expect(candidateTable).toBeVisible();
+    await expect(candidateTable).toContainText('Geen universele kandidaten met score 0,500 of hoger voor dit bonartikel.');
+    await expect(candidateTable.getByText('Gekoppelde lagere score')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Ontkoppel artikel', exact: true })).toBeDisabled();
     await expectNoConsoleErrors(consoleErrors);
   });
 
   test('Fallbackkandidaat is zichtbaar maar niet koppelbaar', async ({ page }) => {
     const consoleErrors = attachConsoleErrorCollector(page);
     await routeReceiptItems(page, [{
+      receipt_item_id: 'purchase-import-line:purchase-line-fallback-regression',
+      receipt_item_type: 'purchase_import_line',
+      receipt_item_source_id: 'purchase-line-fallback-regression',
       context_key: 'ctx-fallback-regression', receipt_line_id: 'receipt-line-fallback-regression', purchase_import_line_id: 'purchase-line-fallback-regression', receipt_line_text: 'Fallback kandidaat regressietest', retailer_code: 'lidl', retailer_article_number: '12345', gtin: '', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-fallback-regression', candidate_name: 'Fallback kandidaat', candidate_brand: '-', external_source_name: 'receipt_product_intent_fallback', external_source_product_code: 'fallback:creme-frache', variant: 'Geen externe match', score: 0.1, candidate_status: 'candidate', is_linked_to_catalog: false, is_linkable_to_catalog: true,
     }]);
 
@@ -199,10 +235,11 @@ test.describe('Externe databases frontend-regressie', () => {
     await expect(receiptRow.locator('td').nth(9)).toHaveText('-');
     await expect(receiptRow.locator('td').nth(10)).toHaveText('0');
     await receiptRow.dblclick();
-    const fallbackRow = page.getByTestId('external-receipt-item-candidates-table').locator('tbody tr', { hasText: 'Fallback kandidaat' });
-    await expect(fallbackRow).toBeVisible();
-    await expect(fallbackRow).toContainText('Geen externe match');
-    await expect(fallbackRow.locator('input[type="radio"]')).toBeDisabled();
+    const candidateTable = page.getByTestId('external-receipt-item-candidates-table');
+    await expect(candidateTable).toBeVisible();
+    await expect(candidateTable).toContainText('Geen universele kandidaten met score 0,500 of hoger voor dit bonartikel.');
+    await expect(candidateTable.getByText('Fallback kandidaat')).toHaveCount(0);
+    await expect(candidateTable.getByText('Geen externe match')).toHaveCount(0);
     await expect(page.getByRole('button', { name: 'Koppel artikel', exact: true })).toBeDisabled();
     await expectNoConsoleErrors(consoleErrors);
   });
@@ -210,15 +247,16 @@ test.describe('Externe databases frontend-regressie', () => {
   test('Catalogusfilter reset detailselectie als geselecteerde rij verdwijnt', async ({ page }) => {
     const consoleErrors = attachConsoleErrorCollector(page);
     await routeReceiptItems(page, [
-      { context_key: 'ctx-filter-linked', receipt_line_id: 'line-filter-linked', purchase_import_line_id: 'purchase-filter-linked', receipt_line_text: 'Gekoppeld filter product', retailer_code: 'lidl', retailer_article_number: 'LIDL-LINKED', gtin: '', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-filter-linked', candidate_name: 'Gekoppeld filter kandidaat', candidate_brand: '-', external_source_name: 'Open Food Facts', external_source_product_code: '8710000000001', variant: 'Standaard', score: 0.9, candidate_status: 'linked_to_catalog', is_linked_to_catalog: true, is_linkable_to_catalog: false, global_product_id: 'gp-filter-linked' },
-      { context_key: 'ctx-filter-unlinked', receipt_line_id: 'line-filter-unlinked', purchase_import_line_id: 'purchase-filter-unlinked', receipt_line_text: 'Niet gekoppeld filter product', retailer_code: 'lidl', retailer_article_number: 'LIDL-UNLINKED', gtin: '', quantity_label: '1 stuk', price: 1.45, candidate_id: 'candidate-filter-unlinked', candidate_name: 'Niet gekoppeld filter kandidaat', candidate_brand: '-', external_source_name: 'Open Food Facts', external_source_product_code: '8710000000002', variant: 'Standaard', score: 0.8, candidate_status: 'candidate', is_linked_to_catalog: false, is_linkable_to_catalog: true },
+      { receipt_item_id: 'purchase-import-line:purchase-filter-linked', receipt_item_type: 'purchase_import_line', receipt_item_source_id: 'purchase-filter-linked', context_key: 'ctx-filter-linked', receipt_line_id: 'line-filter-linked', purchase_import_line_id: 'purchase-filter-linked', receipt_line_text: 'Gekoppeld filter product', retailer_code: 'lidl', retailer_article_number: 'LIDL-LINKED', gtin: '', quantity_label: '1 stuk', price: 1.23, candidate_id: 'candidate-filter-linked', candidate_name: 'Gekoppeld filter kandidaat', candidate_brand: '-', external_source_name: 'Open Food Facts', external_source_product_code: '8710000000001', variant: 'Standaard', score: 0.9, candidate_status: 'linked_to_catalog', is_linked_to_catalog: true, is_linkable_to_catalog: false, global_product_id: 'gp-filter-linked' },
+      { receipt_item_id: 'purchase-import-line:purchase-filter-unlinked', receipt_item_type: 'purchase_import_line', receipt_item_source_id: 'purchase-filter-unlinked', context_key: 'ctx-filter-unlinked', receipt_line_id: 'line-filter-unlinked', purchase_import_line_id: 'purchase-filter-unlinked', receipt_line_text: 'Niet gekoppeld filter product', retailer_code: 'lidl', retailer_article_number: 'LIDL-UNLINKED', gtin: '', quantity_label: '1 stuk', price: 1.45, candidate_id: 'candidate-filter-unlinked', candidate_name: 'Niet gekoppeld filter kandidaat', candidate_brand: '-', external_source_name: 'Open Food Facts', external_source_product_code: '8710000000002', variant: 'Standaard', score: 0.8, candidate_status: 'candidate', is_linked_to_catalog: false, is_linkable_to_catalog: true },
     ]);
 
     const receiptTable = await openExternalDatabases(page);
     const unlinkedRow = receiptTable.locator('tbody tr', { hasText: 'Niet gekoppeld filter product' });
     await expect(unlinkedRow).toBeVisible();
     await unlinkedRow.dblclick();
-    await expect(page.getByTestId('external-receipt-item-candidates-table')).toContainText('Niet gekoppeld filter kandidaat');
+    await expect(page.getByText('Universele kandidaten voor: Niet gekoppeld filter product')).toBeVisible();
+    await expect(page.getByTestId('external-receipt-item-candidates-table')).toContainText('Geen universele kandidaten met score 0,500 of hoger voor dit bonartikel.');
     await receiptTable.locator('select').first().selectOption('linked');
     await expect(receiptTable.locator('tbody tr', { hasText: 'Gekoppeld filter product' })).toBeVisible();
     await expect(receiptTable.locator('tbody tr', { hasText: 'Niet gekoppeld filter product' })).toHaveCount(0);

--- a/frontend/tests/e2e/product-groups.frontend-regression.spec.js
+++ b/frontend/tests/e2e/product-groups.frontend-regression.spec.js
@@ -69,34 +69,35 @@ test.describe('Productgroepen frontend-regressie', () => {
     await expect(table).toContainText('Mosterd fijne Dijon extra lange artikelnaam');
     await expect(table).toContainText('Boormachine met zeer lange artikelnaam');
 
-    await expect(page.getByLabel('Hoofdgroep voor Mosterd fijne Dijon extra lange artikelnaam')).toBeVisible();
-    await expect(page.getByLabel('Groep voor Mosterd fijne Dijon extra lange artikelnaam')).toBeVisible();
-    await expect(page.getByLabel('Productgroep voor Mosterd fijne Dijon extra lange artikelnaam')).toBeVisible();
+    await expect(page.getByLabel('Hoofdgroep voor Mosterd fijne Dijon extra lange artikelnaam', { exact: true })).toBeVisible();
+    await expect(page.getByLabel('Groep voor Mosterd fijne Dijon extra lange artikelnaam', { exact: true })).toBeVisible();
+    await expect(page.getByLabel('Productgroep voor Mosterd fijne Dijon extra lange artikelnaam', { exact: true })).toBeVisible();
 
     await page.getByLabel('Zoek artikel').fill('boor');
     await expect(table).toContainText('Boormachine met zeer lange artikelnaam');
     await expect(table).not.toContainText('Mosterd fijne Dijon extra lange artikelnaam');
     await page.getByLabel('Zoek artikel').fill('');
 
-    await page.getByLabel('Hoofdgroep voor Boormachine met zeer lange artikelnaam').selectOption('Voeding');
-    await page.getByLabel('Groep voor Boormachine met zeer lange artikelnaam').selectOption('Sauzen');
-    await page.getByLabel('Productgroep voor Boormachine met zeer lange artikelnaam').selectOption('gpc:10000001');
-    await page.getByRole('button', { name: 'Bevestigen' }).click();
+    await page.getByLabel('Hoofdgroep voor Boormachine met zeer lange artikelnaam', { exact: true }).selectOption('Voeding');
+    await page.getByLabel('Groep voor Boormachine met zeer lange artikelnaam', { exact: true }).selectOption('Sauzen');
+    await page.getByLabel('Productgroep voor Boormachine met zeer lange artikelnaam', { exact: true }).selectOption('gpc:10000001');
+    const boormachineRow = table.getByRole('row', { name: /Boormachine met zeer lange artikelnaam/ });
+    await boormachineRow.getByRole('button', { name: 'Bevestigen', exact: true }).click();
     await expect(page.getByTestId('product-groups-feedback-success')).toContainText('Artikel is aan de productgroep toegevoegd.');
     await page.getByTestId('product-groups-feedback-success-ok-button').click();
 
-    await expect(page.getByLabel('Bestaande productgroep')).toBeVisible();
-    await expect(page.getByLabel('Hoofdgroep beheren')).toBeVisible();
-    await expect(page.getByLabel('Groep beheren')).toBeVisible();
-    await expect(page.getByLabel('Productgroepnaam')).toBeVisible();
-    await expect(page.getByLabel('Eenheid productgroep')).toHaveCount(0);
+    await expect(page.getByLabel('Bestaande productgroep', { exact: true })).toBeVisible();
+    await expect(page.getByLabel('Hoofdgroep beheren', { exact: true })).toBeVisible();
+    await expect(page.getByLabel('Groep beheren', { exact: true })).toBeVisible();
+    await expect(page.getByLabel('Productgroepnaam', { exact: true })).toBeVisible();
+    await expect(page.getByLabel('Eenheid productgroep', { exact: true })).toHaveCount(0);
     await expect(page.getByRole('button', { name: 'Toevoegen' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Bijwerken' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Verwijderen' })).toBeVisible();
 
-    await page.getByLabel('Hoofdgroep beheren').fill('Voeding');
-    await page.getByLabel('Groep beheren').fill('Soepen');
-    await page.getByLabel('Productgroepnaam').fill('Soep');
+    await page.getByLabel('Hoofdgroep beheren', { exact: true }).fill('Voeding');
+    await page.getByLabel('Groep beheren', { exact: true }).fill('Soepen');
+    await page.getByLabel('Productgroepnaam', { exact: true }).fill('Soep');
     await page.getByRole('button', { name: 'Toevoegen' }).click();
     await expect(page.getByTestId('product-groups-feedback-success')).toContainText('Productgroep is toegevoegd.');
     await page.getByTestId('product-groups-feedback-success-ok-button').click();

--- a/frontend/tests/e2e/settings-article-groups.frontend-regression.spec.js
+++ b/frontend/tests/e2e/settings-article-groups.frontend-regression.spec.js
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+import {
+  attachConsoleErrorCollector,
+  expectNoConsoleErrors,
+} from './helpers/rezzervAssertions.js';
+
+test.describe('Instellingen Artikelgroepen frontend-regressie', () => {
+  test('Universele artikelnaam blijft zichtbaar en bulktoewijzing wordt opgeslagen', async ({ page }) => {
+    const consoleErrors = attachConsoleErrorCollector(page);
+    const universalArticleName = 'Mosterd fijne Dijon extra lange universele artikelnaam';
+    let assignedGroupId = null;
+    let assignmentPayload = null;
+
+    const groups = [
+      { id: 'group-sauzen', name: 'Sauzen' },
+      { id: 'group-kruiden', name: 'Kruiden en smaakmakers' },
+    ];
+
+    await page.route('**/api/article-groups?household_id=*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, items: groups }),
+      });
+    });
+
+    await page.route('**/api/article-groups/household-articles?household_id=*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          items: [
+            {
+              id: 'household-article-mosterd',
+              article_name: universalArticleName,
+              article_group_id: assignedGroupId,
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.route('**/api/household-articles/household-article-mosterd/article-group', async (route) => {
+      assignmentPayload = JSON.parse(route.request().postData() || '{}');
+      assignedGroupId = assignmentPayload.article_group_id || null;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          household_article_id: 'household-article-mosterd',
+          article_group_id: assignedGroupId,
+        }),
+      });
+    });
+
+    await page.goto('/instellingen/artikelgroepen');
+
+    await expect(page).toHaveURL(/\/instellingen\/artikelgroepen$/);
+    await expect(page.getByTestId('settings-article-groups-page')).toBeVisible();
+    await expect(page.getByText(universalArticleName, { exact: true })).toBeVisible();
+
+    await page.getByLabel('Filter op artikel', { exact: true }).fill('dijon');
+    await expect(page.getByText(universalArticleName, { exact: true })).toBeVisible();
+    await page.getByLabel('Filter op artikel', { exact: true }).fill('');
+
+    await page.getByLabel(`Selecteer ${universalArticleName}`, { exact: true }).check();
+    await page.getByRole('button', { name: 'Toewijzen aan artikelgroep', exact: true }).click();
+
+    const assignDialog = page.getByRole('dialog', { name: 'Toewijzen aan artikelgroep' });
+    await expect(assignDialog).toBeVisible();
+    await assignDialog.locator('select').selectOption('group-sauzen');
+    await assignDialog.getByRole('button', { name: 'Toewijzen', exact: true }).click();
+
+    const confirmDialog = page.getByRole('dialog', { name: 'Bevestiging' });
+    await expect(confirmDialog).toContainText('Sauzen');
+    await confirmDialog.getByRole('button', { name: 'Opslaan', exact: true }).click();
+
+    await expect.poll(() => assignmentPayload).toEqual({
+      household_id: '1',
+      article_group_id: 'group-sauzen',
+    });
+    await expect(page.getByText(/1 voorraadartikel toegewezen aan Artikelgroep Sauzen\./)).toBeVisible();
+    await expect(page.getByLabel(`Artikelgroep ${universalArticleName}`, { exact: true })).toHaveValue('group-sauzen');
+
+    await expectNoConsoleErrors(consoleErrors);
+  });
+});

--- a/frontend/tests/e2e/uitpakken.frontend-regression.spec.js
+++ b/frontend/tests/e2e/uitpakken.frontend-regression.spec.js
@@ -79,4 +79,110 @@ test.describe('Uitpakken frontend-regressie', () => {
 
     await expectNoConsoleErrors(consoleErrors);
   });
+
+  test('Universele artikelnaam blijft in Uitpakken gekoppeld en bontekst blijft alleen bontekst', async ({ page }) => {
+    const consoleErrors = attachConsoleErrorCollector(page);
+    const batchId = 'universal-name-regression';
+    const lineId = 'line-universal-mosterd';
+    const universalArticleName = 'Mosterd fijne Dijon extra lange universele artikelnaam';
+    const receiptArticleText = 'MOSTERD DIJON 250G';
+
+    await page.route('**/api/household', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: '1',
+          is_viewer: false,
+          permissions: { 'article.create': true },
+          store_import_simplification_level: 'gebalanceerd',
+        }),
+      });
+    });
+
+    await page.route('**/api/store-providers', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ code: 'lidl', name: 'Lidl' }]),
+      });
+    });
+
+    await page.route('**/api/store-review-articles', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'household-article-mosterd',
+            name: universalArticleName,
+            article_name: universalArticleName,
+            label: universalArticleName,
+          },
+        ]),
+      });
+    });
+
+    await page.route('**/api/spaces*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [] }),
+      });
+    });
+
+    await page.route('**/api/sublocations*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [] }),
+      });
+    });
+
+    await page.route(`**/api/purchase-import-batches/${batchId}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          batch_id: batchId,
+          store_provider_code: 'lidl',
+          store_label: 'Lidl',
+          purchase_date: '2026-07-17',
+          import_status: 'review',
+          lines: [
+            {
+              id: lineId,
+              article_name_raw: receiptArticleText,
+              quantity_raw: 1,
+              unit_raw: 'stuk',
+              matched_household_article_id: 'household-article-mosterd',
+              suggested_household_article_id: 'household-article-mosterd',
+              resolved_household_article_name: universalArticleName,
+              target_location_id: '',
+              processing_status: 'pending',
+              review_decision: 'pending',
+              match_status: 'matched',
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.goto(`/kassabonnen/batch/${batchId}`);
+
+    await expect(page).toHaveURL(new RegExp(`/kassabonnen/batch/${batchId}$`));
+    const row = page.getByTestId(`receipt-line-${lineId}`);
+    await expect(row).toBeVisible();
+
+    const linkedArticleCell = page.getByTestId(`receipt-line-article-select-${lineId}`);
+    await expect(linkedArticleCell).toContainText(universalArticleName);
+    await expect(linkedArticleCell).not.toContainText(receiptArticleText);
+
+    const bonArticleCell = row.locator('.rz-store-batch-col-item');
+    await expect(bonArticleCell).toContainText('Mosterd Dijon 250g');
+    await expect(bonArticleCell).not.toContainText(universalArticleName);
+
+    await expectNoConsoleErrors(consoleErrors);
+  });
+
 });

--- a/scripts/run-frontend-regression-report.ps1
+++ b/scripts/run-frontend-regression-report.ps1
@@ -4,7 +4,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-Write-Host "=== Rezzerv frontend regressie: Kassa + Uitpakken ===" -ForegroundColor Cyan
+Write-Host "=== Rezzerv centrale frontendregressie ===" -ForegroundColor Cyan
 
 function Invoke-RegressionFixtureCleanup {
   param(
@@ -72,7 +72,12 @@ try {
     "tests/e2e/uitpakken.frontend-regression.spec.js",
     "tests/e2e/external-databases.frontend-regression.spec.js",
     "tests/e2e/external-databases-off.frontend-regression.spec.js",
-    "tests/e2e/external-databases-unlink.frontend-regression.spec.js"
+    "tests/e2e/external-databases-unlink.frontend-regression.spec.js",
+    "tests/e2e/external-databases-known-gtin.frontend-regression.spec.js",
+    "tests/e2e/external-databases-no-redundant-buttons.frontend-regression.spec.js",
+    "tests/e2e/product-groups.frontend-regression.spec.js",
+    "tests/e2e/settings-article-groups.frontend-regression.spec.js",
+    "tests/e2e/article-detail.frontend-regression.spec.js"
   ) -join " "
 
   docker run --rm `


### PR DESCRIPTION
Fase 2B-1 implementatie Artikelgroepen.

Status na aanvullende bulktoewijzing:
- PR blijft draft tot lokale validatie en PO-check opnieuw akkoord zijn
- Artikelgroepen-functionaliteit is technisch aanwezig
- Beheerpagina Artikelgroepen is gecorrigeerd richting Locaties-patroon
- Kolombreedte-aanpassing is expliciet toegevoegd via ResizableHeaderCell en useResizableColumnWidths
- Bulktoewijzing van meerdere voorraadartikelen aan één Artikelgroep is toegevoegd
- Componenthergebruik is aangescherpt: AppShell, Card, Button, Table, buildTableWidth, ResizableHeaderCell, useResizableColumnWidths, bestaande modal-/actiepatronen

Wijzigingen:
- nieuwe backend service voor Artikelgroepen per huishouden
- nieuwe API routes voor Artikelgroepen beheren
- optionele koppeling household_articles.article_group_id
- lege startset, dus Rezzerv maakt geen standaard Artikelgroepen aan
- hard delete als ongebruikt; in gebruik betekent deactiveren
- nieuwe Instellingen-tegel Artikelgroepen
- nieuwe route /instellingen/artikelgroepen
- beheerpagina voor groepen aanmaken, hernoemen en verwijderen/deactiveren
- handmatige koppeling van huishoudelijke artikelen aan Artikelgroepen via de beheerpagina
- bulkknop Toewijzen aan artikelgroep voor geselecteerde voorraadartikelen
- Voorraad-tabel toont Artikelgroep als contextkolom
- Voorraad toont artikelen zonder groep als Niet ingedeeld

Architectuurcorrectie:
- Artikelgroepen-beheerpagina is gelijkgetrokken met Locaties in opbouw: AppShell + Card, twee beheer-secties, standaard Table, filterrijen, selectie-checkboxen, actieknoppen onder tabellen, feedbackmodal en pending-changes-bewaking.
- Gewone html-table voor artikelkoppelingen is vervangen door het Rezzerv Table-patroon.
- Losse bovenaan-input voor toevoegen is verwijderd; toevoegen loopt via actieknop onder de tabel en modal.
- Lege Artikelgroepen-toestand blijft binnen de tabelstructuur.
- Kolommen in beide tabellen zijn door de gebruiker in breedte aan te passen.
- Bulktoewijzing gebruikt hetzelfde modal- en pending-changes-patroon: selectie zetten, Artikelgroep kiezen, daarna Wijzigingen opslaan.

Bewust niet gewijzigd:
- geen automatische suggesties
- geen automatische aanmaak of toekenning
- geen Uitpakken-mutaties
- geen externe-database-effecten
- geen wijziging aan productgroepen, global product of GTIN
- technische household_article identiteit blijft bestaan

Validatie lokaal tot nu toe:
- diff check na vorige refactor: akkoord
- backend compileall na vorige refactor: akkoord
- lokale npm install/build buiten Docker: niet bruikbaar door bekende npm/Node 25-storing
- Docker frontend regressie na basisimplementatie: groen, 15 van 15 Playwright tests passed
- Docker frontend regressie na Voorraad-kolom Artikelgroep: groen, 15 van 15 Playwright tests passed
- Docker frontend regressie na vorige Artikelgroepen-refactor: groen, 15 van 15 Playwright tests passed
- regressie fixture cleanup: ok
- Voorraad-kolomcommit gepusht: f9c17dc9
- architectuurrefactor Artikelgroepen-pagina gepusht: 9037c93b
- aanvullende resizable/table-correctie gepusht: f1d39884
- bulktoewijzing voorraadartikelen gepusht: 6cffedc

Nog te doen vóór merge:
- lokale branch bijwerken
- diff check na bulktoewijzing
- backend compileall na bulktoewijzing
- Docker frontend-regressie na bulktoewijzing
- PO-check: Artikelgroepenbeheer visueel/functioneel vergelijken met Locaties
- PO-check: kolombreedtes in beide tabellen aanpassen
- PO-check: meerdere voorraadartikelen selecteren en via Toewijzen aan artikelgroep koppelen
- PO-check: bulktoewijzing pas definitief na Wijzigingen opslaan