### PR TITLE
M2C2n: guard receipt admin maintenance routes

### DIFF
--- a/.github/workflows/receipt-admin-household-guard.yml
+++ b/.github/workflows/receipt-admin-household-guard.yml
@@ -1,0 +1,39 @@
+name: Receipt admin household guard
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  validate-receipt-admin-household-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Installeer minimale backend-afhankelijkheden
+        run: |
+          python -m pip install --quiet \
+            fastapi==0.115.0 \
+            httpx==0.27.2
+
+      - name: Compileer gewijzigde modules
+        run: |
+          python -m py_compile \
+            backend/app/__init__.py \
+            backend/app/services/receipt_admin_household_guard.py \
+            backend/app/testing/receipt_admin_household_guard_contract.py
+
+      - name: Voer HTTP-receiptbeheercontract uit
+        env:
+          PYTHONPATH: backend
+        run: |
+          python -m app.testing.receipt_admin_household_guard_contract | tee receipt-admin-household-guard.log
+          grep -F 'RECEIPT_ADMIN_HOUSEHOLD_GUARD_GREEN' receipt-admin-household-guard.log

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -129,6 +129,25 @@ def _install_receipt_share_import_guard_when_ready() -> None:
         time.sleep(0.1)
 
 
+def _install_receipt_admin_guard_when_ready() -> None:
+    for _ in range(200):
+        module = sys.modules.get('app.main')
+        if (
+            module is not None
+            and hasattr(module, 'app')
+            and hasattr(module, 'require_platform_admin_user')
+        ):
+            try:
+                from .services.receipt_admin_household_guard import (
+                    install_receipt_admin_household_guard,
+                )
+                install_receipt_admin_household_guard(module)
+            except Exception:
+                pass
+            return
+        time.sleep(0.1)
+
+
 threading.Thread(target=_install_when_ready, daemon=True).start()
 threading.Thread(
     target=_install_inventory_location_patch_when_ready,
@@ -144,5 +163,9 @@ threading.Thread(
 ).start()
 threading.Thread(
     target=_install_receipt_share_import_guard_when_ready,
+    daemon=True,
+).start()
+threading.Thread(
+    target=_install_receipt_admin_guard_when_ready,
     daemon=True,
 ).start()

--- a/backend/app/services/receipt_admin_household_guard.py
+++ b/backend/app/services/receipt_admin_household_guard.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+
+_PROTECTED_METHOD = "POST"
+_PROTECTED_PATHS = {
+    "/api/admin/recompute-receipt-statuses",
+    "/api/admin/validate-receipt-status-baseline",
+    "/api/admin/diagnose-receipt-status-baseline",
+}
+
+
+def authorize_receipt_admin_request(
+    method: str,
+    path: str,
+    authorization: str | None,
+    require_platform_admin_user: Callable[[str | None], object],
+) -> object | None:
+    if str(method or "").upper() != _PROTECTED_METHOD:
+        return None
+    if str(path or "") not in _PROTECTED_PATHS:
+        return None
+    return require_platform_admin_user(authorization)
+
+
+def install_receipt_admin_household_guard(main_module) -> None:
+    app = main_module.app
+    if getattr(app.state, "receipt_admin_household_guard_installed", False):
+        return
+
+    @app.middleware("http")
+    async def receipt_admin_household_guard(request, call_next):
+        try:
+            authorize_receipt_admin_request(
+                request.method,
+                request.url.path,
+                request.headers.get("authorization"),
+                main_module.require_platform_admin_user,
+            )
+        except HTTPException as exc:
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": exc.detail},
+                headers=exc.headers or None,
+            )
+        return await call_next(request)
+
+    app.state.receipt_admin_household_guard_installed = True

--- a/backend/app/testing/receipt_admin_household_guard_contract.py
+++ b/backend/app/testing/receipt_admin_household_guard_contract.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi import FastAPI, HTTPException, Header
+from fastapi.testclient import TestClient
+
+from app.services.receipt_admin_household_guard import (
+    authorize_receipt_admin_request,
+    install_receipt_admin_household_guard,
+)
+
+
+def run_contract() -> None:
+    app = FastAPI()
+    calls: list[str] = []
+
+    def require_platform_admin_user(authorization: str | None):
+        if not authorization:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+        if authorization != "Bearer platform-admin":
+            raise HTTPException(status_code=403, detail="Platformbeheerder vereist")
+        return {"email": "platform@example.test", "role": "platform_admin"}
+
+    module = SimpleNamespace(
+        app=app,
+        require_platform_admin_user=require_platform_admin_user,
+    )
+    install_receipt_admin_household_guard(module)
+
+    @app.post("/api/admin/recompute-receipt-statuses")
+    def recompute_receipt_statuses(authorization: str | None = Header(None)):
+        calls.append("recompute")
+        return {"status": "ok", "authorization": authorization}
+
+    @app.post("/api/admin/validate-receipt-status-baseline")
+    def validate_receipt_status_baseline():
+        calls.append("validate")
+        return {"status": "ok"}
+
+    @app.post("/api/admin/diagnose-receipt-status-baseline")
+    def diagnose_receipt_status_baseline():
+        calls.append("diagnose")
+        return {"status": "ok"}
+
+    @app.post("/api/admin/unrelated")
+    def unrelated_admin_route():
+        calls.append("unrelated")
+        return {"status": "ok"}
+
+    client = TestClient(app)
+
+    response = client.post("/api/admin/recompute-receipt-statuses")
+    assert response.status_code == 401, response.text
+    assert calls == []
+
+    response = client.post(
+        "/api/admin/validate-receipt-status-baseline",
+        headers={"Authorization": "Bearer household-user"},
+    )
+    assert response.status_code == 403, response.text
+    assert calls == []
+
+    response = client.post(
+        "/api/admin/diagnose-receipt-status-baseline",
+        headers={"Authorization": "Bearer platform-admin"},
+    )
+    assert response.status_code == 200, response.text
+    assert calls == ["diagnose"]
+
+    response = client.post("/api/admin/unrelated")
+    assert response.status_code == 200, response.text
+    assert calls == ["diagnose", "unrelated"]
+
+    assert authorize_receipt_admin_request(
+        "GET",
+        "/api/admin/recompute-receipt-statuses",
+        None,
+        require_platform_admin_user,
+    ) is None
+
+    print("RECEIPT_ADMIN_HOUSEHOLD_GUARD_GREEN")
+
+
+if __name__ == "__main__":
+    run_contract()


### PR DESCRIPTION
## Doel
De drie receiptbeheer-routes uitsluitend door een geverifieerde platformbeheerder laten uitvoeren.

## Gewijzigd
- exacte HTTP-guard voor:
  - `POST /api/admin/recompute-receipt-statuses`;
  - `POST /api/admin/validate-receipt-status-baseline`;
  - `POST /api/admin/diagnose-receipt-status-baseline`;
- bestaande `require_platform_admin_user` beslist toegang vóór uitvoering van de route;
- zelfstandige HTTP-integratietest en gerichte GitHub Action.

## Acceptatie
- ontbrekende autorisatie levert 401;
- gewone huishoudgebruiker levert 403;
- platformbeheerder wordt toegestaan;
- endpointcode wordt bij 401/403 niet uitgevoerd;
- niet-gerelateerde adminroutes worden niet geraakt.

## Niet gewijzigd
- frontend;
- databaseschema;
- kassabonparser;
- receipt-objectroutes;
- voorraadberekeningen;
- `/api/receipts/share-target`.