### PR TITLE
M2C2n: guard Gmail OAuth household scope

### DIFF
--- a/.github/workflows/receipt-gmail-oauth-household-guard.yml
+++ b/.github/workflows/receipt-gmail-oauth-household-guard.yml
@@ -1,0 +1,39 @@
+name: Receipt Gmail OAuth household guard
+
+on:
+  pull_request:
+    paths:
+      - 'backend/app/__init__.py'
+      - 'backend/app/services/receipt_gmail_oauth_household_guard.py'
+      - 'backend/app/testing/receipt_gmail_oauth_household_guard_contract.py'
+      - '.github/workflows/receipt-gmail-oauth-household-guard.yml'
+  workflow_dispatch:
+
+jobs:
+  validate-receipt-gmail-oauth-household-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Installeer minimale backend-afhankelijkheden
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install fastapi starlette httpx
+
+      - name: Compileer gewijzigde modules
+        run: |
+          python -m compileall \
+            backend/app/__init__.py \
+            backend/app/services/receipt_gmail_oauth_household_guard.py \
+            backend/app/testing/receipt_gmail_oauth_household_guard_contract.py
+
+      - name: Voer HTTP-Gmail-OAuth-contract uit
+        env:
+          PYTHONPATH: backend
+        run: python backend/app/testing/receipt_gmail_oauth_household_guard_contract.py

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -148,6 +148,26 @@ def _install_receipt_admin_guard_when_ready() -> None:
         time.sleep(0.1)
 
 
+def _install_receipt_gmail_oauth_guard_when_ready() -> None:
+    for _ in range(200):
+        module = sys.modules.get('app.main')
+        if (
+            module is not None
+            and hasattr(module, 'app')
+            and hasattr(module, 'require_household_admin_context')
+            and hasattr(module, 'verify_gmail_state')
+        ):
+            try:
+                from .services.receipt_gmail_oauth_household_guard import (
+                    install_receipt_gmail_oauth_household_guard,
+                )
+                install_receipt_gmail_oauth_household_guard(module)
+            except Exception:
+                pass
+            return
+        time.sleep(0.1)
+
+
 threading.Thread(target=_install_when_ready, daemon=True).start()
 threading.Thread(
     target=_install_inventory_location_patch_when_ready,
@@ -167,5 +187,9 @@ threading.Thread(
 ).start()
 threading.Thread(
     target=_install_receipt_admin_guard_when_ready,
+    daemon=True,
+).start()
+threading.Thread(
+    target=_install_receipt_gmail_oauth_guard_when_ready,
     daemon=True,
 ).start()

--- a/backend/app/services/receipt_gmail_oauth_household_guard.py
+++ b/backend/app/services/receipt_gmail_oauth_household_guard.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+
+_CONNECT_METHOD = "GET"
+_CONNECT_PATH = "/api/receipts/gmail/connect-url"
+_CALLBACK_METHOD = "GET"
+_CALLBACK_PATH = "/api/receipts/gmail/callback"
+
+
+def require_explicit_gmail_state_household(
+    state: str | None,
+    verify_gmail_state: Callable[[str], dict[str, Any]],
+) -> dict[str, Any]:
+    """Verify Gmail OAuth state and reject missing or ambiguous household scope."""
+
+    payload = verify_gmail_state(str(state or ""))
+    provider = str(payload.get("provider") or "").strip().lower()
+    household_id = str(payload.get("household_id") or "").strip()
+    if provider != "gmail":
+        raise HTTPException(status_code=400, detail="Ongeldige Gmail OAuth-state")
+    if not household_id:
+        raise HTTPException(status_code=400, detail="Huishouden ontbreekt in Gmail OAuth-state")
+    return payload
+
+
+def install_receipt_gmail_oauth_household_guard(main_module) -> None:
+    """Protect Gmail connect initiation and fail closed on callback household scope."""
+
+    app = main_module.app
+    if getattr(app.state, "receipt_gmail_oauth_household_guard_installed", False):
+        return
+
+    @app.middleware("http")
+    async def receipt_gmail_oauth_household_guard(request, call_next):
+        method = str(request.method or "").upper()
+        path = str(request.url.path or "")
+        try:
+            if method == _CONNECT_METHOD and path == _CONNECT_PATH:
+                household_id = str(request.query_params.get("householdId") or "").strip()
+                if not household_id:
+                    raise HTTPException(status_code=400, detail="householdId is verplicht")
+                main_module.require_household_admin_context(
+                    request.headers.get("authorization"),
+                    household_id,
+                )
+            elif method == _CALLBACK_METHOD and path == _CALLBACK_PATH:
+                require_explicit_gmail_state_household(
+                    request.query_params.get("state"),
+                    main_module.verify_gmail_state,
+                )
+        except HTTPException as exc:
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": exc.detail},
+                headers=exc.headers or None,
+            )
+        return await call_next(request)
+
+    app.state.receipt_gmail_oauth_household_guard_installed = True

