### PR TITLE
M2C2n: harden unpacking target-location household isolation

### DIFF
--- a/.github/workflows/unpacking-household-location-isolation.yml
+++ b/.github/workflows/unpacking-household-location-isolation.yml
@@ -1,0 +1,39 @@
+name: Unpacking household location isolation
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  validate-unpacking-household-location-isolation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Installeer minimale backend-afhankelijkheden
+        run: |
+          python -m pip install --quiet \
+            fastapi==0.115.0 \
+            sqlalchemy==2.0.36
+
+      - name: Compileer gewijzigde modules
+        run: |
+          python -m py_compile \
+            backend/app/__init__.py \
+            backend/app/services/unpacking_household_location_patch.py \
+            backend/app/testing/unpacking_household_location_isolation_contract.py
+
+      - name: Voer A-B-Uitpakken-locatiecontract uit
+        env:
+          PYTHONPATH: backend
+        run: |
+          python -m app.testing.unpacking_household_location_isolation_contract | tee unpacking-household-location-isolation.log
+          grep -F 'UNPACKING_HOUSEHOLD_LOCATION_ISOLATION_GREEN' unpacking-household-location-isolation.log

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -71,8 +71,31 @@ def _install_inventory_location_patch_when_ready() -> None:
         time.sleep(0.1)
 
 
+def _install_unpacking_location_patch_when_ready() -> None:
+    for _ in range(200):
+        module = sys.modules.get('app.main')
+        if (
+            module is not None
+            and hasattr(module, 'validate_purchase_import_target_location')
+            and hasattr(module, 'resolve_space_and_sublocation_ids')
+        ):
+            try:
+                from .services.unpacking_household_location_patch import (
+                    install_unpacking_household_location_patch,
+                )
+                install_unpacking_household_location_patch(module)
+            except Exception:
+                pass
+            return
+        time.sleep(0.1)
+
+
 threading.Thread(target=_install_when_ready, daemon=True).start()
 threading.Thread(
     target=_install_inventory_location_patch_when_ready,
+    daemon=True,
+).start()
+threading.Thread(
+    target=_install_unpacking_location_patch_when_ready,
     daemon=True,
 ).start()

