### PR TITLE
M2C2n: guard unpacking batch and line household access

### DIFF
--- a/.github/workflows/unpacking-household-object-guard.yml
+++ b/.github/workflows/unpacking-household-object-guard.yml
@@ -1,0 +1,39 @@
+name: Unpacking household object guard
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  validate-unpacking-household-object-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Installeer minimale backend-afhankelijkheden
+        run: |
+          python -m pip install --quiet \
+            fastapi==0.115.0 \
+            sqlalchemy==2.0.36
+
+      - name: Compileer gewijzigde modules
+        run: |
+          python -m py_compile \
+            backend/app/__init__.py \
+            backend/app/services/unpacking_household_object_guard.py \
+            backend/app/testing/unpacking_household_object_guard_contract.py
+
+      - name: Voer A-B-Uitpakken-objectguardcontract uit
+        env:
+          PYTHONPATH: backend
+        run: |
+          python -m app.testing.unpacking_household_object_guard_contract | tee unpacking-household-object-guard.log
+          grep -F 'UNPACKING_HOUSEHOLD_OBJECT_GUARD_GREEN' unpacking-household-object-guard.log

--- a/.github/workflows/unpacking-household-object-guard.yml
+++ b/.github/workflows/unpacking-household-object-guard.yml
@@ -22,7 +22,8 @@ jobs:
         run: |
           python -m pip install --quiet \
             fastapi==0.115.0 \
-            sqlalchemy==2.0.36
+            sqlalchemy==2.0.36 \
+            httpx==0.27.2
 
       - name: Compileer gewijzigde modules
         run: |

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -90,6 +90,26 @@ def _install_unpacking_location_patch_when_ready() -> None:
         time.sleep(0.1)
 
 
