### PR TITLE
M2C2n: harden article-group household isolation

### DIFF
--- a/.github/workflows/article-group-household-isolation.yml
+++ b/.github/workflows/article-group-household-isolation.yml
@@ -1,0 +1,41 @@
+name: Article group household isolation
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'backend/app/api/article_group_routes.py'
+      - 'backend/app/services/article_group_store.py'
+      - 'backend/app/services/article_group_secure_store.py'
+      - 'backend/app/testing/article_group_household_isolation_contract.py'
+      - '.github/workflows/article-group-household-isolation.yml'
+  workflow_dispatch:
+
+jobs:
+  validate-article-group-household-isolation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Installeer minimale backend-afhankelijkheid
+        run: python -m pip install --quiet sqlalchemy==2.0.36
+
+      - name: Compileer gewijzigde modules
+        run: |
+          python -m py_compile \
+            backend/app/services/article_group_store.py \
+            backend/app/services/article_group_secure_store.py \
+            backend/app/testing/article_group_household_isolation_contract.py
+
+      - name: Voer A-B-isolatiecontract uit
+        env:
+          PYTHONPATH: backend
+          DATABASE_URL: sqlite:///${{ runner.temp }}/rezzerv-unused-runtime.db
+        run: python -m app.testing.article_group_household_isolation_contract

--- a/backend/app/api/article_group_routes.py
+++ b/backend/app/api/article_group_routes.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Optional
 
 from fastapi import APIRouter, Body, Header, HTTPException, Query
 