--- a/backend/app/testing/receipt_gmail_oauth_household_guard_contract.py
+++ b/backend/app/testing/receipt_gmail_oauth_household_guard_contract.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi import FastAPI, Header, HTTPException, Query
+from fastapi.testclient import TestClient
+
+from app.services.receipt_gmail_oauth_household_guard import (
+    install_receipt_gmail_oauth_household_guard,
+)
+
+
+def run_contract() -> None:
+    app = FastAPI()
+    calls = {"connect": 0, "callback": 0, "other": 0}
+
+    def require_household_admin_context(authorization: str | None, household_id: str | None):
+        if not authorization:
+            raise HTTPException(status_code=401, detail="Autorisatie ontbreekt")
+        if authorization == "Bearer member-a":
+            raise HTTPException(status_code=403, detail="Huishoudadmin vereist")
+        if authorization != "Bearer admin-a" or household_id != "household-a":
+            raise HTTPException(status_code=403, detail="Geen toegang tot dit huishouden")
+        return {"active_household_id": "household-a", "display_role": "admin"}
+
+    def verify_gmail_state(state: str):
+        states = {
+            "valid": {"provider": "gmail", "household_id": "household-a"},
+            "missing-household": {"provider": "gmail"},
+            "wrong-provider": {"provider": "other", "household_id": "household-a"},
+        }
+        payload = states.get(state)
+        if payload is None:
+            raise HTTPException(status_code=400, detail="Ongeldige OAuth-state")
+        return payload
+
+    main_module = SimpleNamespace(
+        app=app,
+        require_household_admin_context=require_household_admin_context,
+        verify_gmail_state=verify_gmail_state,
+    )
+    install_receipt_gmail_oauth_household_guard(main_module)
+
+    @app.get("/api/receipts/gmail/connect-url")
+    def connect_url(
+        householdId: str = Query(...),
+        authorization: str | None = Header(None),
+    ):
+        calls["connect"] += 1
+        return {"household_id": householdId, "authorization": authorization}
+
+    @app.get("/api/receipts/gmail/callback")
+    def callback(state: str = Query(...)):
+        calls["callback"] += 1
+        return {"state": state}
+
+    @app.get("/api/receipts/gmail/status-probe")
+    def other_route():
+        calls["other"] += 1
+        return {"ok": True}
+
+    client = TestClient(app)
+
+    response = client.get("/api/receipts/gmail/connect-url?householdId=household-a")
+    assert response.status_code == 401, response.text
+    assert calls["connect"] == 0
+
+    response = client.get(
+        "/api/receipts/gmail/connect-url?householdId=household-a",
+        headers={"Authorization": "Bearer member-a"},
+    )
+    assert response.status_code == 403, response.text
+    assert calls["connect"] == 0
+
+    response = client.get(
+        "/api/receipts/gmail/connect-url?householdId=household-b",
+        headers={"Authorization": "Bearer admin-a"},
+    )
+    assert response.status_code == 403, response.text
+    assert calls["connect"] == 0
+
+    response = client.get(
+        "/api/receipts/gmail/connect-url?householdId=household-a",
+        headers={"Authorization": "Bearer admin-a"},
+    )
+    assert response.status_code == 200, response.text
+    assert calls["connect"] == 1
+
+    response = client.get("/api/receipts/gmail/callback?state=missing-household")
+    assert response.status_code == 400, response.text
+    assert calls["callback"] == 0
+
+    response = client.get("/api/receipts/gmail/callback?state=wrong-provider")
+    assert response.status_code == 400, response.text
+    assert calls["callback"] == 0
+
+    response = client.get("/api/receipts/gmail/callback?state=unknown")
+    assert response.status_code == 400, response.text
+    assert calls["callback"] == 0
+
+    response = client.get("/api/receipts/gmail/callback?state=valid")
+    assert response.status_code == 200, response.text
+    assert calls["callback"] == 1
+
+    response = client.get("/api/receipts/gmail/status-probe")
+    assert response.status_code == 200, response.text
+    assert calls["other"] == 1
+
+
+if __name__ == "__main__":
+    run_contract()
+    print("receipt Gmail OAuth household guard contract: OK")


### PR DESCRIPTION
## Doel
De Gmail-koppeling uitsluitend door een huishoudadmin laten starten en de OAuth-callback gesloten laten falen wanneer de ondertekende state geen expliciet huishouden bevat.

## Gewijzigd
- exacte HTTP-guard voor `GET /api/receipts/gmail/connect-url`;
- huishoudadmin vereist voor het gevraagde `householdId`;
- exacte HTTP-guard voor `GET /api/receipts/gmail/callback`;
- callback-state moet `provider=gmail` en een niet-leeg `household_id` bevatten;
- geen fallback naar huishouden `1` vóór token- of accountopslag;
- zelfstandige HTTP-integratietest en gerichte GitHub Action.

## Acceptatie
- ontbrekende autorisatie op connect-url levert 401;
- gewoon huishoudlid levert 403;
- admin A kan huishouden B niet selecteren;
- huishoudadmin A wordt toegestaan voor huishouden A;
- callback-state zonder huishouden, met verkeerde provider of ongeldige ondertekening levert 400;
- endpointcode wordt bij blokkering niet uitgevoerd;
- geldige Gmail-state blijft functioneel doorgaan.

## Niet gewijzigd
- Gmail-status lezen;
- Gmail synchroniseren;
- receiptbronnen;
- frontend;
- databaseschema;
- kassabonparser;
- `/api/receipts/share-target`.