### PR TITLE
M2C2n: require write permission for product enrichment

### DIFF
--- a/.github/workflows/product-enrichment-write-guard.yml
+++ b/.github/workflows/product-enrichment-write-guard.yml
@@ -1,0 +1,39 @@
+name: Product enrichment write guard
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  validate-product-enrichment-write-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Installeer minimale backend-afhankelijkheden
+        run: |
+          python -m pip install --quiet \
+            fastapi==0.115.0 \
+            httpx==0.27.2
+
+      - name: Compileer gewijzigde modules
+        run: |
+          python -m py_compile \
+            backend/app/__init__.py \
+            backend/app/services/product_enrichment_write_guard.py \
+            backend/app/testing/product_enrichment_write_guard_contract.py
+
+      - name: Voer productverrijkings-schrijfcontract uit
+        env:
+          PYTHONPATH: backend
+        run: |
+          python -m app.testing.product_enrichment_write_guard_contract | tee product-enrichment-write-guard.log
+          grep -F 'PRODUCT_ENRICHMENT_WRITE_GUARD_GREEN' product-enrichment-write-guard.log

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -111,6 +111,25 @@ def _install_unpacking_object_guard_when_ready() -> None:
         time.sleep(0.1)
 
 
+def _install_product_enrichment_write_guard_when_ready() -> None:
+    for _ in range(200):
+        module = sys.modules.get('app.main')
+        if (
+            module is not None
+            and hasattr(module, 'app')
+            and hasattr(module, 'require_inventory_write_context')
+        ):
+            try:
+                from .services.product_enrichment_write_guard import (
+                    install_product_enrichment_write_guard,
+                )
+                install_product_enrichment_write_guard(module)
+            except Exception:
+                pass
+            return
+        time.sleep(0.1)
+
+
 def _install_receipt_share_import_guard_when_ready() -> None:
     for _ in range(200):
         module = sys.modules.get('app.main')
@@ -200,6 +219,10 @@ threading.Thread(
 ).start()
 threading.Thread(
     target=_install_unpacking_object_guard_when_ready,
+    daemon=True,
+).start()
+threading.Thread(
+    target=_install_product_enrichment_write_guard_when_ready,
     daemon=True,
 ).start()
 threading.Thread(

--- a/backend/app/services/product_enrichment_write_guard.py
+++ b/backend/app/services/product_enrichment_write_guard.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+
+_PROTECTED_METHOD = "POST"
+_PROTECTED_PATHS = {
+    "/api/products/enrich",
+    "/api/products/enrich/retry",
+}
+
+
+def extract_requested_household_id(body: bytes) -> str | None:
+    if not body:
+        return None
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("household_id")
+    return str(value).strip() if value not in (None, "") else None
+
+
+def authorize_product_enrichment_request(
+    method: str,
+    path: str,
+    authorization: str | None,
+    body: bytes,
+    require_inventory_write_context: Callable[[str | None, str | None], dict[str, Any]],
+) -> dict[str, Any] | None:
+    if str(method or "").strip().upper() != _PROTECTED_METHOD:
+        return None
+    if str(path or "").strip() not in _PROTECTED_PATHS:
+        return None
+    requested_household_id = extract_requested_household_id(body)
+    return require_inventory_write_context(authorization, requested_household_id)
+
+
+def install_product_enrichment_write_guard(main_module) -> None:
+    app = main_module.app
+    if getattr(app.state, "product_enrichment_write_guard_installed", False):
+        return
+
+    @app.middleware("http")
+    async def product_enrichment_write_guard(request, call_next):
+        try:
+            body = await request.body()
+            authorize_product_enrichment_request(
+                request.method,
+                request.url.path,
+                request.headers.get("authorization"),
+                body,
+                main_module.require_inventory_write_context,
+            )
+        except HTTPException as exc:
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": exc.detail},
+                headers=exc.headers or None,
+            )
+        return await call_next(request)
+
+    app.state.product_enrichment_write_guard_installed = True

