### PR TITLE
M2C2n WP-1: generate reproducible FastAPI route catalog

### DIFF
--- a/.github/workflows/m2c2n-route-catalog.yml
+++ b/.github/workflows/m2c2n-route-catalog.yml
@@ -1,0 +1,62 @@
+name: M2C2n route catalog
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  generate-route-catalog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Controleer Docker-versie
+        run: docker --version
+
+      - name: Controleer Docker Compose-versie
+        run: docker compose version
+
+      - name: Bouw backend-image
+        run: docker compose build backend
+
+      - name: Genereer runtime-routecatalogus
+        run: |
+          mkdir -p route-catalog-output
+          docker compose run --rm --no-deps \
+            -v "$PWD/route-catalog-output:/tmp/m2c2n-route-catalog" \
+            backend \
+            python -m app.testing.route_catalog \
+              --output-dir /tmp/m2c2n-route-catalog \
+            | tee route-catalog.log
+          grep -F 'M2C2N_ROUTE_CATALOG_GREEN' route-catalog.log
+
+      - name: Controleer gegenereerde bestanden
+        run: |
+          test -s route-catalog-output/M2C2N-ROUTE-CATALOG.json
+          test -s route-catalog-output/M2C2N-ROUTE-CATALOG.md
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path('route-catalog-output/M2C2N-ROUTE-CATALOG.json').read_text(encoding='utf-8'))
+          summary = payload['summary']
+          assert summary['route_registrations'] > 0
+          assert summary['unique_method_paths'] > 0
+          assert summary['by_access'].get('mutation', 0) > 0
+          assert all(item['method'] and item['path'] and item['endpoint'] and item['module'] for item in payload['routes'])
+          print(json.dumps(summary, ensure_ascii=False, sort_keys=True))
+          PY
+
+      - name: Publiceer routecatalogus
+        uses: actions/upload-artifact@v4
+        with:
+          name: m2c2n-route-catalog
+          path: |
+            route-catalog-output/M2C2N-ROUTE-CATALOG.json
+            route-catalog-output/M2C2N-ROUTE-CATALOG.md
+            route-catalog.log
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/m2c2n-route-catalog.yml
+++ b/.github/workflows/m2c2n-route-catalog.yml
@@ -33,21 +33,56 @@ jobs:
             | tee route-catalog.log
           grep -F 'M2C2N_ROUTE_CATALOG_GREEN' route-catalog.log
 
-      - name: Controleer gegenereerde bestanden
+      - name: Controleer catalogus en vastgelegde baseline
         run: |
           test -s route-catalog-output/M2C2N-ROUTE-CATALOG.json
           test -s route-catalog-output/M2C2N-ROUTE-CATALOG.md
+          test -s docs/quality/M2C2N-ROUTE-CATALOG-BASELINE.json
           python - <<'PY'
+          import hashlib
           import json
           from pathlib import Path
 
           payload = json.loads(Path('route-catalog-output/M2C2N-ROUTE-CATALOG.json').read_text(encoding='utf-8'))
+          baseline = json.loads(Path('docs/quality/M2C2N-ROUTE-CATALOG-BASELINE.json').read_text(encoding='utf-8'))
           summary = payload['summary']
+
           assert summary['route_registrations'] > 0
           assert summary['unique_method_paths'] > 0
           assert summary['by_access'].get('mutation', 0) > 0
           assert all(item['method'] and item['path'] and item['endpoint'] and item['module'] for item in payload['routes'])
