### PR TITLE
Herstel geldige GTIN in OFF-contracttest

### DIFF
--- a/backend/tests/test_off_product_type_link_contract_selftest.py
+++ b/backend/tests/test_off_product_type_link_contract_selftest.py
@@ -16,10 +16,11 @@ def _count(conn, table_name: str) -> int:
 def main() -> int:
     ensure_product_inventory_group_schema()
     suffix = uuid.uuid4().hex
+    numeric_suffix = f"{uuid.uuid4().int % 10**11:011d}"
     batch_id = f"off-link-batch-{suffix}"
     line_id = f"off-link-line-{suffix}"
     product_type_key = f"test.off.halfvolle.melk.{suffix}"
-    gtin = f"98{suffix[:11]}"
+    gtin = f"98{numeric_suffix}"
 
     with engine.begin() as conn:
         before = {
@@ -135,7 +136,7 @@ def main() -> int:
     assert result.get("mutates_inventory") is False, result
     global_product_id = str((result.get("global_product") or {}).get("id") or "")
 
-    rollback_gtin = f"97{suffix[:11]}"
+    rollback_gtin = f"97{numeric_suffix}"
     try:
         link_off_product_with_product_type(
             receipt_item_id=f"purchase-import-line:{line_id}",


### PR DESCRIPTION
## Samenvatting

Deze hotfix maakt de OFF-contracttest deterministisch door voor zowel de normale koppeling als de rollbackcontrole uitsluitend numerieke GTIN-testwaarden te genereren.

## Oorzaak

De test gebruikte een deel van `uuid.uuid4().hex`. Dat kan letters `a` tot en met `f` bevatten, terwijl de productiecode terecht alleen GTIN-waarden van 8 tot en met 14 cijfers accepteert. Daardoor kon de contracttest willekeurig falen.

## Wijziging

- aparte numerieke suffix van 11 cijfers;
- geldige 13-cijferige test-GTIN voor de normale koppeling;
- geldige 13-cijferige test-GTIN voor de rollbackcontrole;
- geen wijziging in productiecode.

## Validatie

- backend health: groen;
- Python-compile: groen;
- `git diff --check`: inhoudelijk schoon;
- `OFF_PRODUCT_TYPE_LINK_CONTRACT_GREEN`;
- frontendregressie op de voorafgaande merge: 22/22 geslaagd.

## Commit

`8feef6f9c13db2fc0b003a33dd6ae28bfa16c846`