### PR TITLE
M2C2n: require write permission for unpacking mutations

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -98,6 +98,7 @@ def _install_unpacking_object_guard_when_ready() -> None:
             and hasattr(module, 'app')
             and hasattr(module, 'engine')
             and hasattr(module, 'require_household_context')
+            and hasattr(module, 'require_inventory_write_context')
         ):
             try:
                 from .services.unpacking_household_object_guard import (

--- a/backend/app/services/unpacking_household_object_guard.py
+++ b/backend/app/services/unpacking_household_object_guard.py
@@ -9,6 +9,7 @@ from sqlalchemy import text
 
 _LINE_PATH = re.compile(r"^/api/purchase-import-lines/([^/]+)(?:/|$)")
 _BATCH_PATH = re.compile(r"^/api/purchase-import-batches/([^/]+)(?:/|$)")
+_WRITE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 
 
 def resolve_purchase_import_household(conn, request_path: str) -> str | None:
@@ -63,15 +64,21 @@ def resolve_purchase_import_household(conn, request_path: str) -> str | None:
 
 def authorize_purchase_import_request(
     conn,
+    request_method: str,
     request_path: str,
     authorization: str | None,
     require_household_context: Callable[[str | None, str | None], dict[str, Any]],
+    require_inventory_write_context: Callable[[str | None, str | None], dict[str, Any]],
 ) -> dict[str, Any] | None:
-    """Authorize a protected request against the server-side owning household."""
+    """Authorize a production Uitpakken request against its server-side household."""
 
     household_id = resolve_purchase_import_household(conn, request_path)
     if household_id is None:
         return None
+
+    normalized_method = str(request_method or "").strip().upper()
+    if normalized_method in _WRITE_METHODS:
+        return require_inventory_write_context(authorization, household_id)
     return require_household_context(authorization, household_id)
 
 
@@ -88,9 +95,11 @@ def install_unpacking_household_object_guard(main_module) -> None:
             with main_module.engine.begin() as conn:
                 authorize_purchase_import_request(
                     conn,
+                    request.method,
                     request.url.path,
                     request.headers.get("authorization"),
                     main_module.require_household_context,
+                    main_module.require_inventory_write_context,
                 )
         except HTTPException as exc:
             return JSONResponse(

--- a/backend/app/testing/unpacking_household_object_guard_contract.py
+++ b/backend/app/testing/unpacking_household_object_guard_contract.py
@@ -1,4 +1,4 @@
-"""Contract for server-side household authorization of Uitpakken objects."""
+"""Contract for server-side household and write authorization of Uitpakken objects."""
 
 from __future__ import annotations
 
@@ -75,18 +75,27 @@ def _seed(engine) -> None:
 
 
 def _require_context(authorization, requested_household_id):
-    token_household = {
-        "Bearer token-a": "household-a",
-        "Bearer token-b": "household-b",
+    token_context = {
+        "Bearer token-a-admin": ("household-a", "admin"),
+        "Bearer token-a-viewer": ("household-a", "viewer"),
+        "Bearer token-b-admin": ("household-b", "admin"),
     }.get(authorization)
-    if token_household is None:
+    if token_context is None:
         raise HTTPException(status_code=401, detail="Unauthorized")
+    token_household, display_role = token_context
     if token_household != requested_household_id:
         raise HTTPException(status_code=403, detail="Geen toegang")
     return {
         "active_household_id": token_household,
-        "display_role": "admin",
+        "display_role": display_role,
     }
+
+
+def _require_write_context(authorization, requested_household_id):
+    context = _require_context(authorization, requested_household_id)
+    if context["display_role"] == "viewer":
+        raise HTTPException(status_code=403, detail="Kijkers mogen deze voorraadactie niet uitvoeren")
+    return context
 
 
 def _run_http_contract(engine) -> None:
@@ -95,12 +104,22 @@ def _run_http_contract(engine) -> None:
 
     @app.post("/api/purchase-import-lines/{line_id}/map")
     def map_line(line_id: str):
-        endpoint_calls.append(line_id)
+        endpoint_calls.append(f"map:{line_id}")
+        return {"line_id": line_id, "executed": True}
+
+    @app.post("/api/purchase-import-lines/{line_id}/external-product-candidates/search")
+    def search_candidates(line_id: str):
+        endpoint_calls.append(f"search:{line_id}")
+        return {"line_id": line_id, "executed": True}
+
+    @app.get("/api/purchase-import-lines/{line_id}/external-product-candidates")
+    def get_candidates(line_id: str):
+        endpoint_calls.append(f"read:{line_id}")
         return {"line_id": line_id, "executed": True}
 
     @app.post("/api/purchase-import-batches/{batch_id}/complete-review")
     def complete_review(batch_id: str):
-        endpoint_calls.append(batch_id)
+        endpoint_calls.append(f"complete:{batch_id}")
         return {"batch_id": batch_id, "executed": True}
 
     @app.get("/api/testing/diagnostics/purchase-import-batches/{batch_id}")
@@ -111,37 +130,60 @@ def _run_http_contract(engine) -> None:
         app=app,
         engine=engine,
         require_household_context=_require_context,
+        require_inventory_write_context=_require_write_context,
     )
     install_unpacking_household_object_guard(main_module)
 
     with TestClient(app) as client:
-        own = client.post(
+        own_write = client.post(
             "/api/purchase-import-lines/line-a/map",
-            headers={"Authorization": "Bearer token-a"},
+            headers={"Authorization": "Bearer token-a-admin"},
         )
-        assert own.status_code == 200, own.text
-        assert own.json()["executed"] is True
-        assert endpoint_calls == ["line-a"]
+        assert own_write.status_code == 200, own_write.text
+        assert own_write.json()["executed"] is True
+        assert endpoint_calls == ["map:line-a"]
+
+        viewer_write = client.post(
+            "/api/purchase-import-lines/line-a/map",
+            headers={"Authorization": "Bearer token-a-viewer"},
+        )
+        assert viewer_write.status_code == 403, viewer_write.text
+        assert endpoint_calls == ["map:line-a"], "Map-endpoint werd ondanks kijkersblokkering uitgevoerd"
+
+        viewer_search = client.post(
+            "/api/purchase-import-lines/line-a/external-product-candidates/search",
+            headers={"Authorization": "Bearer token-a-viewer"},
+        )
+        assert viewer_search.status_code == 403, viewer_search.text
+        assert endpoint_calls == ["map:line-a"], "Zoekendpoint werd ondanks kijkersblokkering uitgevoerd"
+
+        viewer_read = client.get(
+            "/api/purchase-import-lines/line-a/external-product-candidates",
+            headers={"Authorization": "Bearer token-a-viewer"},
+        )
+        assert viewer_read.status_code == 200, viewer_read.text
+        assert viewer_read.json()["executed"] is True
+        assert endpoint_calls == ["map:line-a", "read:line-a"]
 
         cross_household = client.post(
             "/api/purchase-import-lines/line-b/map",
-            headers={"Authorization": "Bearer token-a"},
+            headers={"Authorization": "Bearer token-a-admin"},
         )
         assert cross_household.status_code == 403, cross_household.text
-        assert endpoint_calls == ["line-a"], "Endpoint werd ondanks 403 uitgevoerd"
+        assert endpoint_calls == ["map:line-a", "read:line-a"], "Endpoint werd ondanks 403 uitgevoerd"
 
         missing_auth = client.post(
             "/api/purchase-import-batches/batch-a/complete-review",
         )
         assert missing_auth.status_code == 401, missing_auth.text
-        assert endpoint_calls == ["line-a"], "Endpoint werd ondanks 401 uitgevoerd"
+        assert endpoint_calls == ["map:line-a", "read:line-a"], "Endpoint werd ondanks 401 uitgevoerd"
 
         missing_object = client.post(
             "/api/purchase-import-lines/missing/map",
-            headers={"Authorization": "Bearer token-a"},
+            headers={"Authorization": "Bearer token-a-admin"},
         )
         assert missing_object.status_code == 404, missing_object.text
-        assert endpoint_calls == ["line-a"], "Endpoint werd ondanks 404 uitgevoerd"
+        assert endpoint_calls == ["map:line-a", "read:line-a"], "Endpoint werd ondanks 404 uitgevoerd"
 
         testing = client.get(
             "/api/testing/diagnostics/purchase-import-batches/batch-a",
@@ -170,37 +212,71 @@ def run_contract() -> None:
             == "household-b"
         )
 
-        calls: list[tuple[str | None, str | None]] = []
+        read_calls: list[tuple[str | None, str | None]] = []
+        write_calls: list[tuple[str | None, str | None]] = []
 
         def recording_require_context(authorization, requested_household_id):
-            calls.append((authorization, requested_household_id))
+            read_calls.append((authorization, requested_household_id))
             return _require_context(authorization, requested_household_id)
 
-        context = authorize_purchase_import_request(
+        def recording_require_write_context(authorization, requested_household_id):
+            write_calls.append((authorization, requested_household_id))
+            return _require_write_context(authorization, requested_household_id)
+
+        read_context = authorize_purchase_import_request(
             conn,
-            "/api/purchase-import-lines/line-a/map",
-            "Bearer token-a",
+            "GET",
+            "/api/purchase-import-lines/line-a/external-product-candidates",
+            "Bearer token-a-viewer",
             recording_require_context,
+            recording_require_write_context,
         )
-        assert context and context["active_household_id"] == "household-a"
-        assert calls[-1] == ("Bearer token-a", "household-a")
+        assert read_context and read_context["display_role"] == "viewer"
+        assert read_calls[-1] == ("Bearer token-a-viewer", "household-a")
+        assert write_calls == []
+
+        write_context = authorize_purchase_import_request(
+            conn,
+            "POST",
+            "/api/purchase-import-lines/line-a/map",
+            "Bearer token-a-admin",
+            recording_require_context,
+            recording_require_write_context,
+        )
+        assert write_context and write_context["display_role"] == "admin"
+        assert write_calls[-1] == ("Bearer token-a-admin", "household-a")
 
         _expect_http_error(
             403,
             lambda: authorize_purchase_import_request(
                 conn,
-                "/api/purchase-import-lines/line-b/create-article",
-                "Bearer token-a",
+                "POST",
+                "/api/purchase-import-lines/line-a/external-product-candidates/search",
+                "Bearer token-a-viewer",
                 recording_require_context,
+                recording_require_write_context,
+            ),
+        )
+        _expect_http_error(
+            403,
+            lambda: authorize_purchase_import_request(
+                conn,
+                "POST",
+                "/api/purchase-import-lines/line-b/create-article",
+                "Bearer token-a-admin",
+                recording_require_context,
+                recording_require_write_context,
             ),
         )
         _expect_http_error(
             401,
             lambda: authorize_purchase_import_request(
                 conn,
+                "POST",
                 "/api/purchase-import-batches/batch-a/complete-review",
                 None,
                 recording_require_context,
+                recording_require_write_context,
             ),
         )
         _expect_http_error(


### PR DESCRIPTION
## Doel
M2C2n-huishoudisolatie uitbreiden met een expliciete rolgrens voor muterende purchase-importbatch- en regelroutes.

## Gewijzigd
- centrale Uitpakken-objectguard maakt onderscheid tussen lees- en schrijfmethoden;
- GET en overige veilige leesmethoden blijven via `require_household_context` lopen;
- POST, PUT, PATCH en DELETE vereisen `require_inventory_write_context`;
- owning household blijft server-side uit batch of regel afgeleid;
- installatie wacht nu ook op `require_inventory_write_context`;
- HTTP-contracttest uitgebreid met viewer-, admin-, cross-household-, ontbrekende-auth- en ontbrekend-objectscenario's.

## Acceptatie
- kijker kan kandidaatgegevens van een eigen importregel lezen;
- kijker kan geen externe kandidaatsearch starten;
- kijker kan geen importregel mappen of andere muterende batch-/regelroute uitvoeren;
- admin/lid met inventory-schrijfrecht kan eigen mutaties uitvoeren;
- objecten van andere huishoudens blijven geblokkeerd;
- testing-routes blijven buiten deze productieguard;
- alle bestaande regressiegates blijven groen.

## Niet gewijzigd
- productidentiteitsalgoritme;
- externe productbronadapters;
- kandidaatselectie;
- purchase-importinhoud;
- frontend;
- `/api/receipts/share-target`.