### PR TITLE
M2C2n: protect receipt export fixture routes

### DIFF
--- a/backend/app/services/receipt_admin_household_guard.py
+++ b/backend/app/services/receipt_admin_household_guard.py
@@ -5,12 +5,13 @@ from collections.abc import Callable
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 
-_PROTECTED_METHOD = "POST"
-_PROTECTED_PATHS = {
-    "/api/admin/backfill-purchase-import-live-aliases",
-    "/api/admin/recompute-receipt-statuses",
-    "/api/admin/validate-receipt-status-baseline",
-    "/api/admin/diagnose-receipt-status-baseline",
+_PROTECTED_REQUESTS = {
+    ("POST", "/api/admin/backfill-purchase-import-live-aliases"),
+    ("POST", "/api/admin/recompute-receipt-statuses"),
+    ("POST", "/api/admin/validate-receipt-status-baseline"),
+    ("POST", "/api/admin/diagnose-receipt-status-baseline"),
+    ("POST", "/api/testing/fixtures/receipt-export/generate"),
+    ("GET", "/api/testing/fixtures/receipt-export/download"),
 }
 
 
@@ -20,9 +21,8 @@ def authorize_receipt_admin_request(
     authorization: str | None,
     require_platform_admin_user: Callable[[str | None], object],
 ) -> object | None:
-    if str(method or "").upper() != _PROTECTED_METHOD:
-        return None
-    if str(path or "") not in _PROTECTED_PATHS:
+    request_key = (str(method or "").upper(), str(path or ""))
+    if request_key not in _PROTECTED_REQUESTS:
         return None
     return require_platform_admin_user(authorization)
 

--- a/backend/app/testing/receipt_admin_household_guard_contract.py
+++ b/backend/app/testing/receipt_admin_household_guard_contract.py
@@ -48,6 +48,16 @@ def run_contract() -> None:
         calls.append("diagnose")
         return {"status": "ok"}
 
+    @app.post("/api/testing/fixtures/receipt-export/generate")
+    def generate_receipt_export_fixture():
+        calls.append("fixture-generate")
+        return {"status": "ok"}
+
+    @app.get("/api/testing/fixtures/receipt-export/download")
+    def download_receipt_export_fixture():
+        calls.append("fixture-download")
+        return {"status": "ok"}
+
     @app.post("/api/admin/unrelated")
     def unrelated_admin_route():
         calls.append("unrelated")
@@ -73,31 +83,71 @@ def run_contract() -> None:
     assert response.status_code == 200, response.text
     assert calls == ["live-alias-backfill"]
 
-    response = client.post("/api/admin/recompute-receipt-statuses")
+    response = client.post("/api/testing/fixtures/receipt-export/generate")
     assert response.status_code == 401, response.text
     assert calls == ["live-alias-backfill"]
 
     response = client.post(
-        "/api/admin/validate-receipt-status-baseline",
+        "/api/testing/fixtures/receipt-export/generate",
+        headers={"Authorization": "Bearer household-user"},
+    )
+    assert response.status_code == 403, response.text
+    assert calls == ["live-alias-backfill"]
+
+    response = client.get("/api/testing/fixtures/receipt-export/download")
+    assert response.status_code == 401, response.text
+    assert calls == ["live-alias-backfill"]
+
+    response = client.get(
+        "/api/testing/fixtures/receipt-export/download",
         headers={"Authorization": "Bearer household-user"},
     )
     assert response.status_code == 403, response.text
     assert calls == ["live-alias-backfill"]
 
     response = client.post(
+        "/api/testing/fixtures/receipt-export/generate",
+        headers={"Authorization": "Bearer platform-admin"},
+    )
+    assert response.status_code == 200, response.text
+    assert calls == ["live-alias-backfill", "fixture-generate"]
+
+    response = client.get(
+        "/api/testing/fixtures/receipt-export/download",
+        headers={"Authorization": "Bearer platform-admin"},
+    )
+    assert response.status_code == 200, response.text
+    assert calls == ["live-alias-backfill", "fixture-generate", "fixture-download"]
+
+    response = client.post("/api/admin/recompute-receipt-statuses")
+    assert response.status_code == 401, response.text
+
+    response = client.post(
+        "/api/admin/validate-receipt-status-baseline",
+        headers={"Authorization": "Bearer household-user"},
+    )
+    assert response.status_code == 403, response.text
+
+    response = client.post(
         "/api/admin/diagnose-receipt-status-baseline",
         headers={"Authorization": "Bearer platform-admin"},
     )
     assert response.status_code == 200, response.text
-    assert calls == ["live-alias-backfill", "diagnose"]
+    assert calls[-1] == "diagnose"
 
     response = client.post("/api/admin/unrelated")
     assert response.status_code == 200, response.text
-    assert calls == ["live-alias-backfill", "diagnose", "unrelated"]
+    assert calls[-1] == "unrelated"
 
     assert authorize_receipt_admin_request(
         "GET",
         "/api/admin/backfill-purchase-import-live-aliases",
+        None,
+        require_platform_admin_user,
+    ) is None
+    assert authorize_receipt_admin_request(
+        "POST",
+        "/api/testing/fixtures/receipt-export/download",
         None,
         require_platform_admin_user,
     ) is None


### PR DESCRIPTION
## Doel
De receipt-exporttestfixture uitsluitend door een platformbeheerder laten genereren of downloaden, omdat de downloadroute bij ontbrekende ID's indirect muterende fixture-aanmaak uitvoert.

## Gewijzigd
- bestaande platform-adminguard uitgebreid met methode-padcombinaties;
- `POST /api/testing/fixtures/receipt-export/generate` beschermd;
- `GET /api/testing/fixtures/receipt-export/download` beschermd;
- bestaande HTTP-contracttest uitgebreid met 401, 403 en platform-admin-toegang voor beide routes.

## Acceptatie
- ontbrekende autorisatie levert 401 voor generate en download;
- gewone huishoudgebruiker levert 403;
- alleen platformbeheerder bereikt de routecode;
- GET-download kan anoniem geen indirecte fixture-aanmaak meer starten;
- bestaande adminroutes blijven beschermd;
- niet-gerelateerde routes blijven onaangetast;
- alle bestaande regressiegates blijven groen.

## Niet gewijzigd
- fixture-inhoud;
- exportformaat;
- store connections;
- purchase-importalgoritme;
- frontend;
- `/api/receipts/share-target`.