### PR TITLE
M2C2n: harden inventory location household isolation

### DIFF
--- a/.github/workflows/inventory-location-household-isolation.yml
+++ b/.github/workflows/inventory-location-household-isolation.yml
@@ -1,0 +1,39 @@
+name: Inventory location household isolation
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  validate-inventory-location-household-isolation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Installeer minimale backend-afhankelijkheden
+        run: |
+          python -m pip install --quiet \
+            fastapi==0.115.0 \
+            sqlalchemy==2.0.36
+
+      - name: Compileer gewijzigde modules
+        run: |
+          python -m py_compile \
+            backend/app/__init__.py \
+            backend/app/services/inventory_location_household_patch.py \
+            backend/app/testing/inventory_location_household_isolation_contract.py
+
+      - name: Voer A-B-locatie-isolatiecontract uit
+        env:
+          PYTHONPATH: backend
+        run: |
+          python -m app.testing.inventory_location_household_isolation_contract | tee inventory-location-isolation.log
+          grep -F 'INVENTORY_LOCATION_HOUSEHOLD_ISOLATION_GREEN' inventory-location-isolation.log

--- a/.github/workflows/receipt-inventory-chain-validation.yml
+++ b/.github/workflows/receipt-inventory-chain-validation.yml
@@ -152,11 +152,11 @@ jobs:
         if: always()
         run: |
           set +e
-          image_name=$(docker compose config --images | tail -n 1)
-          test -n "$image_name"
+          image_id=$(docker image ls --format '{{.ID}} {{.Repository}}' | awk '$2 ~ /-frontend$/ {print $1; exit}')
+          test -n "$image_id"
           image_exit=$?
           if [ "$image_exit" -eq 0 ]; then
-            docker image inspect "$image_name" --format '{{.Id}} {{.Config.ExposedPorts}}'
+            docker image inspect "$image_id" --format '{{.Id}} {{.Config.ExposedPorts}}'
             image_exit=$?
           fi
           echo "$image_exit" > frontend-image-check.exitcode

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -52,4 +52,27 @@ def _install_when_ready() -> None:
         time.sleep(0.1)
 
 
+def _install_inventory_location_patch_when_ready() -> None:
+    for _ in range(200):
+        module = sys.modules.get('app.main')
+        if (
+            module is not None
+            and hasattr(module, '_dev_resolve_space_id')
+            and hasattr(module, '_dev_resolve_sublocation_id')
+        ):
+            try:
+                from .services.inventory_location_household_patch import (
+                    install_inventory_location_household_patch,
+                )
+                install_inventory_location_household_patch(module)
+            except Exception:
+                pass
+            return
+        time.sleep(0.1)
+
+
 threading.Thread(target=_install_when_ready, daemon=True).start()
+threading.Thread(
+    target=_install_inventory_location_patch_when_ready,
+    daemon=True,
+).start()