+def _install_unpacking_object_guard_when_ready() -> None:
+    for _ in range(200):
+        module = sys.modules.get('app.main')
+        if (
+            module is not None
+            and hasattr(module, 'app')
+            and hasattr(module, 'engine')
+            and hasattr(module, 'require_household_context')
+        ):
+            try:
+                from .services.unpacking_household_object_guard import (
+                    install_unpacking_household_object_guard,
+                )
+                install_unpacking_household_object_guard(module)
+            except Exception:
+                pass
+            return
+        time.sleep(0.1)
+
+
 threading.Thread(target=_install_when_ready, daemon=True).start()
 threading.Thread(
     target=_install_inventory_location_patch_when_ready,
@@ -97,5 +117,9 @@ threading.Thread(
 ).start()
 threading.Thread(
     target=_install_unpacking_location_patch_when_ready,
+    daemon=True,
+).start()
+threading.Thread(
+    target=_install_unpacking_object_guard_when_ready,
     daemon=True,
 ).start()

--- a/backend/app/services/unpacking_household_object_guard.py
+++ b/backend/app/services/unpacking_household_object_guard.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Callable
+
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
+
+_LINE_PATH = re.compile(r"^/api/purchase-import-lines/([^/]+)(?:/|$)")
+_BATCH_PATH = re.compile(r"^/api/purchase-import-batches/([^/]+)(?:/|$)")
+
+
+def resolve_purchase_import_household(conn, request_path: str) -> str | None:
+    """Resolve the owning household for protected Uitpakken production URLs."""
+
+    normalized_path = str(request_path or "").strip()
+    if normalized_path.startswith("/api/testing/"):
+        return None
+
+    line_match = _LINE_PATH.match(normalized_path)
+    if line_match:
+        line_id = line_match.group(1).strip()
+        row = conn.execute(
+            text(
+                """
+                SELECT pib.household_id
+                FROM purchase_import_lines pil
+                JOIN purchase_import_batches pib ON pib.id = pil.batch_id
+                WHERE pil.id = :line_id
+                LIMIT 1
+                """
+            ),
+            {"line_id": line_id},
+        ).mappings().first()
+        if not row or not str(row.get("household_id") or "").strip():
+            raise HTTPException(status_code=404, detail="Onbekende importregel")
+        return str(row["household_id"]).strip()
+
+    batch_match = _BATCH_PATH.match(normalized_path)
+    if batch_match:
+        batch_id = batch_match.group(1).strip()
+        row = conn.execute(
+            text(
+                """
+                SELECT household_id
+                FROM purchase_import_batches
+                WHERE id = :batch_id
+                LIMIT 1
+                """
+            ),
+            {"batch_id": batch_id},
+        ).mappings().first()
+        if not row or not str(row.get("household_id") or "").strip():
+            raise HTTPException(
+                status_code=404,
+                detail="Onbekende purchase import batch",
+            )
+        return str(row["household_id"]).strip()
+
+    return None
+
+
+def authorize_purchase_import_request(
+    conn,
+    request_path: str,
+    authorization: str | None,
+    require_household_context: Callable[[str | None, str | None], dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Authorize a protected request against the server-side owning household."""
+
+    household_id = resolve_purchase_import_household(conn, request_path)
+    if household_id is None:
+        return None
+    return require_household_context(authorization, household_id)
+
+
+def install_unpacking_household_object_guard(main_module) -> None:
+    """Install one HTTP guard for all production Uitpakken batch/line routes."""
+
+    app = main_module.app
+    if getattr(app.state, "unpacking_household_object_guard_installed", False):
+        return
+
+    @app.middleware("http")
+    async def unpacking_household_object_guard(request, call_next):
+        try:
+            with main_module.engine.begin() as conn:
+                authorize_purchase_import_request(
+                    conn,
+                    request.url.path,
+                    request.headers.get("authorization"),
+                    main_module.require_household_context,
+                )
+        except HTTPException as exc:
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": exc.detail},
+                headers=exc.headers or None,
+            )
+        return await call_next(request)
+
+    app.state.unpacking_household_object_guard_installed = True

--- a/backend/app/testing/unpacking_household_object_guard_contract.py
+++ b/backend/app/testing/unpacking_household_object_guard_contract.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
-from fastapi import HTTPException
+from types import SimpleNamespace
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, text
+from sqlalchemy.pool import StaticPool
 
 from app.services.unpacking_household_object_guard import (
     authorize_purchase_import_request,
+    install_unpacking_household_object_guard,
     resolve_purchase_import_household,
 )
 
@@ -20,8 +25,16 @@ def _expect_http_error(status_code: int, callback) -> None:
     raise AssertionError(f"Verwachte HTTP {status_code} bleef uit")
 
 
-def run_contract() -> None:
-    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+def _create_engine():
+    return create_engine(
+        "sqlite+pysqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+
+def _seed(engine) -> None:
     with engine.begin() as conn:
         conn.execute(
             text(
@@ -60,6 +73,88 @@ def run_contract() -> None:
             )
         )
 
+
+def _require_context(authorization, requested_household_id):
+    token_household = {
+        "Bearer token-a": "household-a",
+        "Bearer token-b": "household-b",
+    }.get(authorization)
+    if token_household is None:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    if token_household != requested_household_id:
+        raise HTTPException(status_code=403, detail="Geen toegang")
+    return {
+        "active_household_id": token_household,
+        "display_role": "admin",
+    }
+
+
+def _run_http_contract(engine) -> None:
+    app = FastAPI()
+    endpoint_calls: list[str] = []
+
+    @app.post("/api/purchase-import-lines/{line_id}/map")
+    def map_line(line_id: str):
+        endpoint_calls.append(line_id)
+        return {"line_id": line_id, "executed": True}
+
+    @app.post("/api/purchase-import-batches/{batch_id}/complete-review")
+    def complete_review(batch_id: str):
+        endpoint_calls.append(batch_id)
+        return {"batch_id": batch_id, "executed": True}
+
+    @app.get("/api/testing/diagnostics/purchase-import-batches/{batch_id}")
+    def testing_route(batch_id: str):
+        return {"batch_id": batch_id, "testing": True}
+
+    main_module = SimpleNamespace(
+        app=app,
+        engine=engine,
+        require_household_context=_require_context,
+    )
+    install_unpacking_household_object_guard(main_module)
+
+    with TestClient(app) as client:
+        own = client.post(
+            "/api/purchase-import-lines/line-a/map",
+            headers={"Authorization": "Bearer token-a"},
+        )
+        assert own.status_code == 200, own.text
+        assert own.json()["executed"] is True
+        assert endpoint_calls == ["line-a"]
+
+        cross_household = client.post(
+            "/api/purchase-import-lines/line-b/map",
+            headers={"Authorization": "Bearer token-a"},
+        )
+        assert cross_household.status_code == 403, cross_household.text
+        assert endpoint_calls == ["line-a"], "Endpoint werd ondanks 403 uitgevoerd"
+
+        missing_auth = client.post(
+            "/api/purchase-import-batches/batch-a/complete-review",
+        )
+        assert missing_auth.status_code == 401, missing_auth.text
+        assert endpoint_calls == ["line-a"], "Endpoint werd ondanks 401 uitgevoerd"
+
+        missing_object = client.post(
+            "/api/purchase-import-lines/missing/map",
+            headers={"Authorization": "Bearer token-a"},
+        )
+        assert missing_object.status_code == 404, missing_object.text
+        assert endpoint_calls == ["line-a"], "Endpoint werd ondanks 404 uitgevoerd"
+
+        testing = client.get(
+            "/api/testing/diagnostics/purchase-import-batches/batch-a",
+        )
+        assert testing.status_code == 200, testing.text
+        assert testing.json()["testing"] is True
+
+
+def run_contract() -> None:
+    engine = _create_engine()
+    _seed(engine)
+
+    with engine.begin() as conn:
         assert (
             resolve_purchase_import_household(
                 conn,
@@ -77,26 +172,15 @@ def run_contract() -> None:
 
         calls: list[tuple[str | None, str | None]] = []
 
-        def require_context(authorization, requested_household_id):
+        def recording_require_context(authorization, requested_household_id):
             calls.append((authorization, requested_household_id))
-            token_household = {
-                "Bearer token-a": "household-a",
-                "Bearer token-b": "household-b",
-            }.get(authorization)
-            if token_household is None:
-                raise HTTPException(status_code=401, detail="Unauthorized")
-            if token_household != requested_household_id:
-                raise HTTPException(status_code=403, detail="Geen toegang")
-            return {
-                "active_household_id": token_household,
-                "display_role": "admin",
-            }
+            return _require_context(authorization, requested_household_id)
 
         context = authorize_purchase_import_request(
             conn,
             "/api/purchase-import-lines/line-a/map",
             "Bearer token-a",
-            require_context,
+            recording_require_context,
         )
         assert context and context["active_household_id"] == "household-a"
         assert calls[-1] == ("Bearer token-a", "household-a")
@@ -107,7 +191,7 @@ def run_contract() -> None:
                 conn,
                 "/api/purchase-import-lines/line-b/create-article",
                 "Bearer token-a",
-                require_context,
+                recording_require_context,
             ),
         )
         _expect_http_error(
@@ -116,7 +200,7 @@ def run_contract() -> None:
                 conn,
                 "/api/purchase-import-batches/batch-a/complete-review",
                 None,
-                require_context,
+                recording_require_context,
             ),
         )
         _expect_http_error(
@@ -141,11 +225,9 @@ def run_contract() -> None:
             )
             is None
         )
-        assert (
-            resolve_purchase_import_household(conn, "/api/receipts")
-            is None
-        )
+        assert resolve_purchase_import_household(conn, "/api/receipts") is None
 
+    _run_http_contract(engine)
     print("UNPACKING_HOUSEHOLD_OBJECT_GUARD_GREEN")
 
 

--- a/backend/app/testing/unpacking_household_object_guard_contract.py
+++ b/backend/app/testing/unpacking_household_object_guard_contract.py
@@ -1,0 +1,153 @@
+"""Contract for server-side household authorization of Uitpakken objects."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+from sqlalchemy import create_engine, text
+
+from app.services.unpacking_household_object_guard import (
+    authorize_purchase_import_request,
+    resolve_purchase_import_household,
+)
+
+
+def _expect_http_error(status_code: int, callback) -> None:
+    try:
+        callback()
+    except HTTPException as exc:
+        assert exc.status_code == status_code, exc
+        return
+    raise AssertionError(f"Verwachte HTTP {status_code} bleef uit")
+
+
+def run_contract() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE purchase_import_batches (
+                    id TEXT PRIMARY KEY,
+                    household_id TEXT NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE purchase_import_lines (
+                    id TEXT PRIMARY KEY,
+                    batch_id TEXT NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO purchase_import_batches (id, household_id)
+                VALUES ('batch-a', 'household-a'), ('batch-b', 'household-b')
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO purchase_import_lines (id, batch_id)
+                VALUES ('line-a', 'batch-a'), ('line-b', 'batch-b')
+                """
+            )
+        )
+
+        assert (
+            resolve_purchase_import_household(
+                conn,
+                "/api/purchase-import-lines/line-a/map",
+            )
+            == "household-a"
+        )
+        assert (
+            resolve_purchase_import_household(
+                conn,
+                "/api/purchase-import-batches/batch-b/process",
+            )
+            == "household-b"
+        )
+
+        calls: list[tuple[str | None, str | None]] = []
+
+        def require_context(authorization, requested_household_id):
+            calls.append((authorization, requested_household_id))
+            token_household = {
+                "Bearer token-a": "household-a",
+                "Bearer token-b": "household-b",
+            }.get(authorization)
+            if token_household is None:
+                raise HTTPException(status_code=401, detail="Unauthorized")
+            if token_household != requested_household_id:
+                raise HTTPException(status_code=403, detail="Geen toegang")
+            return {
+                "active_household_id": token_household,
+                "display_role": "admin",
+            }
+
+        context = authorize_purchase_import_request(
+            conn,
+            "/api/purchase-import-lines/line-a/map",
+            "Bearer token-a",
+            require_context,
+        )
+        assert context and context["active_household_id"] == "household-a"
+        assert calls[-1] == ("Bearer token-a", "household-a")
+
+        _expect_http_error(
+            403,
+            lambda: authorize_purchase_import_request(
+                conn,
+                "/api/purchase-import-lines/line-b/create-article",
+                "Bearer token-a",
+                require_context,
+            ),
+        )
+        _expect_http_error(
+            401,
+            lambda: authorize_purchase_import_request(
+                conn,
+                "/api/purchase-import-batches/batch-a/complete-review",
+                None,
+                require_context,
+            ),
+        )
+        _expect_http_error(
+            404,
+            lambda: resolve_purchase_import_household(
+                conn,
+                "/api/purchase-import-lines/missing/map",
+            ),
+        )
+        _expect_http_error(
+            404,
+            lambda: resolve_purchase_import_household(
+                conn,
+                "/api/purchase-import-batches/missing/process",
+            ),
+        )
+
+        assert (
+            resolve_purchase_import_household(
+                conn,
+                "/api/testing/diagnostics/purchase-import-batches/batch-a",
+            )
+            is None
+        )
+        assert (
+            resolve_purchase_import_household(conn, "/api/receipts")
+            is None
+        )
+
+    print("UNPACKING_HOUSEHOLD_OBJECT_GUARD_GREEN")
+
+
+if __name__ == "__main__":
+    run_contract()


### PR DESCRIPTION
## Doel
Alle productie-URL's voor Uitpakken-batches en importregels vooraf server-side begrenzen op het huishouden van het object.

## Gewijzigd
- centrale HTTP-objectguard voor `/api/purchase-import-lines/{line_id}/...`;
- centrale HTTP-objectguard voor `/api/purchase-import-batches/{batch_id}/...`;
- regelhuishouden wordt afgeleid via `purchase_import_lines → purchase_import_batches`;
- batchhuishouden wordt rechtstreeks uit `purchase_import_batches` gelezen;
- centrale `require_household_context` beslist toegang vóór uitvoering van de route;
- `/api/testing/...` blijft buiten de productieguard;
- zelfstandige A/B-contracttest en gerichte GitHub Action.

## Acceptatie
- A kan productieacties uitvoeren op eigen regel en batch;
- A krijgt 403 op regel of batch van B;
- ontbrekende autorisatie levert 401;
- ontbrekende regel of batch levert 404;
- bestaande routes zonder eigen autorisatieparameter zijn alsnog beschermd;
- niet-Uitpakken-routes en testdiagnoseroutes worden niet geraakt.

## Niet gewijzigd
- frontend;
- databaseschema;
- kassabonparser;
- artikelgroepen;
- productcatalogus;
- voorraadberekeningen.

## Risico
Laag tot middel: één centrale middlewareguard voor een afgebakende productie-URL-familie, met directe A/B-contractdekking.