### PR TITLE
M2C2n: bind Resend inbound source to registered household

### DIFF
--- a/.github/workflows/receipt-resend-inbound-source-household-guard.yml
+++ b/.github/workflows/receipt-resend-inbound-source-household-guard.yml
@@ -1,0 +1,36 @@
+name: Receipt Resend inbound source household guard
+
+on:
+  pull_request:
+    paths:
+      - 'backend/app/services/receipt_resend_inbound_source_household_guard.py'
+      - 'backend/app/services/receipt_resend_webhook_guard.py'
+      - 'backend/app/testing/receipt_resend_inbound_source_household_guard_contract.py'
+      - '.github/workflows/receipt-resend-inbound-source-household-guard.yml'
+  workflow_dispatch:
+
+jobs:
+  validate-receipt-resend-inbound-source-household-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Installeer minimale backend-afhankelijkheden
+        run: python -m pip install --disable-pip-version-check fastapi sqlalchemy httpx
+
+      - name: Compileer gewijzigde modules
+        run: |
+          python -m py_compile backend/app/services/receipt_resend_inbound_source_household_guard.py
+          python -m py_compile backend/app/services/receipt_resend_webhook_guard.py
+          python -m py_compile backend/app/testing/receipt_resend_inbound_source_household_guard_contract.py
+
+      - name: Voer HTTP-bron-huishoudcontract uit
+        env:
+          PYTHONPATH: backend
+        run: python backend/app/testing/receipt_resend_inbound_source_household_guard_contract.py

--- a/backend/app/services/receipt_resend_inbound_source_household_guard.py
+++ b/backend/app/services/receipt_resend_inbound_source_household_guard.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+
+
+def resolve_registered_inbound_source(module: Any, recipient_addresses: list[str]) -> dict[str, Any]:
+    normalized_addresses = sorted({
+        str(value or "").strip().lower()
+        for value in (recipient_addresses or [])
+        if str(value or "").strip()
+    })
+    if not normalized_addresses:
+        raise HTTPException(status_code=400, detail="De inkomende e-mail bevat geen bruikbaar Rezzerv-ontvangstadres.")
+
+    placeholders = ", ".join(f":address_{index}" for index, _ in enumerate(normalized_addresses))
+    parameters = {
+        f"address_{index}": address
+        for index, address in enumerate(normalized_addresses)
+    }
+    with module.engine.begin() as conn:
+        rows = conn.execute(
+            module.text(
+                f"""
+                SELECT
+                    rs.id,
+                    rs.household_id,
+                    rs.type,
+                    rs.label,
+                    rs.source_path,
+                    rs.is_active,
+                    rs.last_scan_at,
+                    rs.created_at,
+                    rs.updated_at
+                FROM receipt_sources rs
+                JOIN household_registry hr ON hr.id = rs.household_id
+                WHERE rs.type = 'email'
+                  AND COALESCE(rs.is_active, 0) = 1
+                  AND lower(trim(rs.source_path)) IN ({placeholders})
+                ORDER BY rs.id ASC
+                """
+            ),
+            parameters,
+        ).mappings().all()
+
+    unique_rows: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        item = dict(row)
+        source_id = str(item.get("id") or "").strip()
+        household_id = str(item.get("household_id") or "").strip()
+        source_path = str(item.get("source_path") or "").strip().lower()
+        if not source_id or not household_id or source_path not in normalized_addresses:
+            continue
+        unique_rows[source_id] = item
+
+    if not unique_rows:
+        raise HTTPException(
+            status_code=400,
+            detail="Deze inkomende e-mail past niet bij een vooraf geregistreerd actief Rezzerv-adres.",
+        )
+    if len(unique_rows) != 1:
+        raise HTTPException(
+            status_code=409,
+            detail="Het inkomende e-mailadres is dubbelzinnig geconfigureerd en kan niet veilig aan één huishouden worden gekoppeld.",
+        )
+
+    row = next(iter(unique_rows.values()))
+    response = module.build_receipt_source_response(row)
+    response["route_address"] = str(row.get("source_path") or "").strip().lower()
+    response["household_id"] = str(row.get("household_id") or "").strip()
+    if not response["household_id"]:
+        raise HTTPException(status_code=400, detail="De geregistreerde receiptbron heeft geen geldig huishouden.")
+    return response
+
+
+def install_receipt_resend_inbound_source_household_guard(module: Any) -> None:
+    if getattr(module, "_receipt_resend_inbound_source_household_guard_installed", False):
+        return
+
+    def strict_resolver(recipient_addresses: list[str]) -> dict[str, Any]:
+        return resolve_registered_inbound_source(module, recipient_addresses)
+
+    module.resolve_household_email_source = strict_resolver
+    module._receipt_resend_inbound_source_household_guard_installed = True

--- a/backend/app/services/receipt_resend_webhook_guard.py
+++ b/backend/app/services/receipt_resend_webhook_guard.py
@@ -10,6 +10,10 @@ from typing import Any
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from app.services.receipt_resend_inbound_source_household_guard import (
+    install_receipt_resend_inbound_source_household_guard,
+)
+
 INBOUND_PATH = "/api/receipts/inbound"
 MAX_TIMESTAMP_SKEW_SECONDS = 300
 
@@ -131,6 +135,7 @@ def install_receipt_resend_webhook_guard(module: Any) -> None:
     if getattr(module.app.state, "receipt_resend_webhook_guard_installed", False):
         return
     ensure_delivery_table(module)