-from app.services.article_group_store import (
+from app.services.article_group_secure_store import (
     assign_household_article_group,
     create_article_group,
     delete_article_group,

--- a/backend/app/services/article_group_secure_store.py
+++ b/backend/app/services/article_group_secure_store.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import text
+
+from app.services import article_group_store as legacy_store
+
+
+def list_article_groups(household_id: Any = None) -> dict[str, Any]:
+    return legacy_store.list_article_groups(household_id=household_id)
+
+
+def create_article_group(household_id: Any, name: Any) -> dict[str, Any]:
+    return legacy_store.create_article_group(household_id=household_id, name=name)
+
+
+def list_household_articles_for_grouping(household_id: Any = None) -> dict[str, Any]:
+    return legacy_store.list_household_articles_for_grouping(household_id=household_id)
+
+
+def _required_household_id(household_id: Any) -> str:
+    normalized = str(household_id or "").strip()
+    if not normalized:
+        raise ValueError("household_id is verplicht voor een huishoudgebonden mutatie")
+    return normalized
+
+
+def update_article_group(
+    group_id: Any,
+    household_id: Any,
+    name: Any = None,
+    sort_order: Any = None,
+) -> dict[str, Any]:
+    legacy_store.ensure_article_group_schema()
+    normalized_group_id = str(group_id or "").strip()
+    if not normalized_group_id:
+        return {"ok": False, "error": "Artikelgroep-id is verplicht"}
+
+    normalized_household_id = _required_household_id(household_id)
+    timestamp = legacy_store.now_iso()
+
+    with legacy_store.engine.begin() as conn:
+        existing = conn.execute(
+            text(
+                """
+                SELECT *
+                FROM article_groups
+                WHERE id = :id
+                  AND household_id = :household_id
+                LIMIT 1
+                """
+            ),
+            {
+                "id": normalized_group_id,
+                "household_id": normalized_household_id,
+            },
+        ).mappings().first()
+        if not existing:
+            return {"ok": False, "error": "Artikelgroep niet gevonden"}
+
+        next_name = legacy_store.display_article_group_name(
+            name if name is not None else existing.get("name")
+        )
+        next_normalized_name = legacy_store.normalize_article_group_name(next_name)
+        if not next_name or not next_normalized_name:
+            return {"ok": False, "error": "Artikelgroepnaam is verplicht"}
+
+        duplicate = conn.execute(
+            text(
+                """
+                SELECT id
+                FROM article_groups
+                WHERE household_id = :household_id
+                  AND normalized_name = :normalized_name
+                  AND id <> :id
+                LIMIT 1
+                """
+            ),
+            {
+                "household_id": normalized_household_id,
+                "normalized_name": next_normalized_name,
+                "id": normalized_group_id,
+            },
+        ).mappings().first()
+        if duplicate:
+            return {"ok": False, "error": "Artikelgroep bestaat al"}
+
+        try:
+            next_sort_order = int(
+                sort_order if sort_order is not None else existing.get("sort_order") or 0
+            )
+        except (TypeError, ValueError):
+            next_sort_order = int(existing.get("sort_order") or 0)
+
+        result = conn.execute(
+            text(
+                """
+                UPDATE article_groups
+                SET name = :name,
+                    normalized_name = :normalized_name,
+                    sort_order = :sort_order,
+                    updated_at = :updated_at
+                WHERE id = :id
+                  AND household_id = :household_id
+                """
+            ),
+            {
+                "id": normalized_group_id,
+                "household_id": normalized_household_id,
+                "name": next_name,
+                "normalized_name": next_normalized_name,
+                "sort_order": next_sort_order,
+                "updated_at": timestamp,
+            },
+        )
+        if int(result.rowcount or 0) != 1:
+            return {"ok": False, "error": "Artikelgroep niet gevonden"}
+
+    return {
+        "ok": True,
+        "item": {
+            "id": normalized_group_id,
+            "household_id": normalized_household_id,
+            "name": next_name,
+            "normalized_name": next_normalized_name,
+            "sort_order": next_sort_order,
+        },
+        "mutates_inventory": False,
+    }
+
+
+def delete_article_group(group_id: Any, household_id: Any) -> dict[str, Any]:
+    legacy_store.ensure_article_group_schema()
+    normalized_group_id = str(group_id or "").strip()
+    if not normalized_group_id:
+        return {"ok": False, "error": "Artikelgroep-id is verplicht"}
+
+    normalized_household_id = _required_household_id(household_id)
+
+    with legacy_store.engine.begin() as conn:
+        existing = conn.execute(
+            text(
+                """
+                SELECT id
+                FROM article_groups
+                WHERE id = :id
+                  AND household_id = :household_id
+                LIMIT 1
+                """
+            ),
+            {
+                "id": normalized_group_id,
+                "household_id": normalized_household_id,
+            },
+        ).mappings().first()
+        if not existing:
+            return {"ok": False, "error": "Artikelgroep niet gevonden"}
+
+        linked_count = 0
+        if legacy_store._table_exists(conn, "household_articles"):
+            columns = legacy_store._get_columns(conn, "household_articles")
+            if "article_group_id" in columns and "household_id" in columns:
+                linked_count = int(
+                    conn.execute(
+                        text(
+                            """
+                            SELECT COUNT(*) AS count
+                            FROM household_articles
+                            WHERE article_group_id = :id
+                              AND household_id = :household_id
+                            """
+                        ),
+                        {
+                            "id": normalized_group_id,
+                            "household_id": normalized_household_id,
+                        },
+                    ).mappings().first().get("count")
+                    or 0
+                )
+
+        if linked_count > 0:
+            suffix = "en" if linked_count != 1 else ""
+            return {
+                "ok": False,
+                "error": (
+                    "Artikelgroep kan niet worden verwijderd zolang er "
+                    f"{linked_count} artikel{suffix} aan gekoppeld zijn"
+                ),
+                "id": normalized_group_id,
+                "deleted": False,
+                "deactivated": False,
+                "linked_count": linked_count,
+                "mutates_inventory": False,
+            }
+
+        result = conn.execute(
+            text(
+                """
+                DELETE FROM article_groups
+                WHERE id = :id
+                  AND household_id = :household_id
+                """
+            ),
+            {
+                "id": normalized_group_id,
+                "household_id": normalized_household_id,
+            },
+        )
+        if int(result.rowcount or 0) != 1:
+            return {"ok": False, "error": "Artikelgroep niet gevonden"}
+
+    return {
+        "ok": True,
+        "id": normalized_group_id,
+        "deleted": True,
+        "deactivated": False,
+        "linked_count": 0,
+        "mutates_inventory": False,
+    }
+
+
+def assign_household_article_group(
+    article_id: Any,
+    article_group_id: Any = None,
+    household_id: Any = None,
+) -> dict[str, Any]:
+    legacy_store.ensure_article_group_schema()
+    normalized_article_id = str(article_id or "").strip()
+    if not normalized_article_id:
+        return {"ok": False, "error": "Artikel-id is verplicht"}
+
+    normalized_household_id = _required_household_id(household_id)
+    normalized_group_id = str(article_group_id or "").strip() or None
+
+    with legacy_store.engine.begin() as conn:
+        if not legacy_store._table_exists(conn, "household_articles"):
+            return {"ok": False, "error": "household_articles tabel ontbreekt"}
+
+        columns = legacy_store._get_columns(conn, "household_articles")
+        id_column = legacy_store._first_existing(columns, ["id", "household_article_id"])
+        if not id_column:
+            return {"ok": False, "error": "household_articles heeft geen id-kolom"}
+        if "household_id" not in columns:
+            return {
+                "ok": False,
+                "error": "household_articles heeft geen household_id-kolom",
+            }
+
+        article = conn.execute(
+            text(
+                f"""
+                SELECT CAST({id_column} AS TEXT) AS id
+                FROM household_articles
+                WHERE CAST({id_column} AS TEXT) = :id
+                  AND CAST(household_id AS TEXT) = :household_id
+                LIMIT 1
+                """
+            ),
+            {
+                "id": normalized_article_id,
+                "household_id": normalized_household_id,
+            },
+        ).mappings().first()
+        if not article:
+            return {"ok": False, "error": "Huishoudelijk artikel niet gevonden"}
+
+        group_name = "Niet ingedeeld"
+        if normalized_group_id:
+            group = conn.execute(
+                text(
+                    """
+                    SELECT id, name
+                    FROM article_groups
+                    WHERE id = :id
+                      AND household_id = :household_id
+                    LIMIT 1
+                    """
+                ),
+                {
+                    "id": normalized_group_id,
+                    "household_id": normalized_household_id,
+                },
+            ).mappings().first()
+            if not group:
+                return {"ok": False, "error": "Artikelgroep niet gevonden"}
+            group_name = str(group.get("name") or "") or group_name
+
+        result = conn.execute(
+            text(
+                f"""
+                UPDATE household_articles
+                SET article_group_id = :article_group_id
+                WHERE CAST({id_column} AS TEXT) = :id
+                  AND CAST(household_id AS TEXT) = :household_id
+                """
+            ),
+            {
+                "id": normalized_article_id,
+                "household_id": normalized_household_id,
+                "article_group_id": normalized_group_id,
+            },
+        )
+        if int(result.rowcount or 0) != 1:
+            return {"ok": False, "error": "Huishoudelijk artikel niet gevonden"}
+
+    return {
+        "ok": True,
+        "article_id": normalized_article_id,
+        "article_group_id": normalized_group_id,
+        "article_group_name": group_name,
+        "mutates_inventory": False,
+    }

--- a/backend/app/testing/article_group_household_isolation_contract.py
+++ b/backend/app/testing/article_group_household_isolation_contract.py
@@ -1,0 +1,161 @@
+"""Contracttest voor artikelgroep-isolatie tussen huishoudens A en B.
+
+Run vanuit repository root met:
+    PYTHONPATH=backend python -m app.testing.article_group_household_isolation_contract
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from sqlalchemy import create_engine, text
+
+from app.services import article_group_secure_store as secure_store
+from app.services import article_group_store as legacy_store
+
+
+def _expect_failure(result: dict, expected_error: str) -> None:
+    assert result.get("ok") is False, result
+    assert result.get("error") == expected_error, result
+
+
+def run_contract() -> None:
+    original_engine = legacy_store.engine
+
+    with tempfile.TemporaryDirectory(prefix="rezzerv-article-group-isolation-") as tmp:
+        database_path = Path(tmp) / "contract.sqlite"
+        test_engine = create_engine(
+            f"sqlite:///{database_path}",
+            connect_args={"check_same_thread": False},
+        )
+        legacy_store.engine = test_engine
+
+        try:
+            with test_engine.begin() as conn:
+                conn.execute(
+                    text(
+                        """
+                        CREATE TABLE household_articles (
+                            id TEXT PRIMARY KEY,
+                            household_id TEXT NOT NULL,
+                            custom_name TEXT,
+                            article_group_id TEXT
+                        )
+                        """
+                    )
+                )
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO household_articles (
+                            id,
+                            household_id,
+                            custom_name,
+                            article_group_id
+                        ) VALUES
+                            ('article-a', 'household-a', 'Artikel A', NULL),
+                            ('article-b', 'household-b', 'Artikel B', NULL)
+                        """
+                    )
+                )
+
+            group_a = secure_store.create_article_group("household-a", "Groep A")
+            group_b = secure_store.create_article_group("household-b", "Groep B")
+            assert group_a.get("ok") is True, group_a
+            assert group_b.get("ok") is True, group_b
+
+            group_a_id = str(group_a["item"]["id"])
+            group_b_id = str(group_b["item"]["id"])
+
+            own_update = secure_store.update_article_group(
+                group_id=group_a_id,
+                household_id="household-a",
+                name="Groep A gewijzigd",
+            )
+            assert own_update.get("ok") is True, own_update
+
+            _expect_failure(
+                secure_store.update_article_group(
+                    group_id=group_b_id,
+                    household_id="household-a",
+                    name="Ongeoorloofd gewijzigd",
+                ),
+                "Artikelgroep niet gevonden",
+            )
+            _expect_failure(
+                secure_store.delete_article_group(
+                    group_id=group_b_id,
+                    household_id="household-a",
+                ),
+                "Artikelgroep niet gevonden",
+            )
+            _expect_failure(
+                secure_store.assign_household_article_group(
+                    article_id="article-b",
+                    article_group_id=group_a_id,
+                    household_id="household-a",
+                ),
+                "Huishoudelijk artikel niet gevonden",
+            )
+            _expect_failure(
+                secure_store.assign_household_article_group(
+                    article_id="article-a",
+                    article_group_id=group_b_id,
+                    household_id="household-a",
+                ),
+                "Artikelgroep niet gevonden",
+            )
+
+            own_assignment = secure_store.assign_household_article_group(
+                article_id="article-a",
+                article_group_id=group_a_id,
+                household_id="household-a",
+            )
+            assert own_assignment.get("ok") is True, own_assignment
+
+            with test_engine.begin() as conn:
+                article_a = conn.execute(
+                    text(
+                        """
+                        SELECT household_id, article_group_id
+                        FROM household_articles
+                        WHERE id = 'article-a'
+                        """
+                    )
+                ).mappings().one()
+                article_b = conn.execute(
+                    text(
+                        """
+                        SELECT household_id, article_group_id
+                        FROM household_articles
+                        WHERE id = 'article-b'
+                        """
+                    )
+                ).mappings().one()
+                stored_group_b = conn.execute(
+                    text(
+                        """
+                        SELECT household_id, name
+                        FROM article_groups
+                        WHERE id = :id
+                        """
+                    ),
+                    {"id": group_b_id},
+                ).mappings().one()
+
+            assert article_a["household_id"] == "household-a"
+            assert article_a["article_group_id"] == group_a_id
+            assert article_b["household_id"] == "household-b"
+            assert article_b["article_group_id"] is None
+            assert stored_group_b["household_id"] == "household-b"
+            assert stored_group_b["name"] == "Groep B"
+
+            print("ARTICLE_GROUP_HOUSEHOLD_ISOLATION_CONTRACT_GREEN")
+        finally:
+            legacy_store.engine = original_engine
+            test_engine.dispose()
+
+
+if __name__ == "__main__":
+    run_contract()


### PR DESCRIPTION
## Doel
Artikelgroepmutaties volledig begrenzen op het actieve huishouden.

## Gewijzigd
- nieuwe beveiligde storelaag voor artikelgroepmutaties
- bestaande artikelgroeproutes aangesloten op die storelaag

## Niet gewijzigd
- frontend
- databaseschema
- kassabonlogica
- voorraadprojectie
- globale productcatalogus

## Acceptatie
- update/delete op artikelgroepen filtert op id + household_id
- koppelen van huishoudartikel aan artikelgroep filtert op artikel-id + household_id
- cross-household object-ID's leveren geen mutatie op
- bestaande routes en rollen blijven ongewijzigd

## Risico
Laag tot middel: uitsluitend backend artikelgroepmutaties, met bestaande routecontracten behouden.