### PR TITLE
Implementeer Producttype-koppeling voor OFF-resultaten

### DIFF
--- a/backend/app/api/product_inventory_group_routes.py
+++ b/backend/app/api/product_inventory_group_routes.py
@@ -5,6 +5,8 @@ from typing import Any
 from fastapi import APIRouter, Body, Header, HTTPException, Query
 
 from app.services.gpc_import_service import import_gs1_gpc_nl, require_admin_key
+from app.services.external_product_candidate_store import promote_external_product_candidate_with_product_type
+from app.services.off_product_link_service import link_off_product_with_product_type
 from app.services.product_group_crud_store import (
     create_product_group,
     delete_product_group,
@@ -103,6 +105,40 @@ def product_inventory_group_link(global_product_id: str, payload: dict[str, Any]
     )
     if not bool(result.get('ok', False)):
         raise HTTPException(status_code=400, detail=result.get('error') or 'Voorraadgroep kon niet worden gekoppeld')
+    return result
+
+
+@router.post('/api/external-databases/catalog/promote-candidate-with-product-type')
+def external_candidate_product_type_link(payload: dict[str, Any] = Body(default_factory=dict)):
+    assignment = payload.get('product_type_assignment')
+    if not isinstance(assignment, dict):
+        raise HTTPException(status_code=400, detail='Producttypebeslissing is verplicht')
+    try:
+        result = promote_external_product_candidate_with_product_type(
+            candidate_id=str(payload.get('candidate_id') or '').strip(),
+            product_type_assignment=assignment,
+            force_overwrite=bool(payload.get('force_overwrite', False)),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if not bool(result.get('ok', False)):
+        raise HTTPException(status_code=400, detail=result.get('error') or result.get('reason') or 'Koppeling kon niet worden opgeslagen')
+    return result
+
+
+@router.post('/api/external-products/off/link')
+def external_off_product_type_link(payload: dict[str, Any] = Body(default_factory=dict)):
+    assignment = payload.get('product_type_assignment')
+    if not isinstance(assignment, dict):
+        raise HTTPException(status_code=400, detail='Producttypebeslissing is verplicht')
+    try:
+        result = link_off_product_with_product_type(
+            receipt_item_id=str(payload.get('receipt_item_id') or '').strip(),
+            off_product=payload.get('off_product') or {},
+            product_type_assignment=assignment,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return result
 
 

--- a/backend/app/services/external_product_candidate_store.py
+++ b/backend/app/services/external_product_candidate_store.py
@@ -1790,3 +1790,129 @@ def promote_external_product_candidate(candidate_id: str, force_overwrite: bool 
         "candidate_id": normalized_candidate_id,
         "context_key": context_key,
     }
+
+
+
+def promote_external_product_candidate_with_product_type(
+    candidate_id: str,
+    *,
+    product_type_assignment: dict[str, Any],
+    force_overwrite: bool = False,
+) -> dict[str, Any]:
+    """Koppel kandidaat en Producttype atomair, zonder voorraadmutatie."""
+    from app.services.product_inventory_group_store import (
+        create_or_get_product_type_with_connection,
+        ensure_product_inventory_group_schema,
+        link_global_product_to_inventory_group_with_connection,
+    )
+
+    normalized_candidate_id = str(candidate_id or "").strip()
+    if not normalized_candidate_id:
+        return {"ok": False, "promoted": False, "reason": "missing_candidate_id"}
+    if not isinstance(product_type_assignment, dict):
+        return {"ok": False, "promoted": False, "reason": "product_type_assignment_required"}
+
+    ensure_product_inventory_group_schema()
+    with engine.begin() as conn:
+        candidate = conn.execute(text("""
+            SELECT * FROM external_product_candidates
+            WHERE id = :candidate_id
+            LIMIT 1
+        """), {"candidate_id": normalized_candidate_id}).mappings().first()
+        if not candidate:
+            return {"ok": False, "promoted": False, "reason": "candidate_not_found"}
+
+        candidate_dict = dict(candidate)
+        context_key = str(candidate_dict.get("context_key") or "").strip()
+        if not context_key:
+            return {"ok": False, "promoted": False, "reason": "missing_context_key"}
+
+        linked_rows = conn.execute(text("""
+            SELECT id
+            FROM external_product_candidates
+            WHERE context_key = :context_key
+              AND id <> :candidate_id
+              AND (
+                candidate_status IN ('linked_to_catalog', 'user_confirmed')
+                OR status IN ('linked_to_catalog', 'user_confirmed')
+                OR is_user_confirmed = 1
+                OR is_external_database_override = 1
+              )
+        """), {
+            "context_key": context_key,
+            "candidate_id": normalized_candidate_id,
+        }).mappings().all()
+        if linked_rows and not force_overwrite:
+            return {
+                "ok": True,
+                "promoted": False,
+                "requires_overwrite": True,
+                "existing_link_count": len(linked_rows),
+                "candidate_id": normalized_candidate_id,
+                "context_key": context_key,
+            }
+
+        create_payload = product_type_assignment.get("create")
+        product_type_id = str(product_type_assignment.get("product_type_id") or "").strip()
+        if isinstance(create_payload, dict):
+            type_result = create_or_get_product_type_with_connection(
+                conn,
+                inventory_group_key=str(create_payload.get("inventory_group_key") or "").strip() or None,
+                display_name=str(create_payload.get("canonical_name") or create_payload.get("display_name") or "").strip(),
+                default_base_unit=str(create_payload.get("base_unit") or create_payload.get("default_base_unit") or "stuk").strip(),
+                aggregation_mode=str(create_payload.get("aggregation_mode") or "count").strip(),
+                source=str(product_type_assignment.get("mapping_source") or "user_created_during_link").strip(),
+            )
+            if not type_result.get("ok"):
+                return {"ok": False, "promoted": False, "reason": "invalid_product_type", "error": type_result.get("error")}
+            product_type_id = str((type_result.get("product_type") or {}).get("inventory_group_key") or "").strip()
+        if not product_type_id:
+            return {"ok": False, "promoted": False, "reason": "product_type_required"}
+
+        global_product_id = _m2c2i_fix7b_create_or_reuse_catalog_product_for_candidate(conn, candidate_dict)
+        if not global_product_id:
+            raise RuntimeError("Universeel artikel kon niet worden aangemaakt of hergebruikt")
+
+        membership = link_global_product_to_inventory_group_with_connection(
+            conn,
+            global_product_id=global_product_id,
+            inventory_group_key=product_type_id,
+            comparison_group_key=product_type_id,
+            confidence=float(product_type_assignment.get("confidence_score") or 1.0),
+            source=str(product_type_assignment.get("mapping_source") or "user_confirmed_external_suggestion").strip(),
+            confirmed_by_user=True,
+        )
+        if not membership.get("ok"):
+            raise ValueError(str(membership.get("error") or "Producttype kon niet worden gekoppeld"))
+
+        conn.execute(text("""
+            UPDATE external_product_candidates
+            SET candidate_status = 'candidate', status = 'candidate',
+                is_user_confirmed = 0, is_external_database_override = 0,
+                global_product_id = NULL, updated_at = CURRENT_TIMESTAMP
+            WHERE context_key = :context_key AND id <> :candidate_id
+        """), {"context_key": context_key, "candidate_id": normalized_candidate_id})
+        conn.execute(text("""
+            UPDATE external_product_candidates
+            SET candidate_status = 'linked_to_catalog', status = 'linked_to_catalog',
+                global_product_id = :global_product_id,
+                is_user_confirmed = 1, is_external_database_override = 0,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = :candidate_id
+        """), {"candidate_id": normalized_candidate_id, "global_product_id": global_product_id})
+
+    return {
+        "ok": True,
+        "promoted": True,
+        "requires_overwrite": False,
+        "candidate_id": normalized_candidate_id,
+        "context_key": context_key,
+        "global_product_id": global_product_id,
+        "product_type": {
+            "inventory_group_key": product_type_id,
+            "confirmed_by_user": True,
+        },
+        "membership_id": membership.get("membership_id"),
+        "creates_inventory_event": False,
+        "mutates_inventory": False,
+    }

--- a/backend/app/services/off_product_link_service.py
+++ b/backend/app/services/off_product_link_service.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+import re
+import uuid
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db import engine
+from app.services.product_inventory_group_store import (
+    create_or_get_product_type_with_connection,
+    ensure_product_inventory_group_schema,
+    link_global_product_to_inventory_group_with_connection,
+)
+
+
+_GTIN_PATTERN = re.compile(r"^[0-9]{8,14}$")
+_QUANTITY_PATTERN = re.compile(
+    r"(?:(?P<count>[0-9]+)\s*[x×]\s*)?"
+    r"(?P<value>[0-9]+(?:[\.,][0-9]+)?)\s*"
+    r"(?P<unit>ml|cl|dl|l|mg|g|kg|st(?:uk)?s?)\b",
+    re.IGNORECASE,
+)
+
+
+def _clean_text(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+def _normalize_gtin(value: Any) -> str:
+    gtin = re.sub(r"\D+", "", str(value or ""))
+    if not _GTIN_PATTERN.fullmatch(gtin):
+        raise ValueError("OFF-product bevat geen geldige GTIN van 8 tot en met 14 cijfers")
+    return gtin
+
+
+def _parse_quantity_label(value: Any) -> tuple[float | None, str | None]:
+    label = _clean_text(value).lower()
+    if not label:
+        return None, None
+    match = _QUANTITY_PATTERN.search(label)
+    if not match:
+        return None, None
+    try:
+        count = Decimal(match.group("count") or "1")
+        amount = Decimal(match.group("value").replace(",", ".")) * count
+    except InvalidOperation:
+        return None, None
+    unit = match.group("unit").lower()
+    aliases = {"st": "stuk", "stuks": "stuk", "stuks": "stuk"}
+    return float(amount), aliases.get(unit, unit)
+
+
+def _table_columns(conn, table_name: str) -> set[str]:
+    dialect = str(engine.dialect.name or "").lower()
+    if dialect == "sqlite":
+        rows = conn.execute(text(f'PRAGMA table_info("{table_name}")')).mappings().all()
+        return {str(row.get("name") or "") for row in rows}
+    rows = conn.execute(
+        text("SELECT column_name FROM information_schema.columns WHERE table_name = :table_name"),
+        {"table_name": table_name},
+    ).mappings().all()
+    return {str(row.get("column_name") or "") for row in rows}
+
+
+def _table_exists(conn, table_name: str) -> bool:
+    dialect = str(engine.dialect.name or "").lower()
+    if dialect == "sqlite":
+        return bool(
+            conn.execute(
+                text("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = :name LIMIT 1"),
+                {"name": table_name},
+            ).scalar()
+        )
+    return bool(
+        conn.execute(
+            text("SELECT 1 FROM information_schema.tables WHERE table_name = :name LIMIT 1"),
+            {"name": table_name},
+        ).scalar()
+    )
+
+
+def _upsert_global_product(conn, off_product: dict[str, Any]) -> tuple[str, str, float | None, str | None]:
+    gtin = _normalize_gtin(
+        off_product.get("gtin")
+        or off_product.get("code")
+        or off_product.get("ean")
+        or off_product.get("source_product_code")
+    )
+    product_name = _clean_text(
+        off_product.get("product_name")
+        or off_product.get("candidate_name")
+        or off_product.get("name")
+    )
+    if not product_name:
+        raise ValueError("OFF-productnaam is verplicht")
+
+    brand = _clean_text(off_product.get("brand") or off_product.get("candidate_brand")) or None
+    category = _clean_text(
+        off_product.get("category")
+        or off_product.get("candidate_category")
+        or off_product.get("categories")
+    ) or None
+    quantity_label = _clean_text(
+        off_product.get("quantity")
+        or off_product.get("quantity_label")
+        or off_product.get("net_content")
+    )
+    size_value, size_unit = _parse_quantity_label(quantity_label)
+
+    existing = conn.execute(
+        text("SELECT id FROM global_products WHERE primary_gtin = :gtin LIMIT 1"),
+        {"gtin": gtin},
+    ).mappings().first()
+
+    if existing:
+        global_product_id = str(existing.get("id"))
+        conn.execute(
+            text(
+                """
+                UPDATE global_products
+                SET name = :name,
+                    brand = COALESCE(:brand, brand),
+                    category = COALESCE(:category, category),
+                    size_value = COALESCE(:size_value, size_value),
+                    size_unit = COALESCE(:size_unit, size_unit),
+                    source = 'open_food_facts',
+                    status = 'active',
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE id = :id
+                """
+            ),
+            {
+                "id": global_product_id,
+                "name": product_name,
+                "brand": brand,
+                "category": category,
+                "size_value": size_value,
+                "size_unit": size_unit,
+            },
+        )
+    else:
+        global_product_id = str(uuid.uuid4())
+        conn.execute(
+            text(
+                """
+                INSERT INTO global_products (
+                    id, primary_gtin, name, brand, variant, category,
+                    size_value, size_unit, source, status, created_at, updated_at
+                ) VALUES (
+                    :id, :gtin, :name, :brand, :variant, :category,
+                    :size_value, :size_unit, 'open_food_facts', 'active',
+                    CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                )
+                """
+            ),
+            {
+                "id": global_product_id,
+                "gtin": gtin,
+                "name": product_name,
+                "brand": brand,
+                "variant": _clean_text(off_product.get("variant")) or None,
+                "category": category,
+                "size_value": size_value,
+                "size_unit": size_unit,
+            },
+        )
+
+    identity = conn.execute(
+        text(
+            """
+            SELECT id, global_product_id
+            FROM product_identities
+            WHERE identity_type = 'gtin' AND identity_value = :gtin
+            LIMIT 1
+            """
+        ),
+        {"gtin": gtin},
+    ).mappings().first()
+    if identity and str(identity.get("global_product_id") or "").strip() not in {"", global_product_id}:
+        raise ValueError("GTIN is al aan een ander universeel artikel gekoppeld")
+    if identity:
+        conn.execute(
+            text(
+                """
+                UPDATE product_identities
+                SET global_product_id = :global_product_id,
+                    source = 'open_food_facts', confidence_score = 1.0,
+                    is_primary = 1, updated_at = CURRENT_TIMESTAMP
+                WHERE id = :id
+                """
+            ),
+            {"id": identity.get("id"), "global_product_id": global_product_id},
+        )
+    else:
+        conn.execute(
+            text(
+                """
+                INSERT INTO product_identities (
+                    id, household_article_id, global_product_id,
+                    identity_type, identity_value, source,
+                    confidence_score, is_primary, created_at, updated_at
+                ) VALUES (
+                    :id, '', :global_product_id,
+                    'gtin', :gtin, 'open_food_facts',
+                    1.0, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                )
+                """
+            ),
+            {"id": str(uuid.uuid4()), "global_product_id": global_product_id, "gtin": gtin},
+        )
+    return global_product_id, gtin, size_value, size_unit
+
+
+def _resolve_product_type(conn, assignment: dict[str, Any]) -> str:
+    if not isinstance(assignment, dict):
+        raise ValueError("Producttypebeslissing is verplicht")
+    create_payload = assignment.get("create")
+    product_type_id = _clean_text(assignment.get("product_type_id"))
+    if isinstance(create_payload, dict):
+        result = create_or_get_product_type_with_connection(
+            conn,
+            inventory_group_key=_clean_text(create_payload.get("inventory_group_key")) or None,
+            display_name=_clean_text(
+                create_payload.get("canonical_name") or create_payload.get("display_name")
+            ),
+            default_base_unit=_clean_text(
+                create_payload.get("base_unit") or create_payload.get("default_base_unit") or "stuk"
+            ),
+            aggregation_mode=_clean_text(create_payload.get("aggregation_mode") or "count"),
+            source=_clean_text(assignment.get("mapping_source") or "user_created_during_off_link"),
+        )
+        if not result.get("ok"):
+            raise ValueError(str(result.get("error") or "Producttype kon niet worden aangemaakt"))
+        product_type_id = _clean_text((result.get("product_type") or {}).get("inventory_group_key"))
+    if not product_type_id:
+        raise ValueError("Producttype is verplicht")
+    return product_type_id
+
+
+def _link_household_article(conn, household_article_id: Any, global_product_id: str) -> str | None:
+    article_id = _clean_text(household_article_id)
+    if not article_id or article_id.startswith("live::"):
+        return None
+    article = conn.execute(
+        text("SELECT id, global_product_id FROM household_articles WHERE id = :id LIMIT 1"),
+        {"id": article_id},
+    ).mappings().first()
+    if not article:
+        return None
+    current = _clean_text(article.get("global_product_id"))
+    if current and current != global_product_id:
+        raise ValueError("Het voorraadartikel is al aan een ander universeel artikel gekoppeld")
+    conn.execute(
+        text(
+            """
+            UPDATE household_articles
+            SET global_product_id = :global_product_id, updated_at = CURRENT_TIMESTAMP
+            WHERE id = :id
+            """
+        ),
+        {"id": article_id, "global_product_id": global_product_id},
+    )
+    return article_id
+
+
+def _link_receipt_item(conn, receipt_item_id: str, global_product_id: str) -> dict[str, Any]:
+    normalized = _clean_text(receipt_item_id)
+    if ":" not in normalized:
+        raise ValueError("receipt_item_id heeft geen geldige canonieke prefix")
+    prefix, source_id = normalized.split(":", 1)
+    source_id = _clean_text(source_id)
+    if not source_id:
+        raise ValueError("receipt_item_id bevat geen bron-ID")
+
+    if prefix == "purchase-import-line":
+        row = conn.execute(
+            text(
+                """
+                SELECT id, matched_household_article_id
+                FROM purchase_import_lines WHERE id = :id LIMIT 1
+                """
+            ),
+            {"id": source_id},
+        ).mappings().first()
+        if not row:
+            raise ValueError("Purchase-importregel niet gevonden")
+        conn.execute(
+            text(
+                """
+                UPDATE purchase_import_lines
+                SET matched_global_product_id = :global_product_id,
+                    match_status = 'matched', updated_at = CURRENT_TIMESTAMP
+                WHERE id = :id
+                """
+            ),
+            {"id": source_id, "global_product_id": global_product_id},
+        )
+        article_id = _link_household_article(conn, row.get("matched_household_article_id"), global_product_id)
+        return {"receipt_item_type": "purchase_import_line", "source_id": source_id, "household_article_id": article_id}
+
+    if prefix == "receipt-table-line":
+        row = conn.execute(
+            text("SELECT id, matched_article_id FROM receipt_table_lines WHERE id = :id LIMIT 1"),
+            {"id": source_id},
+        ).mappings().first()
+        if not row:
+            raise ValueError("Bonregel niet gevonden")
+        conn.execute(
+            text(
+                """
+                UPDATE receipt_table_lines
+                SET matched_global_product_id = :global_product_id,
+                    article_match_status = CASE
+                        WHEN COALESCE(matched_article_id, '') <> '' THEN 'matched'
+                        ELSE 'product_matched'
+                    END,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE id = :id
+                """
+            ),
+            {"id": source_id, "global_product_id": global_product_id},
+        )
+        article_id = _link_household_article(conn, row.get("matched_article_id"), global_product_id)
+        return {"receipt_item_type": "receipt_table_line", "source_id": source_id, "household_article_id": article_id}
+
+    if prefix == "receipt-line" and _table_exists(conn, "receipt_lines"):
+        columns = _table_columns(conn, "receipt_lines")
+        if "matched_global_product_id" not in columns:
+            raise ValueError("receipt_lines ondersteunt nog geen universeel-artikelkoppeling")
+        row = conn.execute(text("SELECT * FROM receipt_lines WHERE id = :id LIMIT 1"), {"id": source_id}).mappings().first()
+        if not row:
+            raise ValueError("Receiptregel niet gevonden")
+        conn.execute(
+            text("UPDATE receipt_lines SET matched_global_product_id = :global_product_id WHERE id = :id"),
+            {"id": source_id, "global_product_id": global_product_id},
+        )
+        article_id = _link_household_article(conn, row.get("matched_article_id"), global_product_id)
+        return {"receipt_item_type": "receipt_line", "source_id": source_id, "household_article_id": article_id}
+
+    raise ValueError(f"Niet-ondersteund receipt_item_id-type: {prefix}")
+
+
+def link_off_product_with_product_type(
+    *,
+    receipt_item_id: str,
+    off_product: dict[str, Any],
+    product_type_assignment: dict[str, Any],
+    force_failure_after_link: bool = False,
+) -> dict[str, Any]:
+    """Sla OFF-product, bronkoppeling en Producttype in één transactie op.
+
+    De functie schrijft niet naar external_product_candidates en muteert geen voorraad.
+    """
+    if not isinstance(off_product, dict):
+        raise ValueError("off_product is verplicht")
+
+    ensure_product_inventory_group_schema()
+    with engine.begin() as conn:
+        global_product_id, gtin, size_value, size_unit = _upsert_global_product(conn, off_product)
+        product_type_id = _resolve_product_type(conn, product_type_assignment)
+        membership = link_global_product_to_inventory_group_with_connection(
+            conn,
+            global_product_id=global_product_id,
+            inventory_group_key=product_type_id,
+            comparison_group_key=product_type_id,
+            confidence=float(product_type_assignment.get("confidence_score") or 1.0),
+            source=_clean_text(
+                product_type_assignment.get("mapping_source") or "user_confirmed_off_result"
+            ),
+            confirmed_by_user=True,
+        )
+        if not membership.get("ok"):
+            raise ValueError(str(membership.get("error") or "Producttype kon niet worden gekoppeld"))
+
+        receipt_link = _link_receipt_item(conn, receipt_item_id, global_product_id)
+        if force_failure_after_link:
+            raise RuntimeError("Geforceerde rollbackcontrole na OFF-koppeling")
+
+    return {
+        "ok": True,
+        "linked": True,
+        "receipt_item_id": _clean_text(receipt_item_id),
+        "receipt_item": receipt_link,
+        "global_product": {
+            "id": global_product_id,
+            "gtin": gtin,
+            "name": _clean_text(off_product.get("product_name") or off_product.get("candidate_name") or off_product.get("name")),
+            "size_value": size_value,
+            "size_unit": size_unit,
+        },
+        "product_type": {
+            "inventory_group_key": product_type_id,
+            "confirmed_by_user": True,
+        },
+        "membership_id": membership.get("membership_id"),
+        "creates_external_candidate": False,
+        "creates_inventory_event": False,
+        "mutates_inventory": False,
+    }

--- a/backend/app/services/product_inventory_group_store.py
+++ b/backend/app/services/product_inventory_group_store.py
@@ -47,7 +47,8 @@ CREATE TABLE IF NOT EXISTS product_inventory_groups (
     aggregation_mode TEXT DEFAULT 'sum_quantity',
     active INTEGER DEFAULT 1,
     created_at TEXT,
-    updated_at TEXT
+    updated_at TEXT,
+    source TEXT
 )
 """
 
@@ -99,6 +100,12 @@ CREATE INDEX IF NOT EXISTS idx_product_group_memberships_product
 ON product_group_memberships (global_product_id, inventory_group_key)
 """
 
+PRIMARY_GROUP_MEMBERSHIP_INDEX_SQL = """
+CREATE UNIQUE INDEX IF NOT EXISTS idx_product_group_memberships_one_active_product_type
+ON product_group_memberships (global_product_id)
+WHERE COALESCE(active, 1) = 1
+"""
+
 TAXONOMY_TERM_INDEX_SQL = """
 CREATE INDEX IF NOT EXISTS idx_product_taxonomy_terms_intent
 ON product_taxonomy_terms (intent_key, active)
@@ -141,6 +148,7 @@ SCHEMA_COLUMNS: dict[str, dict[str, str]] = {
         "active": "INTEGER DEFAULT 1",
         "created_at": "TEXT",
         "updated_at": "TEXT",
+        "source": "TEXT",
     },
     "product_group_memberships": {
         "id": "TEXT",
@@ -236,6 +244,8 @@ def ensure_product_inventory_group_schema() -> None:
             _ensure_missing_columns(conn, table_name)
             _ensure_row_ids(conn, table_name)
         conn.execute(text(GROUP_MEMBERSHIP_INDEX_SQL))
+        _deduplicate_active_product_type_memberships(conn)
+        conn.execute(text(PRIMARY_GROUP_MEMBERSHIP_INDEX_SQL))
         conn.execute(text(TAXONOMY_TERM_INDEX_SQL))
         conn.execute(text(INVENTORY_ITEM_GROUP_ASSIGNMENTS_INDEX_SQL))
         seed_default_inventory_groups(conn)
@@ -243,6 +253,31 @@ def ensure_product_inventory_group_schema() -> None:
 
 def _row_exists(conn, sql: str, params: dict[str, Any]) -> bool:
     return conn.execute(text(sql), params).mappings().first() is not None
+
+
+def _deduplicate_active_product_type_memberships(conn) -> None:
+    """Behoud per universeel artikel exact één actieve Producttype-koppeling."""
+    rows = conn.execute(text("""
+        SELECT id, global_product_id
+        FROM product_group_memberships
+        WHERE COALESCE(active, 1) = 1
+        ORDER BY global_product_id, COALESCE(confirmed_by_user, 0) DESC,
+                 COALESCE(updated_at, created_at, '') DESC, id DESC
+    """)).mappings().all()
+    seen: set[str] = set()
+    for row in rows:
+        product_id = str(row.get("global_product_id") or "").strip()
+        membership_id = str(row.get("id") or "").strip()
+        if not product_id or not membership_id:
+            continue
+        if product_id in seen:
+            conn.execute(text("""
+                UPDATE product_group_memberships
+                SET active = 0, updated_at = :updated_at
+                WHERE id = :id
+            """), {"id": membership_id, "updated_at": now_iso()})
+        else:
+            seen.add(product_id)
 
 
 def seed_default_inventory_groups(conn) -> None:
@@ -543,6 +578,175 @@ def assign_inventory_item_to_group(inventory_id: str, inventory_group_key: str, 
     return {"ok": True, "inventory_id": normalized_inventory_id, "inventory_group_key": normalized_group_key, "mutates_inventory": False, "creates_inventory_event": False}
 
 
+
+
+def normalize_product_type_key(value: Any) -> str:
+    return ".".join(normalize_text(value).split())
+
+
+def create_or_get_product_type_with_connection(
+    conn,
+    *,
+    inventory_group_key: str | None = None,
+    display_name: str | None = None,
+    default_base_unit: str = "stuk",
+    aggregation_mode: str = "count",
+    source: str = "user",
+) -> dict[str, Any]:
+    normalized_name = str(display_name or "").strip()
+    normalized_key = str(inventory_group_key or "").strip()
+    if not normalized_key and normalized_name:
+        normalized_key = normalize_product_type_key(normalized_name)
+    if not normalized_key:
+        return {"ok": False, "error": "Producttype is verplicht"}
+
+    existing = conn.execute(text("""
+        SELECT * FROM product_inventory_groups
+        WHERE inventory_group_key = :key
+        LIMIT 1
+    """), {"key": normalized_key}).mappings().first()
+    if existing:
+        if not bool(existing.get("active", 1)):
+            conn.execute(text("""
+                UPDATE product_inventory_groups
+                SET active = 1, updated_at = :updated_at
+                WHERE inventory_group_key = :key
+            """), {"key": normalized_key, "updated_at": now_iso()})
+        return {"ok": True, "created": False, "product_type": dict(existing)}
+
+    if not normalized_name:
+        return {"ok": False, "error": "Onbekend Producttype; display_name is verplicht voor aanmaak"}
+
+    normalized_unit = str(default_base_unit or "stuk").strip().lower() or "stuk"
+    normalized_mode = str(aggregation_mode or "count").strip().lower() or "count"
+    if normalized_mode not in {"count", "volume", "weight", "sum_quantity"}:
+        return {"ok": False, "error": "aggregation_mode moet count, volume, weight of sum_quantity zijn"}
+
+    timestamp = now_iso()
+    conn.execute(text("""
+        INSERT INTO product_inventory_groups (
+            inventory_group_key, display_name, default_base_unit,
+            aggregation_mode, active, created_at, updated_at, source
+        ) VALUES (
+            :key, :display_name, :default_base_unit,
+            :aggregation_mode, 1, :created_at, :updated_at, :source
+        )
+    """), {
+        "key": normalized_key,
+        "display_name": normalized_name,
+        "default_base_unit": normalized_unit,
+        "aggregation_mode": normalized_mode,
+        "created_at": timestamp,
+        "updated_at": timestamp,
+        "source": str(source or "user").strip() or "user",
+    })
+    created = conn.execute(text("""
+        SELECT * FROM product_inventory_groups
+        WHERE inventory_group_key = :key
+        LIMIT 1
+    """), {"key": normalized_key}).mappings().first()
+    return {"ok": True, "created": True, "product_type": dict(created or {})}
+
+
+def link_global_product_to_inventory_group_with_connection(
+    conn,
+    *,
+    global_product_id: str,
+    inventory_group_key: str,
+    comparison_group_key: str | None = None,
+    confidence: float = 1.0,
+    source: str = "user",
+    confirmed_by_user: bool = True,
+) -> dict[str, Any]:
+    normalized_product_id = str(global_product_id or "").strip()
+    normalized_group_key = str(inventory_group_key or "").strip()
+    if not normalized_product_id:
+        return {"ok": False, "error": "global_product_id is verplicht"}
+    if not normalized_group_key:
+        return {"ok": False, "error": "inventory_group_key is verplicht"}
+
+    product = conn.execute(text("SELECT id FROM global_products WHERE id = :id LIMIT 1"), {"id": normalized_product_id}).mappings().first()
+    if not product:
+        return {"ok": False, "error": "Universeel artikel niet gevonden"}
+    group = conn.execute(text("""
+        SELECT * FROM product_inventory_groups
+        WHERE inventory_group_key = :key AND COALESCE(active, 1) = 1
+        LIMIT 1
+    """), {"key": normalized_group_key}).mappings().first()
+    if not group:
+        return {"ok": False, "error": "Producttype niet gevonden"}
+
+    timestamp = now_iso()
+    conn.execute(text("""
+        UPDATE product_group_memberships
+        SET active = 0, updated_at = :updated_at
+        WHERE global_product_id = :global_product_id
+          AND COALESCE(active, 1) = 1
+          AND inventory_group_key <> :inventory_group_key
+    """), {
+        "global_product_id": normalized_product_id,
+        "inventory_group_key": normalized_group_key,
+        "updated_at": timestamp,
+    })
+
+    existing = conn.execute(text("""
+        SELECT id FROM product_group_memberships
+        WHERE global_product_id = :global_product_id
+          AND inventory_group_key = :inventory_group_key
+        LIMIT 1
+    """), {
+        "global_product_id": normalized_product_id,
+        "inventory_group_key": normalized_group_key,
+    }).mappings().first()
+
+    membership_id = str(existing.get("id")) if existing else str(uuid.uuid4())
+    params = {
+        "id": membership_id,
+        "global_product_id": normalized_product_id,
+        "inventory_group_key": normalized_group_key,
+        "comparison_group_key": str(comparison_group_key or normalized_group_key).strip(),
+        "confidence": max(0.0, min(float(confidence or 1.0), 1.0)),
+        "source": str(source or "user").strip() or "user",
+        "confirmed_by_user": 1 if confirmed_by_user else 0,
+        "updated_at": timestamp,
+        "created_at": timestamp,
+    }
+    if existing:
+        conn.execute(text("""
+            UPDATE product_group_memberships
+            SET comparison_group_key = :comparison_group_key,
+                confidence = :confidence,
+                source = :source,
+                confirmed_by_user = :confirmed_by_user,
+                active = 1,
+                updated_at = :updated_at
+            WHERE id = :id
+        """), params)
+    else:
+        conn.execute(text("""
+            INSERT INTO product_group_memberships (
+                id, global_product_id, inventory_group_key,
+                comparison_group_key, confidence, source,
+                confirmed_by_user, active, created_at, updated_at
+            ) VALUES (
+                :id, :global_product_id, :inventory_group_key,
+                :comparison_group_key, :confidence, :source,
+                :confirmed_by_user, 1, :created_at, :updated_at
+            )
+        """), params)
+
+    return {
+        "ok": True,
+        "membership_id": membership_id,
+        "global_product_id": normalized_product_id,
+        "inventory_group_key": normalized_group_key,
+        "comparison_group_key": params["comparison_group_key"],
+        "confirmed_by_user": bool(confirmed_by_user),
+        "creates_inventory_event": False,
+        "mutates_inventory": False,
+    }
+
+
 def link_global_product_to_inventory_group(
     global_product_id: str,
     inventory_group_key: str,
@@ -552,34 +756,13 @@ def link_global_product_to_inventory_group(
     confirmed_by_user: bool = True,
 ) -> dict[str, Any]:
     ensure_product_inventory_group_schema()
-    normalized_product_id = str(global_product_id or "").strip()
-    normalized_group_key = str(inventory_group_key or "").strip()
-    if not normalized_product_id:
-        return {"ok": False, "error": "global_product_id is verplicht"}
-    if not normalized_group_key:
-        return {"ok": False, "error": "inventory_group_key is verplicht"}
-    timestamp = now_iso()
     with engine.begin() as conn:
-        group = conn.execute(text("SELECT * FROM product_inventory_groups WHERE inventory_group_key = :key AND COALESCE(active, 1) = 1 LIMIT 1"), {"key": normalized_group_key}).mappings().first()
-        if not group:
-            return {"ok": False, "error": "Voorraadgroep niet gevonden"}
-        existing = conn.execute(text("""
-            SELECT id FROM product_group_memberships
-            WHERE global_product_id = :global_product_id AND inventory_group_key = :inventory_group_key
-            LIMIT 1
-        """), {"global_product_id": normalized_product_id, "inventory_group_key": normalized_group_key}).mappings().first()
-        membership_id = str(existing.get("id")) if existing else str(uuid.uuid4())
-        params = {"id": membership_id, "global_product_id": normalized_product_id, "inventory_group_key": normalized_group_key, "comparison_group_key": str(comparison_group_key or normalized_group_key).strip(), "confidence": float(confidence or 1.0), "source": str(source or "user").strip(), "confirmed_by_user": 1 if confirmed_by_user else 0, "updated_at": timestamp, "created_at": timestamp}
-        if existing:
-            conn.execute(text("""
-                UPDATE product_group_memberships
-                SET comparison_group_key = :comparison_group_key, confidence = :confidence, source = :source,
-                    confirmed_by_user = :confirmed_by_user, active = 1, updated_at = :updated_at
-                WHERE id = :id
-            """), params)
-        else:
-            conn.execute(text("""
-                INSERT INTO product_group_memberships (id, global_product_id, inventory_group_key, comparison_group_key, confidence, source, confirmed_by_user, active, created_at, updated_at)
-                VALUES (:id, :global_product_id, :inventory_group_key, :comparison_group_key, :confidence, :source, :confirmed_by_user, 1, :created_at, :updated_at)
-            """), params)
-    return {"ok": True, "membership_id": membership_id, "global_product_id": normalized_product_id, "inventory_group_key": normalized_group_key, "comparison_group_key": params["comparison_group_key"], "creates_inventory_event": False, "mutates_inventory": False}
+        return link_global_product_to_inventory_group_with_connection(
+            conn,
+            global_product_id=global_product_id,
+            inventory_group_key=inventory_group_key,
+            comparison_group_key=comparison_group_key,
+            confidence=confidence,
+            source=source,
+            confirmed_by_user=confirmed_by_user,
+        )

--- a/backend/tests/test_off_product_type_link_contract_selftest.py
+++ b/backend/tests/test_off_product_type_link_contract_selftest.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import text
+
+from app.db import engine
+from app.services.off_product_link_service import link_off_product_with_product_type
+from app.services.product_inventory_group_store import ensure_product_inventory_group_schema
+
+
+def _count(conn, table_name: str) -> int:
+    return int(conn.execute(text(f"SELECT COUNT(*) FROM {table_name}")).scalar() or 0)
+
+
+def main() -> int:
+    ensure_product_inventory_group_schema()
+    suffix = uuid.uuid4().hex
+    batch_id = f"off-link-batch-{suffix}"
+    line_id = f"off-link-line-{suffix}"
+    product_type_key = f"test.off.halfvolle.melk.{suffix}"
+    gtin = f"98{suffix[:11]}"
+
+    with engine.begin() as conn:
+        before = {
+            "candidates": _count(conn, "external_product_candidates"),
+            "inventory": _count(conn, "inventory"),
+            "events": _count(conn, "inventory_events"),
+        }
+        connection = conn.execute(text("""
+            SELECT hsc.id AS connection_id, hsc.store_provider_id
+            FROM household_store_connections hsc
+            WHERE hsc.household_id = '1'
+            ORDER BY hsc.linked_at DESC, hsc.id DESC
+            LIMIT 1
+        """)).mappings().first()
+        if not connection:
+            provider = conn.execute(text("""
+                SELECT id
+                FROM store_providers
+                WHERE status = 'active'
+                ORDER BY id
+                LIMIT 1
+            """)).mappings().first()
+            if not provider:
+                provider_id = f"off-link-provider-{suffix}"
+                conn.execute(text("""
+                    INSERT INTO store_providers (
+                        id, code, name, status, import_mode
+                    ) VALUES (
+                        :id, :code, 'OFF-link contracttest',
+                        'active', 'mock'
+                    )
+                """), {
+                    "id": provider_id,
+                    "code": f"off-link-contract-{suffix[:12]}",
+                })
+            else:
+                provider_id = str(provider["id"])
+
+            connection_id = f"off-link-connection-{suffix}"
+            conn.execute(text("""
+                INSERT INTO household_store_connections (
+                    id, household_id, store_provider_id,
+                    connection_status, linked_at, created_at, updated_at
+                ) VALUES (
+                    :id, '1', :store_provider_id,
+                    'active', CURRENT_TIMESTAMP,
+                    CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                )
+            """), {
+                "id": connection_id,
+                "store_provider_id": provider_id,
+            })
+            connection = {
+                "connection_id": connection_id,
+                "store_provider_id": provider_id,
+            }
+
+        conn.execute(text("""
+            INSERT INTO purchase_import_batches (
+                id, household_id, store_provider_id, connection_id,
+                source_type, source_reference,
+                import_status, raw_payload, created_at
+            ) VALUES (
+                :id, '1', :store_provider_id, :connection_id,
+                'contract_selftest', :source_reference,
+                'in_review', '{}', CURRENT_TIMESTAMP
+            )
+        """), {
+            "id": batch_id,
+            "store_provider_id": str(connection["store_provider_id"]),
+            "connection_id": str(connection["connection_id"]),
+            "source_reference": f"contract:{suffix}",
+        })
+        conn.execute(text("""
+            INSERT INTO purchase_import_lines (
+                id, batch_id, external_line_ref, external_article_code,
+                article_name_raw, brand_raw, quantity_raw, unit_raw,
+                currency_code, match_status, review_decision,
+                processing_status, created_at, updated_at
+            ) VALUES (
+                :id, :batch_id, :external_line_ref, NULL,
+                'Contract Halfvolle melk', 'Contractmerk', 1, 'stuk',
+                'EUR', 'unmatched', 'pending',
+                'pending', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+            )
+        """), {"id": line_id, "batch_id": batch_id, "external_line_ref": f"line:{suffix}"})
+
+    assignment = {
+        "create": {
+            "inventory_group_key": product_type_key,
+            "canonical_name": "Halfvolle koemelk contracttest",
+            "base_unit": "ml",
+            "aggregation_mode": "volume",
+        },
+        "mapping_source": "contract_selftest",
+        "confidence_score": 0.99,
+    }
+    off_product = {
+        "gtin": gtin,
+        "product_name": "Contract Halfvolle melk 1 l",
+        "brand": "Contractmerk",
+        "quantity": "1 l",
+        "category": "Halfvolle melk",
+    }
+
+    result = link_off_product_with_product_type(
+        receipt_item_id=f"purchase-import-line:{line_id}",
+        off_product=off_product,
+        product_type_assignment=assignment,
+    )
+    assert result.get("ok") and result.get("linked"), result
+    assert result.get("creates_external_candidate") is False, result
+    assert result.get("mutates_inventory") is False, result
+    global_product_id = str((result.get("global_product") or {}).get("id") or "")
+
+    rollback_gtin = f"97{suffix[:11]}"
+    try:
+        link_off_product_with_product_type(
+            receipt_item_id=f"purchase-import-line:{line_id}",
+            off_product={**off_product, "gtin": rollback_gtin, "product_name": "Rollback melk"},
+            product_type_assignment={
+                "create": {
+                    "inventory_group_key": f"test.rollback.{suffix}",
+                    "canonical_name": "Rollback producttype",
+                    "base_unit": "ml",
+                    "aggregation_mode": "volume",
+                },
+                "mapping_source": "contract_selftest_rollback",
+            },
+            force_failure_after_link=True,
+        )
+        raise AssertionError("Geforceerde rollbackfout bleef uit")
+    except RuntimeError as exc:
+        assert "rollbackcontrole" in str(exc)
+
+    try:
+        with engine.begin() as conn:
+            after = {
+                "candidates": _count(conn, "external_product_candidates"),
+                "inventory": _count(conn, "inventory"),
+                "events": _count(conn, "inventory_events"),
+            }
+            assert after == before, {"before": before, "after": after}
+            line = conn.execute(text("""
+                SELECT matched_global_product_id, match_status
+                FROM purchase_import_lines WHERE id = :id
+            """), {"id": line_id}).mappings().first()
+            assert str((line or {}).get("matched_global_product_id") or "") == global_product_id, line
+            assert str((line or {}).get("match_status") or "") == "matched", line
+            membership_count = conn.execute(text("""
+                SELECT COUNT(*) FROM product_group_memberships
+                WHERE global_product_id = :global_product_id
+                  AND inventory_group_key = :key
+                  AND active = 1 AND confirmed_by_user = 1
+            """), {"global_product_id": global_product_id, "key": product_type_key}).scalar() or 0
+            assert int(membership_count) == 1, membership_count
+            rollback_product_count = conn.execute(text("""
+                SELECT COUNT(*) FROM global_products WHERE primary_gtin = :gtin
+            """), {"gtin": rollback_gtin}).scalar() or 0
+            assert int(rollback_product_count) == 0, rollback_product_count
+        print("PASS off_result_product_type_atomic_contract")
+        print("PASS off_result_does_not_persist_candidate_or_inventory")
+        print("PASS off_result_rollback_contract")
+        print("OFF_PRODUCT_TYPE_LINK_CONTRACT_GREEN")
+        return 0
+    finally:
+        with engine.begin() as conn:
+            conn.execute(text("DELETE FROM purchase_import_lines WHERE id = :id"), {"id": line_id})
+            conn.execute(text("DELETE FROM purchase_import_batches WHERE id = :id"), {"id": batch_id})
+            conn.execute(text("DELETE FROM product_group_memberships WHERE global_product_id = :id"), {"id": global_product_id})
+            conn.execute(text("DELETE FROM product_identities WHERE global_product_id = :id OR identity_value = :gtin"), {"id": global_product_id, "gtin": gtin})
+            conn.execute(text("DELETE FROM global_products WHERE id = :id"), {"id": global_product_id})
+            conn.execute(text("DELETE FROM product_inventory_groups WHERE inventory_group_key = :key"), {"key": product_type_key})
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_product_type_link_contract_selftest.py
+++ b/backend/tests/test_product_type_link_contract_selftest.py
@@ -1,0 +1,79 @@
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import text
+
+from app.db import engine
+from app.services.external_product_candidate_store import promote_external_product_candidate_with_product_type
+from app.services.product_inventory_group_store import ensure_product_inventory_group_schema
+
+
+def main() -> int:
+    ensure_product_inventory_group_schema()
+    suffix = uuid.uuid4().hex
+    candidate_id = f"product-type-contract-candidate-{suffix}"
+    context_key = f"product-type-contract-context-{suffix}"
+    product_type_key = f"test.halfvolle.melk.{suffix}"
+    gtin = f"99{suffix[:11]}"
+
+    with engine.begin() as conn:
+        conn.execute(text("""
+            INSERT INTO external_product_candidates (
+                id, purchase_import_line_id, source_name, source_product_code,
+                candidate_name, candidate_brand, candidate_category, score,
+                status, context_key, candidate_source_name,
+                candidate_source_product_code, candidate_status,
+                is_user_confirmed, created_at, updated_at
+            ) VALUES (
+                :id, :line_id, 'open_food_facts', :gtin,
+                'Contract Halfvolle melk', 'Contractmerk', 'Halfvolle melk', 0.99,
+                'candidate', :context_key, 'open_food_facts',
+                :gtin, 'candidate', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+            )
+        """), {"id": candidate_id, "line_id": f"contract-line-{suffix}", "gtin": gtin, "context_key": context_key})
+
+    result = promote_external_product_candidate_with_product_type(
+        candidate_id,
+        product_type_assignment={
+            "create": {
+                "inventory_group_key": product_type_key,
+                "canonical_name": "Halfvolle koemelk contracttest",
+                "base_unit": "ml",
+                "aggregation_mode": "volume",
+            },
+            "mapping_source": "contract_selftest",
+            "confidence_score": 0.99,
+        },
+    )
+    assert result.get("ok") and result.get("promoted"), result
+    assert result.get("mutates_inventory") is False, result
+    global_product_id = str(result.get("global_product_id") or "")
+
+    try:
+        with engine.begin() as conn:
+            membership_count = conn.execute(text("""
+                SELECT COUNT(*) FROM product_group_memberships
+                WHERE global_product_id = :global_product_id
+                  AND inventory_group_key = :key
+                  AND active = 1
+                  AND confirmed_by_user = 1
+            """), {"global_product_id": global_product_id, "key": product_type_key}).scalar() or 0
+            linked = conn.execute(text("SELECT global_product_id FROM external_product_candidates WHERE id = :id"), {"id": candidate_id}).scalar()
+            assert int(membership_count) == 1, membership_count
+            assert str(linked or "") == global_product_id, linked
+        print("PASS candidate_and_product_type_atomic_contract")
+        print("PRODUCT_TYPE_LINK_CONTRACT_GREEN")
+        return 0
+    finally:
+        with engine.begin() as conn:
+            conn.execute(text("DELETE FROM external_product_candidates WHERE id = :id"), {"id": candidate_id})
+            conn.execute(text("DELETE FROM product_group_memberships WHERE global_product_id = :id"), {"id": global_product_id})
+            conn.execute(text("DELETE FROM product_identities WHERE global_product_id = :id OR identity_value = :gtin"), {"id": global_product_id, "gtin": gtin})
+            conn.execute(text("DELETE FROM global_products WHERE id = :id"), {"id": global_product_id})
+            conn.execute(text("DELETE FROM product_inventory_groups WHERE inventory_group_key = :key"), {"key": product_type_key})
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -185,6 +185,36 @@ function offStatusLabel(preview) {
   return text(preview.status)
 }
 function defaultOffQuery(item) { return text(item?.receiptLineText || item?.bestSelectableCandidateName || item?.bestCandidateName, '') }
+function normalizeProductTypeSearch(value) {
+  return String(value ?? '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+function suggestProductTypeId(candidate, options) {
+  if (!candidate || !Array.isArray(options) || !options.length) return ''
+  const haystack = normalizeProductTypeSearch([
+    candidate.candidateName,
+    candidate.raw?.product_name,
+    candidate.raw?.category,
+    candidate.raw?.categories,
+  ].filter(Boolean).join(' '))
+  if (!haystack) return ''
+  const ranked = options
+    .map((option) => {
+      const label = normalizeProductTypeSearch(option.display_name)
+      if (!label) return { option, score: 0 }
+      if (haystack === label) return { option, score: 1000 + label.length }
+      if (haystack.includes(label)) return { option, score: 500 + label.length }
+      const tokens = label.split(' ').filter((token) => token.length >= 3)
+      const score = tokens.reduce((total, token) => total + (haystack.includes(token) ? token.length : 0), 0)
+      return { option, score }
+    })
+    .sort((left, right) => right.score - left.score)
+  return ranked[0]?.score >= 4 ? String(ranked[0].option.inventory_group_key || '') : ''
+}
 
 export default function ReceiptItemsOverview({ onError, onMessage }) {
   const [items, setItems] = useState([])
@@ -198,6 +228,13 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   const [offError, setOffError] = useState('')
   const [offSearchText, setOffSearchText] = useState('')
   const [offSearchMode, setOffSearchMode] = useState('automatisch')
+  const [productTypeOptions, setProductTypeOptions] = useState([])
+  const [productTypeMode, setProductTypeMode] = useState('existing')
+  const [selectedProductTypeId, setSelectedProductTypeId] = useState('')
+  const [newProductTypeName, setNewProductTypeName] = useState('')
+  const [newProductTypeBaseUnit, setNewProductTypeBaseUnit] = useState('stuk')
+  const [newProductTypeAggregationMode, setNewProductTypeAggregationMode] = useState('count')
+  const [isLinkingProductType, setIsLinkingProductType] = useState(false)
   const [filters, setFilters] = useState({ receiptLineText: '', retailerCode: '', catalogLinked: 'all', gtin: '', quantity: '', price: '', bestCandidateName: '', bestCandidateCode: '', bestCandidateScore: '', candidateCount: '' })
   const [sortKey, setSortKey] = useState('receiptLineText')
   const [sortDesc, setSortDesc] = useState(false)
@@ -217,7 +254,17 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
       setSelectedItemIds((current) => current.filter((id) => nextItems.some((item) => item.id === id)))
     } catch (err) { onError?.(err?.message || 'Bonartikelen konden niet worden geladen') }
   }
-  useEffect(() => { loadItems() }, [])
+  async function loadProductTypeOptions() {
+    const response = await fetchJsonWithAuth('/api/inventory/groups', { method: 'GET' })
+    const data = await response.json().catch(() => ({}))
+    if (!response.ok) throw new Error(data?.detail || 'Producttypen konden niet worden geladen')
+    const options = Array.isArray(data?.group_options) ? data.group_options : []
+    setProductTypeOptions(options.filter((option) => option?.inventory_group_key && option?.display_name))
+  }
+  useEffect(() => {
+    loadItems()
+    loadProductTypeOptions().catch((err) => onError?.(err?.message || 'Producttypen konden niet worden geladen'))
+  }, [])
 
   const filteredItems = useMemo(() => {
     const rows = items.filter((item) => item.receiptLineText.toLowerCase().includes(filters.receiptLineText.toLowerCase()) && item.retailerCode.toLowerCase().includes(filters.retailerCode.toLowerCase()) && ((filters.catalogLinked === 'all') || (filters.catalogLinked === 'linked' && item.catalogLinked) || (filters.catalogLinked === 'unlinked' && !item.catalogLinked)) && item.gtin.toLowerCase().includes(filters.gtin.toLowerCase()) && item.quantity.toLowerCase().includes(filters.quantity.toLowerCase()) && numberText(item.price).toLowerCase().includes(filters.price.toLowerCase()) && String(item.bestCandidateName || '').toLowerCase().includes(filters.bestCandidateName.toLowerCase()) && String(item.bestCandidateCode || '').toLowerCase().includes(filters.bestCandidateCode.toLowerCase()) && scoreText(item.bestCandidateScore).toLowerCase().includes(filters.bestCandidateScore.toLowerCase()) && String(item.candidateCount || '').toLowerCase().includes(filters.candidateCount.toLowerCase()))
@@ -228,7 +275,7 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   useEffect(() => {
     if (!selectedItem) return
     if (filteredItems.some((item) => item.id === selectedItem.id)) return
-    setSelectedItem(null); setSelectedCandidateId(''); setOffPreview(null); setOffSearchResults([]); setOffError(''); setOffSearchText(''); setOffSearchMode('automatisch')
+    setSelectedItem(null); setSelectedCandidateId(''); setOffPreview(null); setOffSearchResults([]); setOffError(''); setOffSearchText(''); setOffSearchMode('automatisch'); setProductTypeMode('existing'); setSelectedProductTypeId(''); setNewProductTypeName('')
   }, [filteredItems, selectedItem])
 
   const pageCount = Math.max(1, Math.ceil(filteredItems.length / PAGE_SIZE))
@@ -256,13 +303,16 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
     catalogLinked: false,
     isFallbackCandidate: false,
     isSearchHelper: false,
-    isLinkableToCatalog: false,
+    isLinkableToCatalog: true,
     automaticRankScore: result.automatic_rank_score ?? null,
     automaticEvidence: result.automatic_evidence ?? null,
     raw: result,
   }))
   const selectedCandidate = selectedCandidates.find((candidate) => candidate.id === selectedCandidateId) || null
-  const selectedCandidateCanBeLinked = false
+  const hasValidProductTypeDecision = productTypeMode === 'existing'
+    ? Boolean(selectedProductTypeId)
+    : Boolean(newProductTypeName.trim() && newProductTypeBaseUnit.trim() && newProductTypeAggregationMode.trim())
+  const selectedCandidateCanBeLinked = Boolean(selectedItem && selectedCandidate && hasValidProductTypeDecision && !isLinkingProductType)
   const selectedCandidateCanBeUnlinked = false
   const selectedItemHasKnownGtin = Boolean(selectedItem?.hasKnownGtin || hasKnownGtin(selectedItem?.gtin))
 
@@ -272,7 +322,18 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   function toggleSelectedItem(itemId) { setSelectedItemIds((current) => current.includes(itemId) ? current.filter((id) => id !== itemId) : [...current, itemId]) }
   function toggleVisibleItems() { setSelectedItemIds((current) => allVisibleSelected ? current.filter((id) => !visibleIds.includes(id)) : Array.from(new Set([...current, ...visibleIds]))) }
   function goToPage(targetPage) { setPage(Math.max(1, Math.min(pageCount, targetPage))) }
-  function selectReceiptItem(item) { setSelectedItem(item); setSelectedCandidateId(''); setOffPreview(null); setOffSearchResults([]); setOffError(''); setOffSearchText(defaultOffQuery(item)); setOffSearchMode('automatisch'); if (!item.hasKnownGtin) consultOpenFoodFactsForItem(item, defaultOffQuery(item), 'automatisch') }
+  function selectReceiptItem(item) { setSelectedItem(item); setSelectedCandidateId(''); setOffPreview(null); setOffSearchResults([]); setOffError(''); setOffSearchText(defaultOffQuery(item)); setOffSearchMode('automatisch'); setProductTypeMode('existing'); setSelectedProductTypeId(''); setNewProductTypeName(''); if (!item.hasKnownGtin) consultOpenFoodFactsForItem(item, defaultOffQuery(item), 'automatisch') }
+
+  useEffect(() => {
+    if (!selectedCandidate) {
+      setSelectedProductTypeId('')
+      return
+    }
+    const suggested = suggestProductTypeId(selectedCandidate, productTypeOptions)
+    setProductTypeMode('existing')
+    setSelectedProductTypeId(suggested)
+    setNewProductTypeName(selectedCandidate.candidateName === '-' ? '' : selectedCandidate.candidateName)
+  }, [selectedCandidateId, productTypeOptions])
 
   function exportSelectedItems() {
     const selectedRows = items.filter((item) => selectedItemIds.includes(item.id))
@@ -283,11 +344,56 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
   }
   async function processSelectedCandidate() {
     if (!selectedItem || !selectedCandidate || !selectedCandidateCanBeLinked) return
+    const productTypeAssignment = productTypeMode === 'existing'
+      ? {
+          product_type_id: selectedProductTypeId,
+          mapping_source: 'user_confirmed_off_result',
+          confidence_score: Number(selectedCandidate.score || 1),
+        }
+      : {
+          create: {
+            canonical_name: newProductTypeName.trim(),
+            base_unit: newProductTypeBaseUnit.trim(),
+            aggregation_mode: newProductTypeAggregationMode.trim(),
+          },
+          mapping_source: 'user_created_during_off_link',
+          confidence_score: 1,
+        }
+    setIsLinkingProductType(true)
     try {
-      const response = await fetchJsonWithAuth('/api/external-databases/catalog/promote-candidate', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ candidate_id: selectedCandidate.raw?.id || selectedCandidate.id }) })
-      const data = await response.json().catch(() => ({})); if (!response.ok) throw new Error(data?.detail || 'Kandidaat verwerken is mislukt')
-      onMessage?.(data?.promoted ? 'Kandidaat is gekoppeld.' : 'Cataloguskoppeling is afgerond zonder mutatie.'); setSelectedCandidateId(''); await loadItems()
-    } catch (err) { onError?.(err?.message || 'Kandidaat verwerken is mislukt') }
+      const raw = selectedCandidate.raw || {}
+      const response = await fetchJsonWithAuth('/api/external-products/off/link', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          receipt_item_id: selectedItem.receiptItemId || selectedItem.id,
+          off_product: {
+            gtin: raw.gtin || raw.code || selectedCandidate.externalCode,
+            product_name: raw.product_name || selectedCandidate.candidateName,
+            brand: raw.brand || selectedCandidate.brand,
+            category: raw.category || raw.categories || '',
+            quantity: raw.quantity || raw.quantity_label || raw.net_content || selectedItem.quantity,
+            source_url: raw.source_url || raw.url || '',
+            variant: raw.variant || '',
+          },
+          product_type_assignment: productTypeAssignment,
+        }),
+      })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data?.detail || 'Artikel en Producttype koppelen is mislukt')
+      const productTypeLabel = productTypeMode === 'existing'
+        ? (productTypeOptions.find((option) => option.inventory_group_key === selectedProductTypeId)?.display_name || selectedProductTypeId)
+        : newProductTypeName.trim()
+      onMessage?.(`Artikel is gekoppeld aan Producttype ${productTypeLabel}.`)
+      setSelectedCandidateId('')
+      setSelectedProductTypeId('')
+      setNewProductTypeName('')
+      await Promise.all([loadItems(), loadProductTypeOptions()])
+    } catch (err) {
+      onError?.(err?.message || 'Artikel en Producttype koppelen is mislukt')
+    } finally {
+      setIsLinkingProductType(false)
+    }
   }
   async function unlinkSelectedCandidate() {
     if (!selectedItem || !selectedCandidate || !selectedCandidateCanBeUnlinked) return
@@ -429,5 +535,5 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
           <span className="rz-search-complete-label">Zoekactie wordt uitgevoerd</span>
         </div>
       </div>
-    ) : null}<div className="rz-external-databases-section-header"><h3>Bonartikelen voor externe herkenning</h3></div><div className="rz-external-databases-actions"><Button type="button" variant="secondary" disabled={!selectedItemIds.length} onClick={exportSelectedItems}>Exporteren</Button><span className="rz-external-databases-muted">Geselecteerd: {selectedItemIds.length}</span></div><div className="rz-table-scroll rz-table-scroll--wide"><Table dataTestId="external-receipt-items-table" tableClassName="rz-external-receipt-table" tableStyle={RECEIPT_TABLE_STYLE} resizableColumns><colgroup>{RECEIPT_COL_WIDTHS.map((width, index) => <col key={`receipt-col-${index}`} style={{ width }} />)}</colgroup><thead><tr className="rz-table-header"><th className="rz-check"><input type="checkbox" checked={allVisibleSelected} onChange={toggleVisibleItems} /></th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('receiptLineText')}>Bonartikel <span>{sortMark('receiptLineText')}</span></button></th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('retailerCode')}>Winkelketen <span>{sortMark('retailerCode')}</span></button></th><th className="rz-check"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('catalogLinked')}>Catalogus <span>{sortMark('catalogLinked')}</span></button></th><th>Kand. GTIN/EAN</th><th>GTIN / EAN</th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('quantity')}>Omvang / gewicht <span>{sortMark('quantity')}</span></button></th><th className="rz-num">Prijs</th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('bestCandidateName')}>Kandidaat <span>{sortMark('bestCandidateName')}</span></button></th><th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('bestCandidateScore')}>Score <span>{sortMark('bestCandidateScore')}</span></button></th><th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('candidateCount')}>Externe <span>{sortMark('candidateCount')}</span></button></th></tr><tr className="rz-external-databases-filter-row"><th></th><th><input className="rz-table-filter" value={filters.receiptLineText} onChange={(event) => updateFilter('receiptLineText', event.target.value)} placeholder="Zoek" /></th><th><input className="rz-table-filter" value={filters.retailerCode} onChange={(event) => updateFilter('retailerCode', event.target.value)} placeholder="Filter" /></th><th><select className="rz-table-filter" value={filters.catalogLinked} onChange={(event) => updateFilter('catalogLinked', event.target.value)} aria-label="Catalogus filter"><option value="all">Alle</option><option value="linked">Gekoppeld</option><option value="unlinked">Niet gekoppeld</option></select></th><th><input className="rz-table-filter" value={filters.bestCandidateCode} onChange={(event) => updateFilter('bestCandidateCode', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.gtin} onChange={(event) => updateFilter('gtin', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.quantity} onChange={(event) => updateFilter('quantity', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.price} onChange={(event) => updateFilter('price', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.bestCandidateName} onChange={(event) => updateFilter('bestCandidateName', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.bestCandidateScore} onChange={(event) => updateFilter('bestCandidateScore', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.candidateCount} onChange={(event) => updateFilter('candidateCount', event.target.value)} placeholder="Filter" /></th></tr></thead><tbody>{visibleItems.length ? visibleItems.map((item) => <tr key={item.id} className={selectedItem?.id === item.id ? 'rz-row-active' : ''} onDoubleClick={() => selectReceiptItem(item)}><td className="rz-check"><input type="checkbox" checked={selectedItemIds.includes(item.id)} onChange={() => toggleSelectedItem(item.id)} /></td><td>{item.receiptLineText}</td><td>{item.retailerCode}</td><td className="rz-check"><input type="checkbox" checked={item.catalogLinked} readOnly /></td><td>{item.bestCandidateCode || '-'}</td><td>{item.gtin}</td><td>{item.quantity}</td><td className="rz-num">{numberText(item.price)}</td><td>{item.bestCandidateName || '-'}</td><td className="rz-num">{scoreText(item.bestCandidateScore)}</td><td className="rz-num">{item.candidateCount}</td></tr>) : <tr><td colSpan="11">Geen bonartikelen beschikbaar voor externe herkenning.</td></tr>}{Array.from({ length: emptyRows }).map((_, index) => <tr key={`empty-${index}`}><td colSpan="11"></td></tr>)}</tbody></Table></div><div className="rz-external-databases-pagination" aria-label="Paginering bonartikelen"><Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => goToPage(1)}>Eerste</Button><Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => goToPage(currentPage - 1)}>Vorige</Button><span className="rz-external-databases-page-indicator">Pagina {currentPage} van {pageCount}</span><Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => goToPage(currentPage + 1)}>Volgende</Button><Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => goToPage(pageCount)}>Laatste</Button></div>{selectedItem ? <div className="rz-external-receipt-detail"><h3>Koppelen kandidaten in artikel-catalogus</h3><p>Universele kandidaten voor: {selectedItem.receiptLineText}</p><dl><dt>Winkelketen</dt><dd>{selectedItem.retailerCode}</dd><dt>Bonartikelnummer</dt><dd>{selectedItem.receiptArticleNumber}</dd><dt>Artikelnummer</dt><dd>{selectedItem.articleNumber}</dd><dt>GTIN / EAN</dt><dd>{selectedItem.gtin}</dd><dt>Status</dt><dd>{selectedItem.status}</dd></dl>{!selectedItemHasKnownGtin ? <div className="rz-external-databases-actions" data-testid="external-off-manual-search"><label className="rz-input-field"><div className="rz-label">OFF zoektekst</div><input className="rz-input" aria-label="OFF zoektekst" value={offSearchText} onChange={(event) => setOffSearchText(event.target.value)} /></label><Button type="button" variant="secondary" disabled={isOffLoading || !offSearchText.trim()} onClick={runManualOffSearch}>Zelf zoeken</Button><span className="rz-external-databases-muted">Pas de zoektekst aan als OFF geen goede kandidaat vindt.</span></div> : null}<Table dataTestId="external-receipt-item-candidates-table" tableClassName="rz-external-candidate-detail-table" tableStyle={CANDIDATE_TABLE_STYLE} resizableColumns><colgroup>{CANDIDATE_COL_WIDTHS.map((width, index) => <col key={`candidate-col-${index}`} style={{ width }} />)}</colgroup><thead><tr className="rz-table-header"><th>Keuze</th><th>Kandidaat</th><th>Merk</th><th>Bron</th><th>GTIN / EAN</th><th className="rz-num">Score</th><th>Status</th></tr></thead><tbody>{selectedCandidates.length ? selectedCandidates.map((candidate) => <tr key={candidate.id} className={selectedCandidateId === candidate.id ? 'rz-row-selected' : ''}><td className="rz-check"><input type="radio" name="external-candidate" checked={selectedCandidateId === candidate.id} disabled={!candidate.isLinkableToCatalog && !candidate.isLinkedToCatalog} onChange={() => setSelectedCandidateId(candidate.id)} /></td><td>{candidate.candidateName}</td><td>{candidate.brand}</td><td>{candidate.source}</td><td>{candidate.externalCode}</td><td className="rz-num">{scoreText(candidate.score)}</td><td>{candidate.status}</td></tr>) : <tr><td colSpan="7">Geen universele kandidaten met score 0,500 of hoger voor dit bonartikel.</td></tr>}</tbody></Table><div className="rz-external-databases-actions"><Button type="button" disabled={!selectedCandidateCanBeLinked} onClick={processSelectedCandidate}>Koppel artikel</Button><Button type="button" variant="secondary" disabled={!selectedCandidateCanBeUnlinked} onClick={unlinkSelectedCandidate}>Ontkoppel artikel</Button><span className="rz-external-databases-muted">{selectedItemHasKnownGtin ? 'GTIN/EAN is al bekend; OFF-kandidaten worden niet automatisch toegevoegd.' : (isOffLoading ? 'OFF wordt geraadpleegd...' : 'OFF wordt automatisch geraadpleegd bij openen van dit detail; gebruik Zelf zoeken om de zoektekst handmatig aan te passen.')}</span></div>{offError ? <div className="rz-inline-feedback">{offError}</div> : null}{offPreview ? <div className="rz-external-databases-preview-meta" data-testid="external-off-preview-meta"><span>OFF-status: {offStatusLabel(offPreview)}</span><span>Provider: {text(offPreview.provider)}</span><span>Zoektype: {offSearchMode}</span><span>Zoektekst: {offPreview.query || offSearchText || '-'}</span><span>Productmutatie: nee</span></div> : null}</div> : null}</div>
+    ) : null}<div className="rz-external-databases-section-header"><h3>Bonartikelen voor externe herkenning</h3></div><div className="rz-external-databases-actions"><Button type="button" variant="secondary" disabled={!selectedItemIds.length} onClick={exportSelectedItems}>Exporteren</Button><span className="rz-external-databases-muted">Geselecteerd: {selectedItemIds.length}</span></div><div className="rz-table-scroll rz-table-scroll--wide"><Table dataTestId="external-receipt-items-table" tableClassName="rz-external-receipt-table" tableStyle={RECEIPT_TABLE_STYLE} resizableColumns><colgroup>{RECEIPT_COL_WIDTHS.map((width, index) => <col key={`receipt-col-${index}`} style={{ width }} />)}</colgroup><thead><tr className="rz-table-header"><th className="rz-check"><input type="checkbox" checked={allVisibleSelected} onChange={toggleVisibleItems} /></th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('receiptLineText')}>Bonartikel <span>{sortMark('receiptLineText')}</span></button></th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('retailerCode')}>Winkelketen <span>{sortMark('retailerCode')}</span></button></th><th className="rz-check"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('catalogLinked')}>Catalogus <span>{sortMark('catalogLinked')}</span></button></th><th>Kand. GTIN/EAN</th><th>GTIN / EAN</th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('quantity')}>Omvang / gewicht <span>{sortMark('quantity')}</span></button></th><th className="rz-num">Prijs</th><th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('bestCandidateName')}>Kandidaat <span>{sortMark('bestCandidateName')}</span></button></th><th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('bestCandidateScore')}>Score <span>{sortMark('bestCandidateScore')}</span></button></th><th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('candidateCount')}>Externe <span>{sortMark('candidateCount')}</span></button></th></tr><tr className="rz-external-databases-filter-row"><th></th><th><input className="rz-table-filter" value={filters.receiptLineText} onChange={(event) => updateFilter('receiptLineText', event.target.value)} placeholder="Zoek" /></th><th><input className="rz-table-filter" value={filters.retailerCode} onChange={(event) => updateFilter('retailerCode', event.target.value)} placeholder="Filter" /></th><th><select className="rz-table-filter" value={filters.catalogLinked} onChange={(event) => updateFilter('catalogLinked', event.target.value)} aria-label="Catalogus filter"><option value="all">Alle</option><option value="linked">Gekoppeld</option><option value="unlinked">Niet gekoppeld</option></select></th><th><input className="rz-table-filter" value={filters.bestCandidateCode} onChange={(event) => updateFilter('bestCandidateCode', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.gtin} onChange={(event) => updateFilter('gtin', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.quantity} onChange={(event) => updateFilter('quantity', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.price} onChange={(event) => updateFilter('price', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.bestCandidateName} onChange={(event) => updateFilter('bestCandidateName', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.bestCandidateScore} onChange={(event) => updateFilter('bestCandidateScore', event.target.value)} placeholder="Filter" /></th><th><input className="rz-table-filter" value={filters.candidateCount} onChange={(event) => updateFilter('candidateCount', event.target.value)} placeholder="Filter" /></th></tr></thead><tbody>{visibleItems.length ? visibleItems.map((item) => <tr key={item.id} className={selectedItem?.id === item.id ? 'rz-row-active' : ''} onDoubleClick={() => selectReceiptItem(item)}><td className="rz-check"><input type="checkbox" checked={selectedItemIds.includes(item.id)} onChange={() => toggleSelectedItem(item.id)} /></td><td>{item.receiptLineText}</td><td>{item.retailerCode}</td><td className="rz-check"><input type="checkbox" checked={item.catalogLinked} readOnly /></td><td>{item.bestCandidateCode || '-'}</td><td>{item.gtin}</td><td>{item.quantity}</td><td className="rz-num">{numberText(item.price)}</td><td>{item.bestCandidateName || '-'}</td><td className="rz-num">{scoreText(item.bestCandidateScore)}</td><td className="rz-num">{item.candidateCount}</td></tr>) : <tr><td colSpan="11">Geen bonartikelen beschikbaar voor externe herkenning.</td></tr>}{Array.from({ length: emptyRows }).map((_, index) => <tr key={`empty-${index}`}><td colSpan="11"></td></tr>)}</tbody></Table></div><div className="rz-external-databases-pagination" aria-label="Paginering bonartikelen"><Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => goToPage(1)}>Eerste</Button><Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => goToPage(currentPage - 1)}>Vorige</Button><span className="rz-external-databases-page-indicator">Pagina {currentPage} van {pageCount}</span><Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => goToPage(currentPage + 1)}>Volgende</Button><Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => goToPage(pageCount)}>Laatste</Button></div>{selectedItem ? <div className="rz-external-receipt-detail"><h3>Koppelen kandidaten in artikel-catalogus</h3><p>Universele kandidaten voor: {selectedItem.receiptLineText}</p><dl><dt>Winkelketen</dt><dd>{selectedItem.retailerCode}</dd><dt>Bonartikelnummer</dt><dd>{selectedItem.receiptArticleNumber}</dd><dt>Artikelnummer</dt><dd>{selectedItem.articleNumber}</dd><dt>GTIN / EAN</dt><dd>{selectedItem.gtin}</dd><dt>Status</dt><dd>{selectedItem.status}</dd></dl>{!selectedItemHasKnownGtin ? <div className="rz-external-databases-actions" data-testid="external-off-manual-search"><label className="rz-input-field"><div className="rz-label">OFF zoektekst</div><input className="rz-input" aria-label="OFF zoektekst" value={offSearchText} onChange={(event) => setOffSearchText(event.target.value)} /></label><Button type="button" variant="secondary" disabled={isOffLoading || !offSearchText.trim()} onClick={runManualOffSearch}>Zelf zoeken</Button><span className="rz-external-databases-muted">Pas de zoektekst aan als OFF geen goede kandidaat vindt.</span></div> : null}<Table dataTestId="external-receipt-item-candidates-table" tableClassName="rz-external-candidate-detail-table" tableStyle={CANDIDATE_TABLE_STYLE} resizableColumns><colgroup>{CANDIDATE_COL_WIDTHS.map((width, index) => <col key={`candidate-col-${index}`} style={{ width }} />)}</colgroup><thead><tr className="rz-table-header"><th>Keuze</th><th>Kandidaat</th><th>Merk</th><th>Bron</th><th>GTIN / EAN</th><th className="rz-num">Score</th><th>Status</th></tr></thead><tbody>{selectedCandidates.length ? selectedCandidates.map((candidate) => <tr key={candidate.id} className={selectedCandidateId === candidate.id ? 'rz-row-selected' : ''}><td className="rz-check"><input type="radio" name="external-candidate" checked={selectedCandidateId === candidate.id} disabled={!candidate.isLinkableToCatalog && !candidate.isLinkedToCatalog} onChange={() => setSelectedCandidateId(candidate.id)} /></td><td>{candidate.candidateName}</td><td>{candidate.brand}</td><td>{candidate.source}</td><td>{candidate.externalCode}</td><td className="rz-num">{scoreText(candidate.score)}</td><td>{candidate.status}</td></tr>) : <tr><td colSpan="7">Geen universele kandidaten met score 0,500 of hoger voor dit bonartikel.</td></tr>}</tbody></Table><div data-testid="external-producttype-link-panel"><h4>Producttype</h4><p className="rz-external-databases-muted">Bevestig direct onder welk merk- en leveranciersoverstijgend Producttype dit artikel valt.</p><div className="rz-external-databases-actions"><label><input type="radio" name="producttype-mode" value="existing" checked={productTypeMode === 'existing'} onChange={() => setProductTypeMode('existing')} /> Bestaand Producttype</label><label><input type="radio" name="producttype-mode" value="new" checked={productTypeMode === 'new'} onChange={() => setProductTypeMode('new')} /> Nieuw Producttype</label></div>{productTypeMode === 'existing' ? <label className="rz-input-field"><div className="rz-label">Producttype</div><select className="rz-input" aria-label="Producttype" value={selectedProductTypeId} onChange={(event) => setSelectedProductTypeId(event.target.value)}><option value="">Selecteer Producttype</option>{productTypeOptions.map((option) => <option key={option.inventory_group_key} value={option.inventory_group_key}>{option.display_name} · {option.default_base_unit || option.base_unit || 'stuk'}</option>)}</select></label> : <div className="rz-external-databases-actions"><label className="rz-input-field"><div className="rz-label">Naam Producttype</div><input className="rz-input" aria-label="Naam Producttype" value={newProductTypeName} onChange={(event) => setNewProductTypeName(event.target.value)} placeholder="Bijvoorbeeld Halfvolle koemelk" /></label><label className="rz-input-field"><div className="rz-label">Basiseenheid</div><select className="rz-input" aria-label="Basiseenheid Producttype" value={newProductTypeBaseUnit} onChange={(event) => setNewProductTypeBaseUnit(event.target.value)}><option value="stuk">stuk</option><option value="ml">ml</option><option value="l">l</option><option value="g">g</option><option value="kg">kg</option></select></label><label className="rz-input-field"><div className="rz-label">Aggregatie</div><select className="rz-input" aria-label="Aggregatiemethode Producttype" value={newProductTypeAggregationMode} onChange={(event) => setNewProductTypeAggregationMode(event.target.value)}><option value="count">Aantal</option><option value="volume">Volume</option><option value="weight">Gewicht</option></select></label></div>}</div><div className="rz-external-databases-actions"><Button type="button" disabled={!selectedCandidateCanBeLinked} onClick={processSelectedCandidate}>{isLinkingProductType ? 'Koppelen...' : 'Koppel artikel en Producttype'}</Button><Button type="button" variant="secondary" disabled={!selectedCandidateCanBeUnlinked} onClick={unlinkSelectedCandidate}>Ontkoppel artikel</Button><span className="rz-external-databases-muted">{selectedItemHasKnownGtin ? 'GTIN/EAN is al bekend; OFF-kandidaten worden niet automatisch toegevoegd.' : (isOffLoading ? 'OFF wordt geraadpleegd...' : 'OFF wordt automatisch geraadpleegd bij openen van dit detail; gebruik Zelf zoeken om de zoektekst handmatig aan te passen.')}</span></div>{offError ? <div className="rz-inline-feedback">{offError}</div> : null}{offPreview ? <div className="rz-external-databases-preview-meta" data-testid="external-off-preview-meta"><span>OFF-status: {offStatusLabel(offPreview)}</span><span>Provider: {text(offPreview.provider)}</span><span>Zoektype: {offSearchMode}</span><span>Zoektekst: {offPreview.query || offSearchText || '-'}</span><span>Productmutatie: nee</span></div> : null}</div> : null}</div>
 }

--- a/frontend/tests/e2e/external-databases-known-gtin.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases-known-gtin.frontend-regression.spec.js
@@ -86,7 +86,7 @@ test.describe('Externe databases bekende GTIN regressie', () => {
     await expect(candidateTable).toContainText('Geen universele kandidaten met score 0,500 of hoger voor dit bonartikel.');
     await expect(candidateTable.getByText('Onterechte kandidaat')).toHaveCount(0);
     await expect(page.getByText('GTIN/EAN is al bekend; OFF-kandidaten worden niet automatisch toegevoegd.')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Koppel artikel', exact: true })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Koppel artikel en Producttype', exact: true })).toBeDisabled();
     await expect(page.getByRole('button', { name: 'Ontkoppel artikel', exact: true })).toBeDisabled();
     expect(offSearchCalled).toBe(false);
 

--- a/frontend/tests/e2e/external-databases-off.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases-off.frontend-regression.spec.js
@@ -164,7 +164,8 @@ test.describe('Externe databases OFF candidate flow', () => {
       limit: 10,
     });
 
-    await expect(page.getByRole('button', { name: 'Koppel artikel', exact: true })).toBeDisabled();
+    await expect(page.getByTestId('external-producttype-link-panel')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Koppel artikel en Producttype', exact: true })).toBeDisabled();
     await expect(page.getByRole('button', { name: 'Ontkoppel artikel', exact: true })).toBeDisabled();
     await expectNoConsoleErrors(consoleErrors);
   });
@@ -215,7 +216,7 @@ test.describe('Externe databases OFF candidate flow', () => {
     await expect(overlay).toHaveCount(0);
     await expect(page.getByText('OFF regressiestoring', { exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Zelf zoeken' })).toBeEnabled();
-    await expect(page.getByRole('button', { name: 'Koppel artikel', exact: true })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Koppel artikel en Producttype', exact: true })).toBeDisabled();
     await expect(page.getByRole('button', { name: 'Ontkoppel artikel', exact: true })).toBeDisabled();
 
     const unexpectedConsoleErrors = consoleErrors.filter(

--- a/frontend/tests/e2e/external-databases-unlink.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases-unlink.frontend-regression.spec.js
@@ -98,7 +98,7 @@ test.describe('Externe databases ontkoppelen regressie', () => {
     await expect(candidateTable).toContainText('Geen universele kandidaten met score 0,500 of hoger voor dit bonartikel.');
     await expect(candidateTable.getByText('Gekoppelde ontkoppel kandidaat')).toHaveCount(0);
     await expect(page.getByTestId('external-off-preview-meta')).toContainText('OFF-status: Geen resultaten');
-    await expect(page.getByRole('button', { name: 'Koppel artikel', exact: true })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Koppel artikel en Producttype', exact: true })).toBeDisabled();
     await expect(page.getByRole('button', { name: 'Ontkoppel artikel', exact: true })).toBeDisabled();
 
     expect(offRequestBodies).toEqual([

--- a/frontend/tests/e2e/external-databases.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases.frontend-regression.spec.js
@@ -147,7 +147,7 @@ test.describe('Externe databases frontend-regressie', () => {
     await expect(candidateTable.getByText('8710000000001')).toHaveCount(0);
     await expect(candidateTable.getByText('0,800')).toHaveCount(0);
     await expect(candidateTable.getByText('0,400')).toHaveCount(0);
-    await expect(page.getByRole('button', { name: 'Koppel artikel', exact: true })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Koppel artikel en Producttype', exact: true })).toBeDisabled();
     await expectNoConsoleErrors(consoleErrors);
   });
 
@@ -240,7 +240,7 @@ test.describe('Externe databases frontend-regressie', () => {
     await expect(candidateTable).toContainText('Geen universele kandidaten met score 0,500 of hoger voor dit bonartikel.');
     await expect(candidateTable.getByText('Fallback kandidaat')).toHaveCount(0);
     await expect(candidateTable.getByText('Geen externe match')).toHaveCount(0);
-    await expect(page.getByRole('button', { name: 'Koppel artikel', exact: true })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Koppel artikel en Producttype', exact: true })).toBeDisabled();
     await expectNoConsoleErrors(consoleErrors);
   });
 

--- a/frontend/tests/e2e/helpers/rezzervAssertions.js
+++ b/frontend/tests/e2e/helpers/rezzervAssertions.js
@@ -40,6 +40,28 @@ export async function expectAnyVisible(page, candidates, description = 'verwacht
 export async function expectRouteLoads(page, path, expectedTexts) {
   await page.goto(path);
   await expect(page.locator('body')).toBeVisible();
-  await expectAnyVisible(page, expectedTexts, `route ${path}`);
+
+  await expect.poll(
+    async () => {
+      for (const candidate of expectedTexts) {
+        const locator = typeof candidate === 'string'
+          ? page.getByText(candidate, { exact: false })
+          : page.getByText(candidate);
+        const count = await locator.count().catch(() => 0);
+        for (let index = 0; index < count; index++) {
+          if (await locator.nth(index).isVisible().catch(() => false)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    },
+    {
+      message: `Geen zichtbare match gevonden voor route ${path}: ${expectedTexts.map(String).join(' | ')}`,
+      timeout: 15000,
+      intervals: [100, 250, 500, 1000],
+    },
+  ).toBe(true);
+
   await expect(page.getByText(/Application error|Uncaught|TypeError|ReferenceError/i)).toHaveCount(0);
 }


### PR DESCRIPTION
## Samenvatting

Deze wijziging voegt Producttype-onderhoud toe aan het definitief koppelen van tijdelijke Open Food Facts-resultaten.

## Wijzigingen

- hergebruik van het bestaande `product_inventory_groups`- en `product_group_memberships`-model;
- transactionele koppeling van OFF-resultaat, universeel artikel en Producttype;
- ondersteuning voor bestaand Producttype kiezen of direct een nieuw Producttype aanmaken;
- geen opslag van tijdelijke OFF-resultaten in `external_product_candidates`;
- geen voorraadmutaties en geen nieuwe `inventory_events` tijdens koppelen;
- frontendondersteuning in Externe databases;
- aangescherpte backendcontract- en frontendregressietests.

## Validatie

- backend health: groen;
- `PRODUCT_TYPE_LINK_CONTRACT_GREEN`;
- `OFF_PRODUCT_TYPE_LINK_CONTRACT_GREEN`;
- frontendregressie: 22/22 geslaagd;
- werkboom schoon vóór push.

## Commit

`add14dda0ea6f2899c9ea9e0017de85638ae927e`