--- a/backend/app/services/unpacking_household_location_patch.py
+++ b/backend/app/services/unpacking_household_location_patch.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import text
+
+
+def _required_household_id(value: Any) -> str:
+    household_id = str(value or "").strip()
+    if not household_id:
+        raise HTTPException(status_code=400, detail="Actief huishouden ontbreekt")
+    return household_id
+
+
+def _line_reference(row, line_id: str) -> dict:
+    if not row:
+        return {"line_id": str(line_id)}
+    external_ref = str(row.get("external_line_ref") or "").strip()
+    display_ref = external_ref or f"regel {int(row.get('ui_sort_order') or 0) + 1}"
+    article_name = str(row.get("article_name_raw") or "").strip()
+    return {
+        "line_id": str(row.get("id") or line_id),
+        "batch_id": str(row.get("batch_id") or ""),
+        "household_id": str(row.get("household_id") or ""),
+        "external_line_ref": external_ref,
+        "ui_line_number": int(row.get("ui_sort_order") or 0) + 1,
+        "article_name": article_name,
+        "target_location_id": str(row.get("target_location_id") or ""),
+        "review_decision": str(row.get("review_decision") or "pending"),
+        "display_label": f"{display_ref}: {article_name}" if article_name else display_ref,
+    }
+
+
+def validate_purchase_import_target_location(conn, line_id: str, target_location_id: str | None):
+    line = conn.execute(
+        text(
+            """
+            SELECT pil.id,
+                   pil.batch_id,
+                   pil.external_line_ref,
+                   pil.article_name_raw,
+                   pil.target_location_id,
+                   pil.review_decision,
+                   COALESCE(pil.ui_sort_order, 0) AS ui_sort_order,
+                   pib.household_id
+            FROM purchase_import_lines pil
+            JOIN purchase_import_batches pib ON pib.id = pil.batch_id
+            WHERE pil.id = :line_id
+            LIMIT 1
+            """
+        ),
+        {"line_id": str(line_id)},
+    ).mappings().first()
+    if not line:
+        raise HTTPException(status_code=404, detail="Inkoopregel niet gevonden")
+
+    household_id = _required_household_id(line.get("household_id"))
+    line_ref = _line_reference(line, line_id)
+    normalized_target_id = str(target_location_id or "").strip()
+    if not normalized_target_id:
+        return None, line_ref
+
+    sublocation = conn.execute(
+        text(
+            """
+            SELECT sl.id AS location_id,
+                   sl.space_id,
+                   s.naam AS space_name,
+                   sl.naam AS sublocation_name
+            FROM sublocations sl
+            JOIN spaces s ON s.id = sl.space_id
+            WHERE sl.id = :target_location_id
+              AND s.household_id = :household_id
+            LIMIT 1
+            """
+        ),
+        {
+            "target_location_id": normalized_target_id,
+            "household_id": household_id,
+        },
+    ).mappings().first()
+    if sublocation:
+        return {
+            "location_id": str(sublocation["location_id"]),
+            "space_id": str(sublocation["space_id"]),
+            "sublocation_id": str(sublocation["location_id"]),
+            "location_label": f"{sublocation['space_name']} / {sublocation['sublocation_name']}",
+        }, line_ref
+
+    space = conn.execute(
+        text(
+            """
+            SELECT id, naam
+            FROM spaces
+            WHERE id = :target_location_id
+              AND household_id = :household_id
+            LIMIT 1
+            """
+        ),
+        {
+            "target_location_id": normalized_target_id,
+            "household_id": household_id,
+        },
+    ).mappings().first()
+    if space:
+        return {
+            "location_id": str(space["id"]),
+            "space_id": str(space["id"]),
+            "sublocation_id": None,
+            "location_label": str(space["naam"]),
+        }, line_ref
+
+    return None, line_ref
+
+
+def resolve_space_and_sublocation_ids(
+    conn,
+    household_id: Any,
+    space_id: str | None = None,
+    sublocation_id: str | None = None,
+    space_name: str | None = None,
+    sublocation_name: str | None = None,
+):
+    household_id = _required_household_id(household_id)
+    normalized_space_name = " ".join(str(space_name or "").strip().split()) or None
+    normalized_sublocation_name = " ".join(str(sublocation_name or "").strip().split()) or None
+    resolved_space_id = str(space_id or "").strip() or None
+    resolved_sublocation_id = str(sublocation_id or "").strip() or None
+
+    if resolved_space_id:
+        row = conn.execute(
+            text("SELECT id FROM spaces WHERE id = :id AND household_id = :household_id LIMIT 1"),
+            {"id": resolved_space_id, "household_id": household_id},
+        ).mappings().first()
+        if not row:
+            raise HTTPException(status_code=400, detail="Onbekende space_id")
+    elif normalized_space_name:
+        row = conn.execute(
+            text("SELECT id FROM spaces WHERE household_id = :household_id AND lower(trim(naam)) = lower(trim(:naam)) LIMIT 1"),
+            {"household_id": household_id, "naam": normalized_space_name},
+        ).mappings().first()
+        if row:
+            resolved_space_id = str(row["id"])
+        else:
+            resolved_space_id = str(conn.execute(
+                text("INSERT INTO spaces (id, naam, household_id) VALUES (lower(hex(randomblob(16))), :naam, :household_id) RETURNING id"),
+                {"naam": normalized_space_name, "household_id": household_id},
+            ).scalar_one())
+
+    if resolved_sublocation_id:
+        row = conn.execute(
+            text(
+                """
+                SELECT sl.id, sl.space_id
+                FROM sublocations sl
+                JOIN spaces s ON s.id = sl.space_id
+                WHERE sl.id = :id
+                  AND s.household_id = :household_id
+                LIMIT 1
+                """
+            ),
+            {"id": resolved_sublocation_id, "household_id": household_id},
+        ).mappings().first()
+        if not row:
+            raise HTTPException(status_code=400, detail="Onbekende sublocation_id")
+        if resolved_space_id and str(row["space_id"]) != resolved_space_id:
+            raise HTTPException(status_code=400, detail="sublocation_id hoort niet bij de gekozen ruimte")
+        resolved_space_id = resolved_space_id or str(row["space_id"])
+    elif normalized_sublocation_name:
+        if not resolved_space_id:
+            raise HTTPException(status_code=400, detail="Ruimte is verplicht voor een sublocatie")
+        row = conn.execute(
+            text(
+                """
+                SELECT sl.id
+                FROM sublocations sl
+                JOIN spaces s ON s.id = sl.space_id
+                WHERE sl.space_id = :space_id
+                  AND s.household_id = :household_id
+                  AND lower(trim(sl.naam)) = lower(trim(:naam))
+                LIMIT 1
+                """
+            ),
+            {
+                "space_id": resolved_space_id,
+                "household_id": household_id,
+                "naam": normalized_sublocation_name,
+            },
+        ).mappings().first()
+        if row:
+            resolved_sublocation_id = str(row["id"])
+        else:
+            resolved_sublocation_id = str(conn.execute(
+                text(
+                    """
+                    INSERT INTO sublocations (id, naam, space_id)
+                    SELECT lower(hex(randomblob(16))), :naam, s.id
+                    FROM spaces s
+                    WHERE s.id = :space_id
+                      AND s.household_id = :household_id
+                    RETURNING id
+                    """
+                ),
+                {
+                    "naam": normalized_sublocation_name,
+                    "space_id": resolved_space_id,
+                    "household_id": household_id,
+                },
+            ).scalar_one())
+
+    return resolved_space_id, resolved_sublocation_id
+
+
+def install_unpacking_household_location_patch(main_module) -> None:
+    main_module.validate_purchase_import_target_location = validate_purchase_import_target_location
+    main_module.resolve_space_and_sublocation_ids = resolve_space_and_sublocation_ids