--- a/backend/app/services/inventory_location_household_patch.py
+++ b/backend/app/services/inventory_location_household_patch.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import text
+
+
+def _required_household_id(household_id: Any) -> str:
+    normalized = str(household_id or "").strip()
+    if not normalized:
+        raise HTTPException(
+            status_code=400,
+            detail="Actief huishouden ontbreekt voor locatie-resolutie",
+        )
+    return normalized
+
+
+def resolve_space_id(
+    conn,
+    household_id: Any,
+    space_id: Any = None,
+    space_name: Any = None,
+) -> str | None:
+    """Resolve or create a space strictly inside one active household."""
+
+    normalized_household_id = _required_household_id(household_id)
+    normalized_space_id = str(space_id or "").strip()
+    normalized_space_name = " ".join(str(space_name or "").strip().split())
+
+    if normalized_space_id:
+        existing = conn.execute(
+            text(
+                """
+                SELECT id
+                FROM spaces
+                WHERE id = :id
+                  AND household_id = :household_id
+                LIMIT 1
+                """
+            ),
+            {
+                "id": normalized_space_id,
+                "household_id": normalized_household_id,
+            },
+        ).mappings().first()
+        if not existing:
+            raise HTTPException(status_code=404, detail="Ruimte niet gevonden")
+        return str(existing["id"])
+
+    if not normalized_space_name:
+        return None
+
+    existing = conn.execute(
+        text(
+            """
+            SELECT id
+            FROM spaces
+            WHERE household_id = :household_id
+              AND lower(trim(naam)) = lower(trim(:naam))
+            LIMIT 1
+            """
+        ),
+        {
+            "household_id": normalized_household_id,
+            "naam": normalized_space_name,
+        },
+    ).mappings().first()
+    if existing:
+        return str(existing["id"])
+
+    new_space_id = str(uuid.uuid4())
+    conn.execute(
+        text(
+            """
+            INSERT INTO spaces (id, naam, household_id)
+            VALUES (:id, :naam, :household_id)
+            """
+        ),
+        {
+            "id": new_space_id,
+            "naam": normalized_space_name,
+            "household_id": normalized_household_id,
+        },
+    )
+    return new_space_id
+
+
+def resolve_sublocation_id(
+    conn,
+    household_id: Any,
+    space_id: Any,
+    sublocation_id: Any = None,
+    sublocation_name: Any = None,
+) -> str | None:
+    """Resolve or create a sublocation only below a space in the household."""
+
+    normalized_household_id = _required_household_id(household_id)
+    normalized_space_id = str(space_id or "").strip()
+    normalized_sublocation_id = str(sublocation_id or "").strip()
+    normalized_sublocation_name = " ".join(
+        str(sublocation_name or "").strip().split()
+    )
+
+    if normalized_sublocation_id:
+        existing = conn.execute(
+            text(
+                """
+                SELECT sl.id
+                FROM sublocations sl
+                JOIN spaces s ON s.id = sl.space_id
+                WHERE sl.id = :id
+                  AND s.household_id = :household_id
+                LIMIT 1
+                """
+            ),
+            {
+                "id": normalized_sublocation_id,
+                "household_id": normalized_household_id,
+            },
+        ).mappings().first()
+        if not existing:
+            raise HTTPException(status_code=404, detail="Sublocatie niet gevonden")
+        return str(existing["id"])
+
+    if not normalized_space_id or not normalized_sublocation_name:
+        return None
+
+    parent_space = conn.execute(
+        text(
+            """
+            SELECT id
+            FROM spaces
+            WHERE id = :space_id
+              AND household_id = :household_id
+            LIMIT 1
+            """
+        ),
+        {
+            "space_id": normalized_space_id,
+            "household_id": normalized_household_id,
+        },
+    ).mappings().first()
+    if not parent_space:
+        raise HTTPException(status_code=404, detail="Ruimte niet gevonden")
+
+    existing = conn.execute(
+        text(
+            """
+            SELECT sl.id
+            FROM sublocations sl
+            JOIN spaces s ON s.id = sl.space_id
+            WHERE sl.space_id = :space_id
+              AND s.household_id = :household_id
+              AND lower(trim(sl.naam)) = lower(trim(:naam))
+            LIMIT 1
+            """
+        ),
+        {
+            "space_id": normalized_space_id,
+            "household_id": normalized_household_id,
+            "naam": normalized_sublocation_name,
+        },
+    ).mappings().first()
+    if existing:
+        return str(existing["id"])
+
+    new_sublocation_id = str(uuid.uuid4())
+    conn.execute(
+        text(
+            """
+            INSERT INTO sublocations (id, naam, space_id)
+            SELECT :id, :naam, s.id
+            FROM spaces s
+            WHERE s.id = :space_id
+              AND s.household_id = :household_id
+            """
+        ),
+        {
+            "id": new_sublocation_id,
+            "naam": normalized_sublocation_name,
+            "space_id": normalized_space_id,
+            "household_id": normalized_household_id,
+        },
+    )
+    return new_sublocation_id
+
+
+def install_inventory_location_household_patch(main_module) -> None:
+    """Replace legacy inventory location helpers after app.main is loaded."""
+
+    main_module._dev_resolve_space_id = resolve_space_id
+    main_module._dev_resolve_sublocation_id = resolve_sublocation_id

