### PR TITLE
M2C2n: verify Resend inbound webhooks

### DIFF
--- a/.github/workflows/receipt-resend-webhook-guard.yml
+++ b/.github/workflows/receipt-resend-webhook-guard.yml
@@ -1,0 +1,39 @@
+name: Receipt Resend webhook guard
+
+on:
+  pull_request:
+    paths:
+      - 'backend/app/__init__.py'
+      - 'backend/app/services/receipt_resend_webhook_guard.py'
+      - 'backend/app/testing/receipt_resend_webhook_guard_contract.py'
+      - '.github/workflows/receipt-resend-webhook-guard.yml'
+  workflow_dispatch:
+
+jobs:
+  validate-receipt-resend-webhook-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Installeer minimale backend-afhankelijkheden
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install fastapi starlette httpx sqlalchemy
+
+      - name: Compileer gewijzigde modules
+        run: |
+          python -m compileall \
+            backend/app/__init__.py \
+            backend/app/services/receipt_resend_webhook_guard.py \
+            backend/app/testing/receipt_resend_webhook_guard_contract.py
+
+      - name: Voer HTTP-Resend-webhookcontract uit
+        env:
+          PYTHONPATH: backend
+        run: python backend/app/testing/receipt_resend_webhook_guard_contract.py

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -168,6 +168,26 @@ def _install_receipt_gmail_oauth_guard_when_ready() -> None:
         time.sleep(0.1)
 
 
+def _install_receipt_resend_webhook_guard_when_ready() -> None:
+    for _ in range(200):
+        module = sys.modules.get('app.main')
+        if (
+            module is not None
+            and hasattr(module, 'app')
+            and hasattr(module, 'engine')
+            and hasattr(module, 'text')
+        ):
+            try:
+                from .services.receipt_resend_webhook_guard import (
+                    install_receipt_resend_webhook_guard,
+                )
+                install_receipt_resend_webhook_guard(module)
+            except Exception:
+                pass
+            return
+        time.sleep(0.1)
+
+
 threading.Thread(target=_install_when_ready, daemon=True).start()
 threading.Thread(
     target=_install_inventory_location_patch_when_ready,
@@ -191,5 +211,9 @@ threading.Thread(
 ).start()
 threading.Thread(
     target=_install_receipt_gmail_oauth_guard_when_ready,
+    daemon=True,
+).start()
+threading.Thread(
+    target=_install_receipt_resend_webhook_guard_when_ready,
     daemon=True,
 ).start()

--- a/backend/app/services/receipt_resend_webhook_guard.py
+++ b/backend/app/services/receipt_resend_webhook_guard.py
@@ -8,6 +8,7 @@ import time
 from typing import Any
 
 from fastapi import HTTPException, Request
+from fastapi.responses import JSONResponse
 
 INBOUND_PATH = "/api/receipts/inbound"
 MAX_TIMESTAMP_SKEW_SECONDS = 300
@@ -122,6 +123,10 @@ def release_delivery(module: Any, *, svix_id: str) -> None:
         )
 
 
+def _error_response(exc: HTTPException) -> JSONResponse:
+    return JSONResponse(status_code=int(exc.status_code), content={"detail": exc.detail})
+
+
 def install_receipt_resend_webhook_guard(module: Any) -> None:
     if getattr(module.app.state, "receipt_resend_webhook_guard_installed", False):
         return
@@ -136,18 +141,22 @@ def install_receipt_resend_webhook_guard(module: Any) -> None:
         svix_id = str(request.headers.get("svix-id") or "").strip()
         svix_timestamp = str(request.headers.get("svix-timestamp") or "").strip()
         svix_signature = str(request.headers.get("svix-signature") or "").strip()
-        verify_resend_webhook(
-            body=body,
-            svix_id=svix_id,
-            svix_timestamp=svix_timestamp,
-            svix_signature=svix_signature,
-        )
-        reserve_delivery(
-            module,
-            svix_id=svix_id,
-            svix_timestamp=svix_timestamp,
-            body=body,
-        )
+        try:
+            verify_resend_webhook(
+                body=body,
+                svix_id=svix_id,
+                svix_timestamp=svix_timestamp,
+                svix_signature=svix_signature,
+            )
+            reserve_delivery(
+                module,
+                svix_id=svix_id,
+                svix_timestamp=svix_timestamp,
+                body=body,
+            )
+        except HTTPException as exc:
+            return _error_response(exc)
+
         try:
             response = await call_next(request)
         except Exception:

