### PR TITLE
M2C2n: require write permission for article detail mutations

### DIFF
--- a/.github/workflows/article-detail-write-guard.yml
+++ b/.github/workflows/article-detail-write-guard.yml
@@ -1,0 +1,39 @@
+name: Article detail write guard
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  validate-article-detail-write-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Installeer minimale backend-afhankelijkheden
+        run: |
+          python -m pip install --quiet \
+            fastapi==0.115.0 \
+            httpx==0.27.2
+
+      - name: Compileer gewijzigde modules
+        run: |
+          python -m py_compile \
+            backend/app/services/article_detail_write_guard.py \
+            backend/app/services/product_enrichment_write_guard.py \
+            backend/app/testing/article_detail_write_guard_contract.py
+
+      - name: Voer artikeldetail-schrijfcontract uit
+        env:
+          PYTHONPATH: backend
+        run: |
+          python -m app.testing.article_detail_write_guard_contract | tee article-detail-write-guard.log
+          grep -F 'ARTICLE_DETAIL_WRITE_GUARD_GREEN' article-detail-write-guard.log

--- a/backend/app/services/article_detail_write_guard.py
+++ b/backend/app/services/article_detail_write_guard.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+
+_TARGET_ENDPOINTS = {
+    "enrich_article_by_id",
+    "patch_article_household_details",
+}
+_WRITE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+
+
+def discover_article_detail_write_routes(app) -> set[tuple[str, str]]:
+    protected: set[tuple[str, str]] = set()
+    for route in getattr(app, "routes", []):
+        endpoint = getattr(route, "endpoint", None)
+        endpoint_name = getattr(endpoint, "__name__", "")
+        if endpoint_name not in _TARGET_ENDPOINTS:
+            continue
+        path = str(getattr(route, "path", "") or "")
+        for method in set(getattr(route, "methods", set()) or set()):
+            normalized_method = str(method).upper()
+            if path and normalized_method in _WRITE_METHODS:
+                protected.add((normalized_method, path))
+    return protected
+
+
+def install_article_detail_write_guard(main_module) -> None:
+    app = main_module.app
+    if getattr(app.state, "article_detail_write_guard_installed", False):
+        return
+
+    protected_routes = discover_article_detail_write_routes(app)
+
+    @app.middleware("http")
+    async def article_detail_write_guard(request, call_next):
+        route_key = (request.method.upper(), request.url.path)
+        matched = route_key in protected_routes
+        if not matched:
+            for method, template in protected_routes:
+                if method != request.method.upper():
+                    continue
+                template_parts = template.strip("/").split("/")
+                request_parts = request.url.path.strip("/").split("/")
+                if len(template_parts) != len(request_parts):
+                    continue
+                if all(tp.startswith("{") and tp.endswith("}") or tp == rp for tp, rp in zip(template_parts, request_parts)):
+                    matched = True
+                    break
+        if matched:
+            try:
+                main_module.require_inventory_write_context(
+                    request.headers.get("authorization"),
+                    None,
+                )
+            except HTTPException as exc:
+                return JSONResponse(
+                    status_code=exc.status_code,
+                    content={"detail": exc.detail},
+                    headers=exc.headers or None,
+                )
+        return await call_next(request)
+
+    app.state.article_detail_write_guard_routes = protected_routes
+    app.state.article_detail_write_guard_installed = True

--- a/backend/app/services/product_enrichment_write_guard.py
+++ b/backend/app/services/product_enrichment_write_guard.py
@@ -67,3 +67,7 @@ def install_product_enrichment_write_guard(main_module) -> None:
         return await call_next(request)
 
     app.state.product_enrichment_write_guard_installed = True
+
+    from .article_detail_write_guard import install_article_detail_write_guard
+
+    install_article_detail_write_guard(main_module)