--- a/backend/app/testing/unpacking_household_location_isolation_contract.py
+++ b/backend/app/testing/unpacking_household_location_isolation_contract.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from fastapi import HTTPException
+from sqlalchemy import create_engine, text
+
+from app.services.unpacking_household_location_patch import (
+    resolve_space_and_sublocation_ids,
+    validate_purchase_import_target_location,
+)
+
+
+def _expect_http_error(status_code: int, callback) -> None:
+    try:
+        callback()
+    except HTTPException as exc:
+        assert exc.status_code == status_code, exc
+        return
+    raise AssertionError(f"Verwachte HTTP {status_code} bleef uit")
+
+
+def run_contract() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE purchase_import_batches (id TEXT PRIMARY KEY, household_id TEXT NOT NULL)"))
+        conn.execute(text("""
+            CREATE TABLE purchase_import_lines (
+                id TEXT PRIMARY KEY,
+                batch_id TEXT NOT NULL,
+                external_line_ref TEXT,
+                article_name_raw TEXT,
+                target_location_id TEXT,
+                review_decision TEXT,
+                ui_sort_order INTEGER
+            )
+        """))
+        conn.execute(text("CREATE TABLE spaces (id TEXT PRIMARY KEY, naam TEXT NOT NULL, household_id TEXT NOT NULL)"))
+        conn.execute(text("CREATE TABLE sublocations (id TEXT PRIMARY KEY, naam TEXT NOT NULL, space_id TEXT NOT NULL)"))
+
+        conn.execute(text("""
+            INSERT INTO purchase_import_batches (id, household_id)
+            VALUES ('batch-a', 'household-a'), ('batch-b', 'household-b')
+        """))
+        conn.execute(text("""
+            INSERT INTO purchase_import_lines (
+                id, batch_id, external_line_ref, article_name_raw,
+                target_location_id, review_decision, ui_sort_order
+            ) VALUES
+                ('line-a', 'batch-a', 'a-1', 'Melk', NULL, 'selected', 0),
+                ('line-b', 'batch-b', 'b-1', 'Brood', NULL, 'selected', 0)
+        """))
+        conn.execute(text("""
+            INSERT INTO spaces (id, naam, household_id)
+            VALUES
+                ('space-a', 'Voorraadkast', 'household-a'),
+                ('space-b', 'Voorraadkast', 'household-b')
+        """))
+        conn.execute(text("""
+            INSERT INTO sublocations (id, naam, space_id)
+            VALUES
+                ('sub-a', 'Boven', 'space-a'),
+                ('sub-b', 'Boven', 'space-b')
+        """))
+
+        resolved, line_ref = validate_purchase_import_target_location(conn, 'line-a', 'space-a')
+        assert resolved and resolved['space_id'] == 'space-a'
+        assert line_ref['household_id'] == 'household-a'
+
+        resolved, _ = validate_purchase_import_target_location(conn, 'line-a', 'sub-a')
+        assert resolved and resolved['sublocation_id'] == 'sub-a'
+
+        resolved, _ = validate_purchase_import_target_location(conn, 'line-a', 'space-b')
+        assert resolved is None
+        resolved, _ = validate_purchase_import_target_location(conn, 'line-a', 'sub-b')
+        assert resolved is None
+
+        _expect_http_error(
+            404,
+            lambda: validate_purchase_import_target_location(conn, 'missing-line', 'space-a'),
+        )
+
+        own_space, own_sub = resolve_space_and_sublocation_ids(
+            conn,
+            'household-a',
+            space_id='space-a',
+            sublocation_id='sub-a',
+        )
+        assert own_space == 'space-a'
+        assert own_sub == 'sub-a'
+
+        _expect_http_error(
+            400,
+            lambda: resolve_space_and_sublocation_ids(
+                conn,
+                'household-a',
+                space_id='space-b',
+            ),
+        )
+        _expect_http_error(
+            400,
+            lambda: resolve_space_and_sublocation_ids(
+                conn,
+                'household-a',
+                sublocation_id='sub-b',
+            ),
+        )
+        _expect_http_error(
+            400,
+            lambda: resolve_space_and_sublocation_ids(
+                conn,
+                None,
+                space_name='Onveilig',
+            ),
+        )
+
+        new_space, new_sub = resolve_space_and_sublocation_ids(
+            conn,
+            'household-a',
+            space_name='Koele berging',
+            sublocation_name='Onderste plank',
+        )
+        created = conn.execute(text("""
+            SELECT s.household_id, sl.id AS sublocation_id
+            FROM spaces s
+            JOIN sublocations sl ON sl.space_id = s.id
+            WHERE s.id = :space_id AND sl.id = :sublocation_id
+        """), {'space_id': new_space, 'sublocation_id': new_sub}).mappings().one()
+        assert created['household_id'] == 'household-a'
+
+        b_counts = conn.execute(text("""
+            SELECT
+                (SELECT COUNT(*) FROM spaces WHERE household_id = 'household-b') AS spaces,
+                (SELECT COUNT(*) FROM sublocations sl JOIN spaces s ON s.id = sl.space_id WHERE s.household_id = 'household-b') AS sublocations
+        """)).mappings().one()
+        assert int(b_counts['spaces']) == 1
+        assert int(b_counts['sublocations']) == 1
+
+    print('UNPACKING_HOUSEHOLD_LOCATION_ISOLATION_GREEN')
+
+
+if __name__ == '__main__':
+    run_contract()