+    install_receipt_resend_inbound_source_household_guard(module)
 
     @module.app.middleware("http")
     async def receipt_resend_webhook_guard(request: Request, call_next):

--- a/backend/app/testing/receipt_resend_inbound_source_household_guard_contract.py
+++ b/backend/app/testing/receipt_resend_inbound_source_household_guard_contract.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import StaticPool
+
+from app.services.receipt_resend_inbound_source_household_guard import (
+    install_receipt_resend_inbound_source_household_guard,
+)
+
+
+def _module():
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE household_registry (id TEXT PRIMARY KEY, naam TEXT NOT NULL)"))
+        conn.execute(
+            text(
+                """
+                CREATE TABLE receipt_sources (
+                    id TEXT PRIMARY KEY,
+                    household_id TEXT,
+                    type TEXT,
+                    label TEXT,
+                    source_path TEXT,
+                    is_active INTEGER,
+                    last_scan_at TEXT,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+        )
+        conn.execute(text("INSERT INTO household_registry (id, naam) VALUES ('A', 'Huishouden A'), ('B', 'Huishouden B')"))
+        conn.execute(
+            text(
+                """
+                INSERT INTO receipt_sources (id, household_id, type, label, source_path, is_active)
+                VALUES
+                    ('source-a', 'A', 'email', 'E-mail A', 'bon+a@example.test', 1),
+                    ('source-inactive', 'A', 'email', 'Inactief', 'bon+inactive@example.test', 0),
+                    ('source-orphan', 'MISSING', 'email', 'Orphan', 'bon+orphan@example.test', 1)
+                """
+            )
+        )
+
+    app = FastAPI()
+    module = SimpleNamespace(
+        app=app,
+        engine=engine,
+        text=text,
+        build_receipt_source_response=lambda row: dict(row),
+        resolve_household_email_source=lambda recipients: {"unsafe": True},
+    )
+    install_receipt_resend_inbound_source_household_guard(module)
+    executed = {"count": 0}
+
+    @app.post("/api/receipts/inbound-source-contract")
+    def inbound_source_contract(payload: dict):
+        source = module.resolve_household_email_source(payload.get("recipients") or [])
+        executed["count"] += 1
+        return {
+            "source_id": source.get("id"),
+            "household_id": source.get("household_id"),
+            "route_address": source.get("route_address"),
+        }
+
+    return module, executed
+
+
+def _assert_status(client: TestClient, recipients: list[str], expected: int) -> dict:
+    response = client.post("/api/receipts/inbound-source-contract", json={"recipients": recipients})
+    assert response.status_code == expected, response.text
+    return response.json()
+
+
+def main() -> None:
+    module, executed = _module()
+    client = TestClient(module.app)
+
+    valid = _assert_status(client, ["BON+A@example.test"], 200)
+    assert valid == {
+        "source_id": "source-a",
+        "household_id": "A",
+        "route_address": "bon+a@example.test",
+    }
+    assert executed["count"] == 1
+
+    with module.engine.begin() as conn:
+        source_count_before = int(conn.execute(text("SELECT COUNT(*) FROM receipt_sources")).scalar_one())
+
+    _assert_status(client, ["bon+unknown@example.test"], 400)
+    _assert_status(client, ["bon+inactive@example.test"], 400)
+    _assert_status(client, ["bon+orphan@example.test"], 400)
+    _assert_status(client, [], 400)
+    assert executed["count"] == 1
+
+    with module.engine.begin() as conn:
+        source_count_after = int(conn.execute(text("SELECT COUNT(*) FROM receipt_sources")).scalar_one())
+        assert source_count_after == source_count_before
+        conn.execute(
+            text(
+                """
+                INSERT INTO receipt_sources (id, household_id, type, label, source_path, is_active)
+                VALUES ('source-b-duplicate', 'B', 'email', 'Dubbel', 'bon+a@example.test', 1)
+                """
+            )
+        )
+
+    _assert_status(client, ["bon+a@example.test"], 409)
+    assert executed["count"] == 1
+
+    unrelated = client.get("/openapi.json")
+    assert unrelated.status_code == 200
+    print("receipt_resend_inbound_source_household_guard_contract: OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Doel
De ondertekende Resend-inboundketen uitsluitend laten importeren via een vooraf geregistreerde actieve e-mailbron van een bestaand huishouden.

## Gewijzigd
- strikte bronresolver voor inbound receipt-e-mail;
- alleen exacte actieve `receipt_sources` van type `email` worden geaccepteerd;
- gekoppeld `household_id` moet bestaan in `household_registry`;
- onbekende `bon+...`-adressen maken tijdens inbound geen bron meer aan;
- dubbelzinnige adresconfiguratie levert 409;
- integratie met de bestaande Resend handtekening- en replayguard;
- zelfstandige HTTP-contracttest en gerichte GitHub Action.

## Acceptatie
- vooraf geregistreerd actief adres van bestaand huishouden wordt toegestaan;
- onbekend adres levert 400 vóór import;
- inactieve bron levert 400;
- bron met ontbrekend huishouden levert 400;
- dubbele actieve bron voor hetzelfde adres levert 409;
- blokkering maakt geen receiptbron aan;
- niet-gerelateerde routes blijven onaangetast.

## Niet gewijzigd
- Resend handtekeningalgoritme;
- replaybescherming;
- receiptparser;
- Gmail/OAuth;
- frontend;
- mobiele/platformbrede shareflow;
- `/api/receipts/share-target`.