--- a/backend/app/testing/article_detail_write_guard_contract.py
+++ b/backend/app/testing/article_detail_write_guard_contract.py
@@ -1,0 +1,113 @@
+"""HTTP contract for article-detail mutation write authorization."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from app.services.article_detail_write_guard import (
+    discover_article_detail_write_routes,
+    install_article_detail_write_guard,
+)
+
+
+def _require_write_context(authorization, requested_household_id):
+    contexts = {
+        "Bearer writer": {"active_household_id": "household-a", "display_role": "lid"},
+        "Bearer viewer": {"active_household_id": "household-a", "display_role": "viewer"},
+    }
+    context = contexts.get(authorization)
+    if context is None:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    if context["display_role"] == "viewer":
+        raise HTTPException(status_code=403, detail="Kijkers mogen deze voorraadactie niet uitvoeren")
+    return context
+
+
+def run_contract() -> None:
+    app = FastAPI()
+    calls: list[str] = []
+
+    @app.post("/api/articles/{article_id}/enrich")
+    def enrich_article_by_id(article_id: str):
+        calls.append(f"enrich:{article_id}")
+        return {"executed": True}
+
+    @app.patch("/api/articles/{article_id}/household-details")
+    def patch_article_household_details(article_id: str):
+        calls.append(f"patch:{article_id}")
+        return {"executed": True}
+
+    @app.get("/api/articles/{article_id}/household-details")
+    def get_article_household_details(article_id: str):
+        calls.append(f"read:{article_id}")
+        return {"executed": True}
+
+    @app.post("/api/products/identify")
+    def identify_article_product():
+        calls.append("identify")
+        return {"executed": True}
+
+    protected = discover_article_detail_write_routes(app)
+    assert ("POST", "/api/articles/{article_id}/enrich") in protected
+    assert ("PATCH", "/api/articles/{article_id}/household-details") in protected
+    assert ("GET", "/api/articles/{article_id}/household-details") not in protected
+    assert ("POST", "/api/products/identify") not in protected
+
+    module = SimpleNamespace(
+        app=app,
+        require_inventory_write_context=_require_write_context,
+    )
+    install_article_detail_write_guard(module)
+
+    with TestClient(app) as client:
+        missing_auth = client.post("/api/articles/article-a/enrich")
+        assert missing_auth.status_code == 401, missing_auth.text
+        assert calls == []
+
+        viewer_enrich = client.post(
+            "/api/articles/article-a/enrich",
+            headers={"Authorization": "Bearer viewer"},
+        )
+        assert viewer_enrich.status_code == 403, viewer_enrich.text
+        assert calls == []
+
+        viewer_patch = client.patch(
+            "/api/articles/article-a/household-details",
+            headers={"Authorization": "Bearer viewer"},
+        )
+        assert viewer_patch.status_code == 403, viewer_patch.text
+        assert calls == []
+
+        writer_enrich = client.post(
+            "/api/articles/article-a/enrich",
+            headers={"Authorization": "Bearer writer"},
+        )
+        assert writer_enrich.status_code == 200, writer_enrich.text
+        assert calls == ["enrich:article-a"]
+
+        writer_patch = client.patch(
+            "/api/articles/article-a/household-details",
+            headers={"Authorization": "Bearer writer"},
+        )
+        assert writer_patch.status_code == 200, writer_patch.text
+        assert calls == ["enrich:article-a", "patch:article-a"]
+
+        viewer_read = client.get(
+            "/api/articles/article-a/household-details",
+            headers={"Authorization": "Bearer viewer"},
+        )
+        assert viewer_read.status_code == 200, viewer_read.text
+        assert calls[-1] == "read:article-a"
+
+        unrelated = client.post("/api/products/identify")
+        assert unrelated.status_code == 200, unrelated.text
+        assert calls[-1] == "identify"
+
+    print("ARTICLE_DETAIL_WRITE_GUARD_GREEN")
+
+
+if __name__ == "__main__":
+    run_contract()


### PR DESCRIPTION
## Doel
Voorkomen dat kijkers via artikel-ID-adapters productverrijking of artikeldetailmutaties uitvoeren.

## Gewijzigd
- centrale write guard toegevoegd die muterende routes dynamisch selecteert op endpointfunctie;
- `enrich_article_by_id` en `patch_article_household_details` vereisen inventory-schrijfrecht;
- route-aliases blijven automatisch afgedekt doordat de guard de FastAPI-router inspecteert;
- bestaande actieve huishoudcontext blijft de objectselectie bepalen;
- installatie gekoppeld aan de bestaande productverrijkingsguard;
- gerichte HTTP-contracttest en CI-workflow toegevoegd.

## Acceptatie
- ontbrekende autorisatie geeft 401;
- kijker krijgt 403 vóór endpointuitvoering;
- schrijver kan eigen artikelverrijking en detailwijziging uitvoeren;
- veilige leesroute blijft voor kijkers beschikbaar;
- `/api/products/identify` en andere productroutes worden niet geraakt;
- archiveren en verwijderen blijven onder hun bestaande admincontrole;
- alle bestaande regressiegates blijven groen.

## Niet gewijzigd
- artikel- of enrichmentalgoritme;
- productbronadapters;
- frontend;
- `/api/receipts/share-target`.