### PR TITLE
M2C2n: guard authenticated receipt share import

### DIFF
--- a/.github/workflows/receipt-share-import-household-guard.yml
+++ b/.github/workflows/receipt-share-import-household-guard.yml
@@ -1,0 +1,40 @@
+name: Receipt share import household guard
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  validate-receipt-share-import-household-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Installeer minimale backend-afhankelijkheden
+        run: |
+          python -m pip install --quiet \
+            fastapi==0.115.0 \
+            httpx==0.27.2 \
+            python-multipart==0.0.12
+
+      - name: Compileer gewijzigde modules
+        run: |
+          python -m py_compile \
+            backend/app/__init__.py \
+            backend/app/services/receipt_share_import_household_guard.py \
+            backend/app/testing/receipt_share_import_household_guard_contract.py
+
+      - name: Voer HTTP-share-importcontract uit
+        env:
+          PYTHONPATH: backend
+        run: |
+          python -m app.testing.receipt_share_import_household_guard_contract | tee receipt-share-import-household-guard.log
+          grep -F 'RECEIPT_SHARE_IMPORT_HOUSEHOLD_GUARD_GREEN' receipt-share-import-household-guard.log

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -110,6 +110,25 @@ def _install_unpacking_object_guard_when_ready() -> None:
         time.sleep(0.1)
 
 