--- a/backend/app/services/receipt_resend_webhook_guard.py
+++ b/backend/app/services/receipt_resend_webhook_guard.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import time
+from typing import Any
+
+from fastapi import HTTPException, Request
+
+INBOUND_PATH = "/api/receipts/inbound"
+MAX_TIMESTAMP_SKEW_SECONDS = 300
+
+
+def _webhook_secret() -> str:
+    return str(os.getenv("REZZERV_RESEND_WEBHOOK_SECRET", "") or "").strip()
+
+
+def _decode_secret(secret: str) -> bytes:
+    encoded = secret[6:] if secret.startswith("whsec_") else secret
+    try:
+        return base64.b64decode(encoded, validate=True)
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail="De Resend webhooksecret is ongeldig geconfigureerd.") from exc
+
+
+def _signature_candidates(value: str) -> list[str]:
+    candidates: list[str] = []
+    for part in str(value or "").split():
+        version, separator, signature = part.partition(",")
+        if separator and version == "v1" and signature:
+            candidates.append(signature)
+    return candidates
+
+
+def verify_resend_webhook(*, body: bytes, svix_id: str, svix_timestamp: str, svix_signature: str, now: int | None = None) -> None:
+    secret = _webhook_secret()
+    if not secret:
+        raise HTTPException(status_code=503, detail="De Resend webhooksecret is niet geconfigureerd.")
+    if not svix_id or not svix_timestamp or not svix_signature:
+        raise HTTPException(status_code=400, detail="Verplichte Resend webhookheaders ontbreken.")
+    try:
+        timestamp = int(svix_timestamp)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="De Resend webhooktimestamp is ongeldig.") from exc
+    current = int(time.time() if now is None else now)
+    if abs(current - timestamp) > MAX_TIMESTAMP_SKEW_SECONDS:
+        raise HTTPException(status_code=401, detail="De Resend webhooktimestamp valt buiten het toegestane tijdvenster.")
+
+    signed_payload = f"{svix_id}.{svix_timestamp}.".encode("utf-8") + body
+    expected = base64.b64encode(hmac.new(_decode_secret(secret), signed_payload, hashlib.sha256).digest()).decode("ascii")
+    candidates = _signature_candidates(svix_signature)
+    if not candidates or not any(hmac.compare_digest(expected, candidate) for candidate in candidates):
+        raise HTTPException(status_code=401, detail="De Resend webhookhandtekening is ongeldig.")
+
+
+def ensure_delivery_table(module: Any) -> None:
+    with module.engine.begin() as conn:
+        conn.execute(
+            module.text(
+                """
+                CREATE TABLE IF NOT EXISTS receipt_webhook_deliveries (
+                    svix_id TEXT PRIMARY KEY,
+                    svix_timestamp INTEGER NOT NULL,
+                    payload_sha256 TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'processing',
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+        )
+
+
+def reserve_delivery(module: Any, *, svix_id: str, svix_timestamp: str, body: bytes) -> None:
+    payload_hash = hashlib.sha256(body).hexdigest()
+    try:
+        with module.engine.begin() as conn:
+            conn.execute(
+                module.text(
+                    """
+                    INSERT INTO receipt_webhook_deliveries (
+                        svix_id, svix_timestamp, payload_sha256, status, created_at, updated_at
+                    ) VALUES (
+                        :svix_id, :svix_timestamp, :payload_sha256, 'processing', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                    )
+                    """
+                ),
+                {
+                    "svix_id": svix_id,
+                    "svix_timestamp": int(svix_timestamp),
+                    "payload_sha256": payload_hash,
+                },
+            )
+    except Exception as exc:
+        message = str(exc).lower()
+        if "unique" in message or "primary key" in message:
+            raise HTTPException(status_code=409, detail="Deze Resend webhooklevering is al verwerkt.") from exc
+        raise
+
+
+def finalize_delivery(module: Any, *, svix_id: str, status: str) -> None:
+    with module.engine.begin() as conn:
+        conn.execute(
+            module.text(
+                """
+                UPDATE receipt_webhook_deliveries
+                SET status = :status, updated_at = CURRENT_TIMESTAMP
+                WHERE svix_id = :svix_id
+                """
+            ),
+            {"svix_id": svix_id, "status": status},
+        )
+
+
+def release_delivery(module: Any, *, svix_id: str) -> None:
+    with module.engine.begin() as conn:
+        conn.execute(
+            module.text("DELETE FROM receipt_webhook_deliveries WHERE svix_id = :svix_id"),
+            {"svix_id": svix_id},
+        )
+
+
+def install_receipt_resend_webhook_guard(module: Any) -> None:
+    if getattr(module.app.state, "receipt_resend_webhook_guard_installed", False):
+        return
+    ensure_delivery_table(module)
+
+    @module.app.middleware("http")
+    async def receipt_resend_webhook_guard(request: Request, call_next):
+        if request.method.upper() != "POST" or request.url.path != INBOUND_PATH:
+            return await call_next(request)
+
+        body = await request.body()
+        svix_id = str(request.headers.get("svix-id") or "").strip()
+        svix_timestamp = str(request.headers.get("svix-timestamp") or "").strip()
+        svix_signature = str(request.headers.get("svix-signature") or "").strip()
+        verify_resend_webhook(
+            body=body,
+            svix_id=svix_id,
+            svix_timestamp=svix_timestamp,
+            svix_signature=svix_signature,
+        )
+        reserve_delivery(
+            module,
+            svix_id=svix_id,
+            svix_timestamp=svix_timestamp,
+            body=body,
+        )
+        try:
+            response = await call_next(request)
+        except Exception:
+            release_delivery(module, svix_id=svix_id)
+            raise
+        if int(response.status_code) >= 500:
+            release_delivery(module, svix_id=svix_id)
+        else:
+            finalize_delivery(module, svix_id=svix_id, status="completed")
+        return response
+
+    module.app.state.receipt_resend_webhook_guard_installed = True

--- a/backend/app/testing/receipt_resend_webhook_guard_contract.py
+++ b/backend/app/testing/receipt_resend_webhook_guard_contract.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import time
+from types import SimpleNamespace
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import StaticPool
+
+from app.services.receipt_resend_webhook_guard import install_receipt_resend_webhook_guard
+
+SECRET_BYTES = b"rezzerv-resend-webhook-contract-secret"
+SECRET = "whsec_" + base64.b64encode(SECRET_BYTES).decode("ascii")
+
+
+def signature(body: bytes, svix_id: str, timestamp: int) -> str:
+    signed = f"{svix_id}.{timestamp}.".encode("utf-8") + body
+    digest = base64.b64encode(hmac.new(SECRET_BYTES, signed, hashlib.sha256).digest()).decode("ascii")
+    return f"v1,{digest}"
+
+
+def headers(body: bytes, svix_id: str, timestamp: int | None = None) -> dict[str, str]:
+    current = int(time.time() if timestamp is None else timestamp)
+    return {
+        "svix-id": svix_id,
+        "svix-timestamp": str(current),
+        "svix-signature": signature(body, svix_id, current),
+        "content-type": "application/json",
+    }
+
+
+def build_app():
+    app = FastAPI()
+    engine = create_engine(
+        "sqlite+pysqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        future=True,
+    )
+    state = {"calls": 0, "fail_once": True}
+
+    @app.post("/api/receipts/inbound")
+    async def inbound(request: Request):
+        state["calls"] += 1
+        payload = await request.json()
+        if payload.get("force_server_error") and state["fail_once"]:
+            state["fail_once"] = False
+            return JSONResponse(status_code=500, content={"detail": "temporary"})
+        return {"accepted": True, "payload": payload}
+
+    @app.post("/api/other")
+    async def other():
+        return {"ok": True}
+
+    module = SimpleNamespace(app=app, engine=engine, text=text)
+    install_receipt_resend_webhook_guard(module)
+    return app, engine, state
+
+
+def main() -> None:
+    previous = os.environ.get("REZZERV_RESEND_WEBHOOK_SECRET")
+    try:
+        os.environ.pop("REZZERV_RESEND_WEBHOOK_SECRET", None)
+        app, engine, state = build_app()
+        client = TestClient(app)
+
+        payload = {"type": "email.received", "data": {"to": ["bon+household-a@example.test"]}}
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+
+        response = client.post("/api/receipts/inbound", content=body)
+        assert response.status_code == 503, response.text
+        assert state["calls"] == 0
+
+        os.environ["REZZERV_RESEND_WEBHOOK_SECRET"] = SECRET
+        response = client.post("/api/receipts/inbound", content=body)
+        assert response.status_code == 400, response.text
+        assert state["calls"] == 0
+
+        bad_headers = headers(body, "evt-bad-signature")
+        bad_headers["svix-signature"] = "v1,invalid"
+        response = client.post("/api/receipts/inbound", content=body, headers=bad_headers)
+        assert response.status_code == 401, response.text
+        assert state["calls"] == 0
+
+        stale = int(time.time()) - 600
+        response = client.post("/api/receipts/inbound", content=body, headers=headers(body, "evt-stale", stale))
+        assert response.status_code == 401, response.text
+        assert state["calls"] == 0
+
+        valid_headers = headers(body, "evt-valid")
+        response = client.post("/api/receipts/inbound", content=body, headers=valid_headers)
+        assert response.status_code == 200, response.text
+        assert response.json()["accepted"] is True
+        assert state["calls"] == 1
+
+        response = client.post("/api/receipts/inbound", content=body, headers=valid_headers)
+        assert response.status_code == 409, response.text
+        assert state["calls"] == 1
+
+        with engine.begin() as conn:
+            stored = conn.execute(text("SELECT status, payload_sha256 FROM receipt_webhook_deliveries WHERE svix_id = 'evt-valid'")).mappings().first()
+        assert stored and stored["status"] == "completed"
+        assert stored["payload_sha256"] == hashlib.sha256(body).hexdigest()
+
+        retry_payload = {"type": "email.received", "force_server_error": True}
+        retry_body = json.dumps(retry_payload, separators=(",", ":")).encode("utf-8")
+        retry_headers = headers(retry_body, "evt-retry")
+        response = client.post("/api/receipts/inbound", content=retry_body, headers=retry_headers)
+        assert response.status_code == 500, response.text
+        with engine.begin() as conn:
+            retry_row = conn.execute(text("SELECT svix_id FROM receipt_webhook_deliveries WHERE svix_id = 'evt-retry'")).first()
+        assert retry_row is None
+
+        response = client.post("/api/receipts/inbound", content=retry_body, headers=retry_headers)
+        assert response.status_code == 200, response.text
+        assert state["calls"] == 3
+
+        response = client.post("/api/other")
+        assert response.status_code == 200, response.text
+
+        print("RECEIPT_RESEND_WEBHOOK_GUARD_GREEN")
+    finally:
+        if previous is None:
+            os.environ.pop("REZZERV_RESEND_WEBHOOK_SECRET", None)
+        else:
+            os.environ["REZZERV_RESEND_WEBHOOK_SECRET"] = previous
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Doel
De publieke receipt-inboundroute uitsluitend geldige, recente en niet eerder verwerkte Resend-webhooks laten uitvoeren.

## Gewijzigd
- exacte HTTP-guard voor `POST /api/receipts/inbound`;
- verificatie over de ongewijzigde raw body met `svix-id`, `svix-timestamp` en `svix-signature`;
- signing secret via `REZZERV_RESEND_WEBHOOK_SECRET`;
- maximaal vijf minuten tijdsafwijking;
- persistente replayblokkering op `svix-id` via `receipt_webhook_deliveries`;
- reservering wordt bij serverfouten vanaf 500 vrijgegeven voor een veilige Resend-retry;
- zelfstandige HTTP-integratietest en gerichte GitHub Action.

## Acceptatie
- ontbrekende webhooksecret levert 503 vóór endpointuitvoering;
- ontbrekende headers leveren 400;
- ongeldige handtekening of verlopen timestamp levert 401;
- geldige webhook wordt uitgevoerd;
- herhaling van dezelfde `svix-id` levert 409 zonder tweede import;
- na een serverfout kan dezelfde geldige levering opnieuw worden aangeboden;
- niet-gerelateerde routes worden niet geraakt.

## Niet gewijzigd
- receiptparser;
- huishoudadresafleiding in de bestaande inbound-importfunctie;
- Gmail/OAuth;
- frontend;
- mobiele/platformbrede shareflow;
- `/api/receipts/share-target`.