-          print(json.dumps(summary, ensure_ascii=False, sort_keys=True))
+
+          identity = [
+              {key: item[key] for key in ('method', 'path', 'endpoint', 'module', 'surface', 'access')}
+              for item in payload['routes']
+          ]
+          fingerprint = hashlib.sha256(
+              json.dumps(identity, ensure_ascii=False, sort_keys=True, separators=(',', ':')).encode('utf-8')
+          ).hexdigest()
+
+          testing_mutations = [
+              f"{item['method']} {item['path']} :: {item['module']}.{item['endpoint']}"
+              for item in payload['routes']
+              if item['surface'] == 'testing' and item['access'] == 'mutation'
+          ]
+          admin_mutations = [
+              f"{item['method']} {item['path']} :: {item['module']}.{item['endpoint']}"
+              for item in payload['routes']
+              if item['surface'] == 'admin' and item['access'] == 'mutation'
+          ]
+          dev_routes = [
+              f"{item['method']} {item['path']} :: {item['module']}.{item['endpoint']}"
+              for item in payload['routes']
+              if item['surface'] == 'dev'
+          ]
+
+          assert summary == baseline['summary'], (summary, baseline['summary'])
+          assert fingerprint == baseline['route_fingerprint_sha256'], (fingerprint, baseline['route_fingerprint_sha256'])
+          assert testing_mutations == baseline['testing_mutations']
+          assert admin_mutations == baseline['admin_mutations']
+          assert dev_routes == baseline['dev_routes']
+
+          print(json.dumps({'summary': summary, 'route_fingerprint_sha256': fingerprint}, ensure_ascii=False, sort_keys=True))
           PY
 
       - name: Publiceer routecatalogus
@@ -58,5 +93,6 @@ jobs:
             route-catalog-output/M2C2N-ROUTE-CATALOG.json
             route-catalog-output/M2C2N-ROUTE-CATALOG.md
             route-catalog.log
+            docs/quality/M2C2N-ROUTE-CATALOG-BASELINE.json
           if-no-files-found: error
           retention-days: 30

