### PR TITLE
Release: fix frontend image validation gate

### DIFF
--- a/.github/workflows/receipt-inventory-chain-validation.yml
+++ b/.github/workflows/receipt-inventory-chain-validation.yml
@@ -152,7 +152,7 @@ jobs:
         if: always()
         run: |
           set +e
-          image_id=$(docker compose images -q frontend | head -n 1)
+          image_id=$(docker image ls --format '{{.ID}} {{.Repository}}' | awk '$2 ~ /-frontend$/ {print $1; exit}')
           test -n "$image_id"
           image_exit=$?
           if [ "$image_exit" -eq 0 ]; then

--- a/.github/workflows/receipt-inventory-chain-validation.yml
+++ b/.github/workflows/receipt-inventory-chain-validation.yml
@@ -152,11 +152,11 @@ jobs:
         if: always()
         run: |
           set +e
-          image_name=$(docker compose config --images | tail -n 1)
-          test -n "$image_name"
+          image_id=$(docker compose images -q frontend | head -n 1)
+          test -n "$image_id"
           image_exit=$?
           if [ "$image_exit" -eq 0 ]; then
-            docker image inspect "$image_name" --format '{{.Id}} {{.Config.ExposedPorts}}'
+            docker image inspect "$image_id" --format '{{.Id}} {{.Config.ExposedPorts}}'
             image_exit=$?
           fi
           echo "$image_exit" > frontend-image-check.exitcode


### PR DESCRIPTION
## Doel
De frontend-Dockerreleasegate het daadwerkelijk gebouwde frontendimage laten controleren.

## Oorzaak
De build was groen en het image was geladen, maar de gate leidde een imagenaam af via `docker compose config --images`. De artifact bewees daardoor `frontend-docker-build.exitcode=0` en `frontend-image-check.exitcode=1`.

## Wijziging
- gebruik `docker compose images -q frontend` om het daadwerkelijk gebouwde image-ID op te halen;
- inspecteer dat image-ID rechtstreeks;
- behoud alle bestaande build-, artifact- en runtimecontroles.

## Scope
Exact één GitHub Actions-workflowbestand. Geen applicatiecode, frontendcode, backendcode of databaseschema.