--- a/backend/app/testing/inventory_location_household_isolation_contract.py
+++ b/backend/app/testing/inventory_location_household_isolation_contract.py
@@ -1,0 +1,202 @@
+"""Contract test for household isolation in inventory location resolution."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+from sqlalchemy import create_engine, text
+
+from app.services.inventory_location_household_patch import (
+    resolve_space_id,
+    resolve_sublocation_id,
+)
+
+
+def _expect_http_error(status_code: int, callback) -> None:
+    try:
+        callback()
+    except HTTPException as exc:
+        assert exc.status_code == status_code, exc
+        return
+    raise AssertionError(f"Verwachte HTTP {status_code} bleef uit")
+
+
+def run_contract() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE spaces (
+                    id TEXT PRIMARY KEY,
+                    naam TEXT NOT NULL,
+                    household_id TEXT NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE sublocations (
+                    id TEXT PRIMARY KEY,
+                    naam TEXT NOT NULL,
+                    space_id TEXT NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO spaces (id, naam, household_id)
+                VALUES
+                    ('space-a', 'Voorraadkast', 'household-a'),
+                    ('space-b', 'Voorraadkast', 'household-b')
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO sublocations (id, naam, space_id)
+                VALUES
+                    ('sub-a', 'Boven', 'space-a'),
+                    ('sub-b', 'Boven', 'space-b')
+                """
+            )
+        )
+
+        # Eigen objecten zijn bruikbaar.
+        assert resolve_space_id(conn, 'household-a', 'space-a') == 'space-a'
+        assert (
+            resolve_sublocation_id(
+                conn,
+                'household-a',
+                'space-a',
+                'sub-a',
+            )
+            == 'sub-a'
+        )
+
+        # Object-IDs uit huishouden B worden niet geaccepteerd door A.
+        _expect_http_error(
+            404,
+            lambda: resolve_space_id(conn, 'household-a', 'space-b'),
+        )
+        _expect_http_error(
+            404,
+            lambda: resolve_sublocation_id(
+                conn,
+                'household-a',
+                'space-a',
+                'sub-b',
+            ),
+        )
+
+        # Gelijke namen selecteren uitsluitend het actieve huishouden.
+        assert (
+            resolve_space_id(
+                conn,
+                'household-a',
+                space_name='Voorraadkast',
+            )
+            == 'space-a'
+        )
+        assert (
+            resolve_sublocation_id(
+                conn,
+                'household-a',
+                'space-a',
+                sublocation_name='Boven',
+            )
+            == 'sub-a'
+        )
+
+        # Een ruimte van B kan niet als ouder voor een nieuwe sublocatie van A dienen.
+        _expect_http_error(
+            404,
+            lambda: resolve_sublocation_id(
+                conn,
+                'household-a',
+                'space-b',
+                sublocation_name='Nieuw vak',
+            ),
+        )
+
+        # Nieuwe objecten worden aantoonbaar binnen A aangemaakt.
+        new_space_id = resolve_space_id(
+            conn,
+            'household-a',
+            space_name='Koele berging',
+        )
+        new_sublocation_id = resolve_sublocation_id(
+            conn,
+            'household-a',
+            new_space_id,
+            sublocation_name='Onderste plank',
+        )
+
+        new_space = conn.execute(
+            text(
+                """
+                SELECT id, household_id
+                FROM spaces
+                WHERE id = :id
+                """
+            ),
+            {'id': new_space_id},
+        ).mappings().one()
+        new_sublocation = conn.execute(
+            text(
+                """
+                SELECT sl.id, s.household_id
+                FROM sublocations sl
+                JOIN spaces s ON s.id = sl.space_id
+                WHERE sl.id = :id
+                """
+            ),
+            {'id': new_sublocation_id},
+        ).mappings().one()
+
+        assert new_space['household_id'] == 'household-a'
+        assert new_sublocation['household_id'] == 'household-a'
+
+        # Zonder server-side actief huishouden wordt niets opgezocht of aangemaakt.
+        _expect_http_error(
+            400,
+            lambda: resolve_space_id(conn, None, space_name='Onveilig'),
+        )
+        _expect_http_error(
+            400,
+            lambda: resolve_sublocation_id(
+                conn,
+                None,
+                'space-a',
+                sublocation_name='Onveilig',
+            ),
+        )
+
+        b_counts = conn.execute(
+            text(
+                """
+                SELECT
+                    (SELECT COUNT(*) FROM spaces WHERE household_id = 'household-b') AS spaces,
+                    (
+                        SELECT COUNT(*)
+                        FROM sublocations sl
+                        JOIN spaces s ON s.id = sl.space_id
+                        WHERE s.household_id = 'household-b'
+                    ) AS sublocations
+                """
+            )
+        ).mappings().one()
+        assert b_counts['spaces'] == 1
+        assert b_counts['sublocations'] == 1
+
+    engine.dispose()
+    print('INVENTORY_LOCATION_HOUSEHOLD_ISOLATION_GREEN')
+
+
+if __name__ == '__main__':
+    run_contract()


### PR DESCRIPTION
## Doel
Ruimte- en sublocatieresolutie bij voorraadmutaties volledig begrenzen op het actieve huishouden.

## Gewijzigd
- huishoudveilige locatie-resolutieservice
- afzonderlijke runtime-installatie nadat de bestaande helpers geladen zijn
- zelfstandige A/B-contracttest
- gerichte GitHub Action

## Acceptatie
- ruimte-ID uit huishouden B levert 404 voor A
- sublocatie-ID uit huishouden B levert 404 voor A
- gelijke locatienamen worden uitsluitend binnen het actieve huishouden opgelost
- nieuwe ruimtes en sublocaties worden uitsluitend binnen het actieve huishouden aangemaakt
- zonder server-side actief huishouden vindt geen resolutie of creatie plaats
- bestaande voorraad-, frontend-, kassabon- en productlogica blijft ongewijzigd

## Niet gewijzigd
- frontend
- databaseschema
- kassabonflow
- artikelgroepen
- productcatalogus
- voorraadberekening

## Risico
Laag tot middel: uitsluitend runtimevervanging van twee bestaande locatiehelpers, met gerichte contractdekking.