--- a/backend/app/testing/route_catalog.py
+++ b/backend/app/testing/route_catalog.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import argparse
+import inspect
+import json
+import time
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+from fastapi.routing import APIRoute
+
+READ_METHODS = {"GET", "HEAD", "OPTIONS"}
+IGNORED_PATHS = {"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"}
+
+
+def classify_surface(path: str) -> str:
+    if path.startswith("/api/testing/"):
+        return "testing"
+    if path.startswith("/api/admin/"):
+        return "admin"
+    if path.startswith("/api/dev/"):
+        return "dev"
+    return "production"
+
+
+def classify_access(method: str) -> str:
+    return "read" if method.upper() in READ_METHODS else "mutation"
+
+
+def endpoint_source(endpoint: Any) -> tuple[str, str, str | None]:
+    module = str(getattr(endpoint, "__module__", "") or "")
+    name = str(getattr(endpoint, "__qualname__", None) or getattr(endpoint, "__name__", "") or "")
+    source_file = inspect.getsourcefile(endpoint) or inspect.getfile(endpoint)
+    normalized_source = str(Path(source_file).resolve()) if source_file else None
+    return module, name, normalized_source
+
+
+def route_signature(routes: Iterable[Any]) -> tuple[tuple[str, str, str], ...]:
+    signature: list[tuple[str, str, str]] = []
+    for route in routes:
+        if not isinstance(route, APIRoute):
+            continue
+        endpoint = getattr(route, "endpoint", None)
+        endpoint_name = str(getattr(endpoint, "__qualname__", None) or getattr(endpoint, "__name__", "") or "")
+        for method in sorted(route.methods or []):
+            signature.append((method.upper(), str(route.path), endpoint_name))
+    return tuple(sorted(signature))
+
+
+def wait_for_stable_routes(app: Any, *, timeout_seconds: float = 20.0, stable_polls: int = 5, interval_seconds: float = 0.25) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    previous: tuple[tuple[str, str, str], ...] | None = None
+    unchanged = 0
+    while time.monotonic() < deadline:
+        current = route_signature(app.routes)
+        if current == previous and current:
+            unchanged += 1
+            if unchanged >= stable_polls:
+                return
+        else:
+            previous = current
+            unchanged = 0
+        time.sleep(interval_seconds)
+    raise RuntimeError("FastAPI-routeset werd niet tijdig stabiel")
+
+
+def build_catalog(app: Any) -> dict[str, Any]:
+    entries: list[dict[str, Any]] = []
+    for route_index, route in enumerate(app.routes):
+        if not isinstance(route, APIRoute):
+            continue
+        path = str(route.path)
+        if path in IGNORED_PATHS:
+            continue
+        endpoint = getattr(route, "endpoint", None)
+        module, endpoint_name, source_file = endpoint_source(endpoint)
+        for method in sorted(route.methods or []):
+            normalized_method = method.upper()
+            entries.append(
+                {
+                    "method": normalized_method,
+                    "path": path,
+                    "endpoint": endpoint_name,
+                    "module": module,
+                    "source_file": source_file,
+                    "surface": classify_surface(path),
+                    "access": classify_access(normalized_method),
+                    "route_index": route_index,
+                    "name": str(getattr(route, "name", "") or ""),
+                }
+            )
+
+    entries.sort(key=lambda item: (item["path"], item["method"], item["module"], item["endpoint"], item["route_index"]))
+
+    method_path_routes: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for entry in entries:
+        method_path_routes[(entry["method"], entry["path"])].append(entry)
+
+    duplicates = [
+        {
+            "method": method,
+            "path": path,
+            "registrations": [
+                {
+                    "module": item["module"],
+                    "endpoint": item["endpoint"],
+                    "route_index": item["route_index"],
+                }
+                for item in registrations
+            ],
+        }
+        for (method, path), registrations in sorted(method_path_routes.items())
+        if len(registrations) > 1
+    ]
+
+    summary = {
+        "route_registrations": len(entries),
+        "unique_method_paths": len(method_path_routes),
+        "duplicates": len(duplicates),
+        "by_surface": dict(sorted(Counter(item["surface"] for item in entries).items())),
+        "by_access": dict(sorted(Counter(item["access"] for item in entries).items())),
+        "mutation_by_surface": dict(
+            sorted(Counter(item["surface"] for item in entries if item["access"] == "mutation").items())
+        ),
+    }
+    return {"summary": summary, "duplicates": duplicates, "routes": entries}
+
+
+def markdown_table(catalog: dict[str, Any]) -> str:
+    summary = catalog["summary"]
+    lines = [
+        "# M2C2n FastAPI-routecatalogus",
+        "",
+        "> Gegenereerd uit de werkelijk geregistreerde `app.routes`; dit bestand niet handmatig onderhouden.",
+        "",
+        "## Samenvatting",
+        "",
+        f"- Routeregistraties: **{summary['route_registrations']}**",
+        f"- Unieke methode-padcombinaties: **{summary['unique_method_paths']}**",
+        f"- Dubbele methode-padregistraties: **{summary['duplicates']}**",
+        f"- Leesregistraties: **{summary['by_access'].get('read', 0)}**",
+        f"- Mutatieregistraties: **{summary['by_access'].get('mutation', 0)}**",
+        "",
+        "### Registraties per oppervlak",
+        "",
+    ]
+    for surface, count in summary["by_surface"].items():
+        mutation_count = summary["mutation_by_surface"].get(surface, 0)
+        lines.append(f"- `{surface}`: **{count}** totaal, **{mutation_count}** muterend")
+
+    lines.extend(["", "## Routes", "", "| Methode | Pad | Soort | Oppervlak | Endpoint | Module |", "|---|---|---|---|---|---|"])
+    for item in catalog["routes"]:
+        values = [
+            item["method"],
+            f"`{item['path']}`",
+            item["access"],
+            item["surface"],
+            f"`{item['endpoint']}`",
+            f"`{item['module']}`",
+        ]
+        lines.append("| " + " | ".join(value.replace("|", "\\|") for value in values) + " |")
+
+    lines.extend(["", "## Dubbele methode-padregistraties", ""])
+    if not catalog["duplicates"]:
+        lines.append("Geen dubbele methode-padregistraties gevonden.")
+    else:
+        for duplicate in catalog["duplicates"]:
+            lines.append(f"### `{duplicate['method']} {duplicate['path']}`")
+            lines.append("")
+            for registration in duplicate["registrations"]:
+                lines.append(
+                    f"- `{registration['module']}.{registration['endpoint']}` (route-index {registration['route_index']})"
+                )
+            lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_catalog(output_dir: Path, catalog: dict[str, Any]) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "M2C2N-ROUTE-CATALOG.json").write_text(
+        json.dumps(catalog, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "M2C2N-ROUTE-CATALOG.md").write_text(markdown_table(catalog), encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Genereer de M2C2n FastAPI-routecatalogus")
+    parser.add_argument("--output-dir", default="/tmp/m2c2n-route-catalog")
+    parser.add_argument("--fail-on-duplicates", action="store_true")
+    args = parser.parse_args()
+
+    from app.main import app
+
+    wait_for_stable_routes(app)
+    catalog = build_catalog(app)
+    write_catalog(Path(args.output_dir), catalog)
+
+    summary = catalog["summary"]
+    print(
+        "M2C2N_ROUTE_CATALOG_GREEN "
+        f"registrations={summary['route_registrations']} "
+        f"unique_method_paths={summary['unique_method_paths']} "
+        f"duplicates={summary['duplicates']} "
+        f"mutations={summary['by_access'].get('mutation', 0)}"
+    )
+    if args.fail_on_duplicates and catalog["duplicates"]:
+        raise SystemExit("Dubbele methode-padregistraties gevonden")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/quality/M2C2N-CLOSURE-MATRIX.md
+++ b/docs/quality/M2C2N-CLOSURE-MATRIX.md
@@ -1,7 +1,7 @@
 # M2C2n afsluitmatrix
 
 Statusdatum: 2026-07-22  
-Basiscommit: `01fce498339b100cdca075c24b96422b1bc81af3`
+Basiscommit: `b430e9cb47d4a1d4e1226992e432ce3a78722b93`
 
 ## Doel
 
@@ -81,6 +81,13 @@ M2C2n bestaat vanaf dit document nog uit maximaal de volgende werkpakketten, in 
    Werk alle matrixrijen bij naar GEREED of DEFERRED, voeg bewijskoppelingen toe en voer de volledige releasekwaliteitketen uit.
 
 Er worden geen nieuwe losse beveiligings-PR’s buiten deze werkpakketten gestart.
+
+## Werkpakketstatus
+
+| Werkpakket | Status | Bewijs/uitvoer |
+|---|---|---|
+| WP-1 — Routecatalogus genereren | IN UITVOERING | Runtimegenerator en Docker-CI worden voorbereid in de WP-1-PR |
+| WP-2 t/m WP-7 | NIET GESTART | Wachten op gecontroleerde WP-1-uitvoer |
 
 ## PR-regels vanaf nu
 

--- a/docs/quality/M2C2N-CLOSURE-MATRIX.md
+++ b/docs/quality/M2C2N-CLOSURE-MATRIX.md
@@ -36,24 +36,24 @@ Een domein krijgt pas status **GEREED** wanneer:
 | M2C2N-04 | Uitpakken: target-location | Batch- en regelhuishouden server-side afgeleid | Schrijfrecht voor mutaties | PR #164 | GEREED | Geen |
 | M2C2N-05 | Uitpakken: batch/regelobjecten | Objectguard voor batch- en regelroutes | Muterende methoden vereisen schrijfrecht | PR #165 en #174 | GEREED | Geen |
 | M2C2N-06 | Receipt share import | Geauthenticeerde import aan actieve huishoudcontext gebonden | Schrijfrecht afgedwongen | PR #166 | GEREED | Geen |
-| M2C2N-07 | Receipt admin- en onderhoudsroutes | Geen vrije huishoudkeuze voor beheeracties | Platform-admin vereist | PR #167 en latere guarduitbreidingen | CONTROLE | Guard consolideren en volledige beschermde-routelijst valideren |
+| M2C2N-07 | Receipt admin- en onderhoudsroutes | Geen vrije huishoudkeuze voor beheeracties | Platform-admin vereist | PR #167 en latere guarduitbreidingen; WP-1-routebaseline | CONTROLE | WP-2: alle 10 adminmutaties valideren en guard consolideren |
 | M2C2N-08 | Gmail OAuth receiptbron | State en bron aan één huishouden gebonden | Geautoriseerde huishoudbeheerder | PR #168 | GEREED | Geen |
 | M2C2N-09 | Resend inbound webhook en bron | Inbound bron server-side aan huishouden gebonden | Webhookcontract en broncontrole | PR #169–#171 | GEREED | Geen |
 | M2C2N-10 | Purchase-import live alias backfill | Platformbeheeractie; geen vrije gebruikersscope | Platform-admin vereist | PR #172 | GEREED | Geen |
 | M2C2N-11 | Receipt-exportfixtures | Vaste regressiescope | Platform-admin vereist | PR #173 | GEREED | Geen |
 | M2C2N-12 | Product enrichment | Actief huishouden uit gevalideerde context | Inventory-schrijfrecht | PR #175 | GEREED | Geen |
 | M2C2N-13 | Artikel-ID-verrijking en detailmutaties | Artikel binnen actieve huishoudcontext opgelost | Inventory-schrijfrecht | PR #176 | GEREED | Geen |
-| M2C2N-14 | Externe productkoppeling via inventory/artikel | Inventory en household article worden binnen actief huishouden gezocht | Admin/lid, kijker geblokkeerd | Codecontrole op `update_inventory_external_product_link` | CONTROLE | Gericht HTTP-contract toevoegen of bestaand bewijs aanwijzen |
+| M2C2N-14 | Externe productkoppeling via inventory/artikel | Inventory en household article worden binnen actief huishouden gezocht | Admin/lid, kijker geblokkeerd | Codecontrole; WP-1-routebaseline | CONTROLE | WP-3: gericht HTTP-contract toevoegen of bestaand bewijs aanwijzen |
 | M2C2N-15 | Testing: store-locationdiagnostiek | Vrij `household_id` niet meer zonder beheerrecht uitvoerbaar | Platform-admin vereist | PR #177 | GEREED | Geen |
 | M2C2N-16 | Testing: almost-out en inventoryfixtures | Vaste regressiescope | Platform-admin vereist | PR #178 | GEREED | Geen |
-| M2C2N-17 | Overige `/api/testing/*`-routes | Nog niet volledig gecatalogiseerd | Nog niet volledig gecatalogiseerd | Alleen deelroutes bewezen | OPEN | Complete methode-padlijst maken; muterende routes classificeren en testen |
-| M2C2N-18 | Product- en artikelroutes buiten reeds beschermde ingangen | Deels bewezen | Deels bewezen | PR #175/#176 plus codecontrole | CONTROLE | Volledige routecatalogus en restcontract |
-| M2C2N-19 | Prognoses en AlmostOut-productieroutes | Onbekend tot complete routecontrole | Onbekend | Geen afsluitend domeincontract | OPEN | Alle lees-, instelling- en mutatieroutes inventariseren |
-| M2C2N-20 | Inkoop, handmatige aankopen en importinstellingen | Deels via actieve context; nog niet volledig bewezen | Deels schrijfrecht | Purchase-importguards aanwezig | OPEN | Productieroutes buiten batch/regelguard volledig controleren |
-| M2C2N-21 | Meldingen en notificatieconfiguratie | Nog niet volledig geïnventariseerd | Nog niet volledig geïnventariseerd | Geen afsluitend domeincontract | OPEN | Routecatalogus, huishoudscope en mutatierechten bewijzen |
-| M2C2N-22 | Stille fallbacks `"1"` en `"demo-household"` | Enkele fallbacks volgen na geldige context; volledige set onbekend | Niet van toepassing | Gedeeltelijke codecontrole | OPEN | Alle productievoorkomens classificeren: bootstrap, test, onbereikbaar of verwijderen |
+| M2C2N-17 | Overige `/api/testing/*`-routes | 40 registraties reproduceerbaar gecatalogiseerd | 17 mutaties; rolgrens nog niet volledig gevalideerd | WP-1-routebaseline | OPEN | WP-2: alle 17 testingmutaties classificeren en testen; 2 dubbele GET-registraties oplossen |
+| M2C2N-18 | Product- en artikelroutes buiten reeds beschermde ingangen | Volledige routescope nu reproduceerbaar beschikbaar | Deels bewezen | PR #175/#176 en WP-1-routebaseline | CONTROLE | WP-3: domeinfilter en restcontract uitvoeren |
+| M2C2N-19 | Prognoses en AlmostOut-productieroutes | Volledige routescope nu reproduceerbaar beschikbaar | Nog niet domeinbreed gevalideerd | WP-1-routebaseline | OPEN | WP-4: relevante routes uit baseline selecteren en controleren |
+| M2C2N-20 | Inkoop, handmatige aankopen en importinstellingen | Volledige routescope nu reproduceerbaar beschikbaar | Deels schrijfrecht bewezen | Purchase-importguards en WP-1-routebaseline | OPEN | WP-4: productieroutes buiten batch/regelguard controleren |
+| M2C2N-21 | Meldingen en notificatieconfiguratie | Volledige routescope nu reproduceerbaar beschikbaar | Nog niet domeinbreed gevalideerd | WP-1-routebaseline | OPEN | WP-5: relevante routes uit baseline selecteren en controleren |
+| M2C2N-22 | Stille fallbacks `"1"` en `"demo-household"` | Routecatalogus beschikbaar; codevoorkomens nog niet geclassificeerd | Niet van toepassing | Gedeeltelijke codecontrole en WP-1-routebaseline | OPEN | WP-6: alle productievoorkomens classificeren of verwijderen |
 | M2C2N-23 | `/api/receipts/share-target` | Huidige vrije `household_id` is niet eindontwerp | Toekomstig signed-tokencontract | Ontwerpbesluit vastgelegd, geen implementatie | DEFERRED | Later: kortlevend signed token, aan exact één huishouden gebonden |
-| M2C2N-24 | Platform-admin-routeguard | Functioneel actief | Platform-admin | Contracttest aanwezig | CONTROLE | Hernoemen van receipt-specifieke guard naar algemene guard en registratie centraliseren |
+| M2C2N-24 | Platform-admin-routeguard | Functioneel actief | Platform-admin | Contracttest en WP-1-routebaseline | CONTROLE | WP-2: hernoemen naar algemene guard en registratie centraliseren |
 
 ## Eindige restlijst
 
@@ -82,12 +82,34 @@ M2C2n bestaat vanaf dit document nog uit maximaal de volgende werkpakketten, in 
 
 Er worden geen nieuwe losse beveiligings-PR’s buiten deze werkpakketten gestart.
 
+## WP-1-uitvoer
+
+De runtimegenerator leest de werkelijk geregistreerde `app.routes` nadat de asynchrone route-installatie stabiel is. De vaste baseline staat in `docs/quality/M2C2N-ROUTE-CATALOG-BASELINE.json` en wordt bij iedere PR opnieuw gecontroleerd.
+
+| Kengetal | Waarde |
+|---|---:|
+| Routeregistraties | 196 |
+| Unieke methode-padcombinaties | 194 |
+| Leesregistraties | 87 |
+| Mutatieregistraties | 109 |
+| Production | 140 totaal / 81 muterend |
+| Testing | 40 totaal / 17 muterend |
+| Admin | 14 totaal / 10 muterend |
+| Dev | 2 totaal / 1 muterend |
+| Dubbele methode-padregistraties | 2 |
+
+De twee dubbele registraties zijn:
+
+- `GET /api/testing/receipt-parser-diagnosis`;
+- `GET /api/testing/receipt-parser-diagnosis/download`.
+
 ## Werkpakketstatus
 
 | Werkpakket | Status | Bewijs/uitvoer |
 |---|---|---|
-| WP-1 — Routecatalogus genereren | IN UITVOERING | Runtimegenerator en Docker-CI worden voorbereid in de WP-1-PR |
-| WP-2 t/m WP-7 | NIET GESTART | Wachten op gecontroleerde WP-1-uitvoer |
+| WP-1 — Routecatalogus genereren | GEREED | Runtimegenerator, Docker-CI, artifact en vaste fingerprintbaseline |
+| WP-2 — Testing en platform-admin consolideren | VOLGENDE | Scope: 17 testingmutaties, 10 adminmutaties en 2 dubbele GET-registraties |
+| WP-3 t/m WP-7 | NIET GESTART | Wachten op afronding WP-2 |
 
 ## PR-regels vanaf nu
 

--- a/docs/quality/M2C2N-ROUTE-CATALOG-BASELINE.json
+++ b/docs/quality/M2C2N-ROUTE-CATALOG-BASELINE.json
@@ -1,0 +1,78 @@
+{
+  "catalog_version": 1,
+  "route_fingerprint_sha256": "71fd519a694963ecf99ce867aed032ff126db55256be19e8a181430f765cb464",
+  "summary": {
+    "route_registrations": 196,
+    "unique_method_paths": 194,
+    "duplicates": 2,
+    "by_surface": {
+      "admin": 14,
+      "dev": 2,
+      "production": 140,
+      "testing": 40
+    },
+    "by_access": {
+      "mutation": 109,
+      "read": 87
+    },
+    "mutation_by_surface": {
+      "admin": 10,
+      "dev": 1,
+      "production": 81,
+      "testing": 17
+    }
+  },
+  "duplicates": [
+    {
+      "method": "GET",
+      "path": "/api/testing/receipt-parser-diagnosis",
+      "registrations": [
+        "app.api.receipt_diagnosis_routes.receipt_parser_diagnosis",
+        "app.api.routes.receipt_parser_diagnosis.get_receipt_parser_diagnosis"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/api/testing/receipt-parser-diagnosis/download",
+      "registrations": [
+        "app.api.receipt_diagnosis_routes.receipt_parser_diagnosis_download",
+        "app.api.routes.receipt_parser_diagnosis.download_receipt_parser_diagnosis"
+      ]
+    }
+  ],
+  "testing_mutations": [
+    "POST /api/testing/diagnostics/store-location-options :: app.main.run_store_location_diagnostic",
+    "POST /api/testing/fixtures/browser-regression/reset :: app.main.reset_browser_regression_fixture",
+    "POST /api/testing/fixtures/cleanup :: app.main.cleanup_regression_fixture_state_endpoint",
+    "POST /api/testing/fixtures/inventory/ensure :: app.main.ensure_regression_inventory_fixture_endpoint",
+    "POST /api/testing/fixtures/receipt-export/generate :: app.main.generate_receipt_export_fixture",
+    "POST /api/testing/fixtures/receipt-layer1/generate :: app.main.generate_layer1_receipt_fixture",
+    "POST /api/testing/fixtures/receipts/seed-kassa :: app.main.seed_regression_kassa_receipts",
+    "POST /api/testing/regression/all/run :: app.api.dev_test_routes.create_dev_test_router.<locals>.run_regression_tests",
+    "POST /api/testing/regression/almost-out-prediction :: app.main.run_almost_out_prediction_regression_endpoint",
+    "POST /api/testing/regression/almost-out-self-test :: app.main.run_almost_out_backend_self_test_endpoint",
+    "POST /api/testing/regression/layer1/run :: app.api.dev_test_routes.create_dev_test_router.<locals>.run_layer1_tests",
+    "POST /api/testing/regression/layer2/run :: app.api.dev_test_routes.create_dev_test_router.<locals>.run_layer2_tests",
+    "POST /api/testing/regression/layer3/run :: app.api.dev_test_routes.create_dev_test_router.<locals>.run_layer3_tests",
+    "POST /api/testing/regression/parsing-fixtures/run :: app.api.dev_test_routes.create_dev_test_router.<locals>.run_parsing_fixture_tests",
+    "POST /api/testing/regression/parsing-raw/run :: app.api.dev_test_routes.create_dev_test_router.<locals>.run_parsing_raw_tests",
+    "POST /api/testing/regression/smoke/run :: app.api.dev_test_routes.create_dev_test_router.<locals>.run_smoke_tests",
+    "POST /api/testing/reports/complete :: app.api.dev_test_routes.create_dev_test_router.<locals>.complete_test_report"
+  ],
+  "admin_mutations": [
+    "POST /api/admin/backfill-purchase-import-live-aliases :: app.main.run_purchase_import_live_alias_backfill",
+    "POST /api/admin/diagnose-receipt-status-baseline :: app.main.run_receipt_status_baseline_diagnosis",
+    "POST /api/admin/external-relations/batch/decision :: app.api.system_routes.admin_external_relation_batch_decision",
+    "POST /api/admin/inventory/groups/ensure-schema :: app.api.product_inventory_group_routes.inventory_groups_ensure_schema",
+    "POST /api/admin/kassa-regression/run :: app.api.routes.kassa_regression_routes.start_kassa_receipt_regression",
+    "POST /api/admin/kassa-smoke/run :: app.api.routes.kassa_smoke_routes.start_kassa_smoke_check",
+    "POST /api/admin/product-groups/import-gpc-nl :: app.api.product_inventory_group_routes.admin_product_groups_import_gpc_nl",
+    "POST /api/admin/receipts/purge-archived :: app.main.purge_archived_receipts",
+    "POST /api/admin/recompute-receipt-statuses :: app.main.run_receipt_status_backfill",
+    "POST /api/admin/validate-receipt-status-baseline :: app.main.run_receipt_status_baseline_validation"
+  ],
+  "dev_routes": [
+    "GET /api/dev/inventory-preview :: app.main.dev_inventory_preview",
+    "PUT /api/dev/inventory/{inventory_id} :: app.main.dev_update_inventory"
+  ]
+}


### PR DESCRIPTION
## Werkpakket
WP-1 — Routecatalogus genereren.

## Geraakte matrix-ID's
M2C2N-07, M2C2N-14, M2C2N-17, M2C2N-18, M2C2N-19, M2C2N-20, M2C2N-21, M2C2N-22 en M2C2N-24 worden nog niet gesloten; deze PR levert de reproduceerbare routescope waarmee de vervolgpakketten worden begrensd.

## Complete routescope
De generator leest alle werkelijk geregistreerde FastAPI `APIRoute`-objecten uit `app.routes` nadat de asynchrone route-installatie stabiel is geworden. Per registratie worden methode, pad, endpointfunctie, bronmodule, bronbestand, oppervlak en lees/mutatie vastgelegd.

## Gewijzigd
- runtimegenerator `backend/app/testing/route_catalog.py`;
- Docker-workflow `.github/workflows/m2c2n-route-catalog.yml`;
- afsluitmatrix bijgewerkt naar WP-1 IN UITVOERING;
- gegenereerde Markdown- en JSON-catalogus worden als CI-artifact gepubliceerd.

## Contract
- routeset moet stabiel worden;
- catalogus moet niet leeg zijn;
- iedere route bevat methode, pad, endpoint en module;
- muterende routes moeten aanwezig en geclassificeerd zijn;
- dubbele methode-padregistraties worden expliciet gerapporteerd;
- uitvoer is deterministisch gesorteerd.

## Niet gewijzigd
- geen productie-endpoint;
- geen autorisatie- of huishoudlogica;
- geen frontend;
- `/api/receipts/share-target` blijft DEFERRED.

## Vervolg binnen deze PR
Na de eerste groene CI-run wordt het echte runtime-artifact beoordeeld en als vaste WP-1-uitvoer aan de repository en matrix toegevoegd. Daarna volgt pas het PO-mergebesluit.