### PR DESCRIPTION
## Doel
Uitpakken-doellocaties en locatieaanmaak uitsluitend binnen het huishouden van de inkoopbatch laten plaatsvinden.

## Gewijzigd
- huishoudveilige validatie van doelruimte en doelsublocatie via purchase_import_lines → purchase_import_batches;
- fail-closed ruimte-/sublocatieresolutie zonder demo-household fallback;
- runtime-installatie nadat de bestaande helpers geladen zijn;
- zelfstandige A/B-contracttest;
- gerichte GitHub Action.

## Acceptatie
- importregel van A accepteert eigen ruimte en sublocatie;
- importregel van A accepteert geen ruimte of sublocatie van B;
- ontbrekende importregel levert 404;
- aangeleverd sublocation_id wordt via de bovenliggende ruimte op household_id gecontroleerd;
- ontbrekende server-side huishoudcontext blokkeert resolutie en aanmaak;
- nieuwe ruimte en sublocatie worden uitsluitend binnen A aangemaakt;
- B-data blijft ongewijzigd.

## Niet gewijzigd
- frontend;
- databaseschema;
- kassabonparser;
- artikelgroepen;
- productcatalogus;
- voorraadberekeningen.

## Risico
Laag tot middel: uitsluitend twee bestaande locatiehelpers worden na laden vervangen, met gerichte contractdekking.