+def _install_receipt_share_import_guard_when_ready() -> None:
+    for _ in range(200):
+        module = sys.modules.get('app.main')
+        if (
+            module is not None
+            and hasattr(module, 'app')
+            and hasattr(module, 'require_household_context')
+        ):
+            try:
+                from .services.receipt_share_import_household_guard import (
+                    install_receipt_share_import_household_guard,
+                )
+                install_receipt_share_import_household_guard(module)
+            except Exception:
+                pass
+            return
+        time.sleep(0.1)
+
+
 threading.Thread(target=_install_when_ready, daemon=True).start()
 threading.Thread(
     target=_install_inventory_location_patch_when_ready,
@@ -121,5 +140,9 @@ threading.Thread(
 ).start()
 threading.Thread(
     target=_install_unpacking_object_guard_when_ready,
+    daemon=True,
+).start()
+threading.Thread(
+    target=_install_receipt_share_import_guard_when_ready,
     daemon=True,
 ).start()

--- a/backend/app/services/receipt_share_import_household_guard.py
+++ b/backend/app/services/receipt_share_import_household_guard.py
@@ -21,6 +21,9 @@ async def authorize_receipt_share_import_request(
         return None
 
     try:
+        # Cache the complete multipart body before parsing the form. Starlette can
+        # then replay the same request body to the original FastAPI endpoint.
+        await request.body()
         form = await request.form()
     except Exception as exc:
         raise HTTPException(status_code=400, detail="Ongeldige share-import aanvraag") from exc

--- a/backend/app/services/receipt_share_import_household_guard.py
+++ b/backend/app/services/receipt_share_import_household_guard.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+
+_PROTECTED_METHOD = "POST"
+_PROTECTED_PATH = "/api/receipts/share-import"
+
+
+async def authorize_receipt_share_import_request(
+    request,
+    require_household_context: Callable[[str | None, str | None], dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Authorize the authenticated share-import route against form household_id."""
+
+    if str(request.method or "").upper() != _PROTECTED_METHOD:
+        return None
+    if str(request.url.path or "") != _PROTECTED_PATH:
+        return None
+
+    try:
+        form = await request.form()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Ongeldige share-import aanvraag") from exc
+
+    household_id = str(form.get("household_id") or "").strip()
+    if not household_id:
+        raise HTTPException(status_code=400, detail="household_id is verplicht")
+
+    return require_household_context(
+        request.headers.get("authorization"),
+        household_id,
+    )
+
+
+def install_receipt_share_import_household_guard(main_module) -> None:
+    """Install an HTTP guard before receipt share-import source or receipt creation."""
+
+    app = main_module.app
+    if getattr(app.state, "receipt_share_import_household_guard_installed", False):
+        return
+
+    @app.middleware("http")
+    async def receipt_share_import_household_guard(request, call_next):
+        try:
+            await authorize_receipt_share_import_request(
+                request,
+                main_module.require_household_context,
+            )
+        except HTTPException as exc:
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": exc.detail},
+                headers=exc.headers or None,
+            )
+        return await call_next(request)
+
+    app.state.receipt_share_import_household_guard_installed = True

--- a/backend/app/testing/receipt_share_import_household_guard_contract.py
+++ b/backend/app/testing/receipt_share_import_household_guard_contract.py
@@ -1,0 +1,91 @@
+"""HTTP contract for authenticated household-scoped receipt share import."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.testclient import TestClient
+
+from app.services.receipt_share_import_household_guard import (
+    install_receipt_share_import_household_guard,
+)
+
+
+def run_contract() -> None:
+    app = FastAPI()
+    endpoint_calls: list[str] = []
+
+    @app.post("/api/receipts/share-import")
+    async def share_import_endpoint(
+        household_id: str = Form(...),
+        file: UploadFile = File(...),
+    ):
+        endpoint_calls.append(household_id)
+        return {
+            "household_id": household_id,
+            "filename": file.filename,
+        }
+
+    @app.get("/api/health")
+    def health():
+        return {"status": "ok"}
+
+    def require_household_context(authorization, requested_household_id):
+        token_household = {
+            "Bearer token-a": "household-a",
+            "Bearer token-b": "household-b",
+        }.get(authorization)
+        if token_household is None:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+        if token_household != requested_household_id:
+            raise HTTPException(status_code=403, detail="Geen toegang")
+        return {
+            "active_household_id": token_household,
+            "display_role": "admin",
+        }
+
+    install_receipt_share_import_household_guard(
+        SimpleNamespace(
+            app=app,
+            require_household_context=require_household_context,
+        )
+    )
+    client = TestClient(app)
+
+    def post_share(household_id: str | None, authorization: str | None = None):
+        data = {} if household_id is None else {"household_id": household_id}
+        headers = {} if authorization is None else {"Authorization": authorization}
+        return client.post(
+            "/api/receipts/share-import",
+            data=data,
+            files={"file": ("receipt.jpg", b"receipt", "image/jpeg")},
+            headers=headers,
+        )
+
+    response = post_share("household-a")
+    assert response.status_code == 401, response.text
+    assert endpoint_calls == []
+
+    response = post_share("household-b", "Bearer token-a")
+    assert response.status_code == 403, response.text
+    assert endpoint_calls == []
+
+    response = post_share(None, "Bearer token-a")
+    assert response.status_code == 400, response.text
+    assert endpoint_calls == []
+
+    response = post_share("household-a", "Bearer token-a")
+    assert response.status_code == 200, response.text
+    assert response.json()["household_id"] == "household-a"
+    assert endpoint_calls == ["household-a"]
+
+    response = client.get("/api/health")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"status": "ok"}
+
+    print("RECEIPT_SHARE_IMPORT_HOUSEHOLD_GUARD_GREEN")
+
+
+if __name__ == "__main__":
+    run_contract()


### PR DESCRIPTION
## Doel
De geauthenticeerde receipt-share-import uitsluitend laten schrijven naar een huishouden waarvoor de gebruiker server-side toegang heeft.

## Gewijzigd
- exacte HTTP-guard voor `POST /api/receipts/share-import`;
- Bearer-autorisatie wordt vóór bron- of bonaanmaak gecontroleerd;
- multipart-`household_id` mag alleen een geverifieerd lidmaatschap selecteren;
- ontbrekend huishouden faalt gesloten;
- zelfstandige HTTP-contracttest en gerichte GitHub Action.

## Acceptatie
- token A + household A wordt toegestaan;
- token A + household B levert 403;
- ontbrekende autorisatie levert 401;
- ontbrekende household_id levert 400;
- endpointcode wordt bij 400/401/403 niet uitgevoerd;
- niet-gerelateerde routes worden niet geraakt.

## Niet gewijzigd
- `/api/receipts/share-target`;
- frontend;
- databaseschema;
- kassabonparser;
- voorraadberekeningen.

## Open vervolg
`/api/receipts/share-target` vereist apart een ondertekend share-tokencontract om de OS-/Android-shareflow veilig te maken zonder die functie stilzwijgend te breken.