--- a/backend/app/testing/product_enrichment_write_guard_contract.py
+++ b/backend/app/testing/product_enrichment_write_guard_contract.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from app.services.product_enrichment_write_guard import (
+    authorize_product_enrichment_request,
+    extract_requested_household_id,
+    install_product_enrichment_write_guard,
+)
+
+
+def run_contract() -> None:
+    app = FastAPI()
+    calls: list[str] = []
+
+    def require_inventory_write_context(authorization: str | None, requested_household_id: str | None):
+        if not authorization:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+        if authorization == "Bearer viewer":
+            raise HTTPException(status_code=403, detail="Kijkers mogen deze voorraadactie niet uitvoeren")
+        if authorization != "Bearer writer":
+            raise HTTPException(status_code=403, detail="Geen toegang")
+        if requested_household_id not in {None, "household-a"}:
+            raise HTTPException(status_code=403, detail="Geen toegang")
+        return {"active_household_id": "household-a", "display_role": "lid"}
+
+    install_product_enrichment_write_guard(
+        SimpleNamespace(
+            app=app,
+            require_inventory_write_context=require_inventory_write_context,
+        )
+    )
+
+    @app.post("/api/products/enrich")
+    def enrich():
+        calls.append("enrich")
+        return {"status": "ok"}
+
+    @app.post("/api/products/enrich/retry")
+    def retry():
+        calls.append("retry")
+        return {"status": "ok"}
+
+    @app.post("/api/products/identify")
+    def identify():
+        calls.append("identify")
+        return {"status": "ok"}
+
+    client = TestClient(app)
+    payload = {"household_id": "household-a", "article_name": "Melk", "force_refresh": False}
+
+    response = client.post("/api/products/enrich", json=payload)
+    assert response.status_code == 401, response.text
+    assert calls == []
+
+    response = client.post(
+        "/api/products/enrich",
+        json=payload,
+        headers={"Authorization": "Bearer viewer"},
+    )
+    assert response.status_code == 403, response.text
+    assert calls == []
+
+    response = client.post(
+        "/api/products/enrich",
+        json={**payload, "household_id": "household-b"},
+        headers={"Authorization": "Bearer writer"},
+    )
+    assert response.status_code == 403, response.text
+    assert calls == []
+
+    response = client.post(
+        "/api/products/enrich",
+        json=payload,
+        headers={"Authorization": "Bearer writer"},
+    )
+    assert response.status_code == 200, response.text
+    assert calls == ["enrich"]
+
+    response = client.post(
+        "/api/products/enrich/retry",
+        json=payload,
+        headers={"Authorization": "Bearer viewer"},
+    )
+    assert response.status_code == 403, response.text
+    assert calls == ["enrich"]
+
+    response = client.post(
+        "/api/products/enrich/retry",
+        json=payload,
+        headers={"Authorization": "Bearer writer"},
+    )
+    assert response.status_code == 200, response.text
+    assert calls == ["enrich", "retry"]
+
+    response = client.post("/api/products/identify")
+    assert response.status_code == 200, response.text
+    assert calls == ["enrich", "retry", "identify"]
+
+    assert extract_requested_household_id(b'{"household_id":"household-a"}') == "household-a"
+    assert extract_requested_household_id(b'{}') is None
+    assert extract_requested_household_id(b'not-json') is None
+
+    assert authorize_product_enrichment_request(
+        "GET",
+        "/api/products/enrich",
+        None,
+        b"",
+        require_inventory_write_context,
+    ) is None
+    assert authorize_product_enrichment_request(
+        "POST",
+        "/api/products/identify",
+        None,
+        b"",
+        require_inventory_write_context,
+    ) is None
+
+    print("PRODUCT_ENRICHMENT_WRITE_GUARD_GREEN")
+
+
+if __name__ == "__main__":
+    run_contract()


### PR DESCRIPTION
## Doel
Voorkomen dat kijkers productverrijking starten en daardoor enrichment-, audit-, global-product- en gekoppelde huishoudartikelgegevens laten muteren.

## Gewijzigd
- centrale write guard toegevoegd voor `POST /api/products/enrich`;
- dezelfde guard toegevoegd voor `POST /api/products/enrich/retry`;
- aangevraagd huishouden wordt uit de JSON-body gelezen;
- `require_inventory_write_context` bepaalt autorisatie;
- guard wordt automatisch geïnstalleerd wanneer de backendcontext beschikbaar is;
- gerichte HTTP-contracttest en CI-workflow toegevoegd.

## Acceptatie
- ontbrekende autorisatie geeft 401;
- kijker krijgt 403 vóór endpointuitvoering;
- schrijver kan productverrijking en retry uitvoeren voor het eigen huishouden;
- cross-household-aanvraag wordt geblokkeerd;
- `POST /api/products/identify` en overige productroutes worden niet door deze guard geraakt;
- alle bestaande regressiegates blijven groen.

## Niet gewijzigd
- enrichmentalgoritme;
- productbronadapters;
- global-productmatching;
- frontend;
- `/api/receipts/share-target`.