### PR TITLE
M2C2n WP-2: consolidate testing and platform admin guard

### DIFF
--- a/.github/workflows/m2c2n-route-catalog.yml
+++ b/.github/workflows/m2c2n-route-catalog.yml
@@ -86,6 +86,7 @@ jobs:
           PY
 
       - name: Publiceer routecatalogus
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: m2c2n-route-catalog

--- a/.github/workflows/receipt-admin-household-guard.yml
+++ b/.github/workflows/receipt-admin-household-guard.yml
@@ -1,4 +1,4 @@
-name: Receipt admin household guard
+name: Platform admin route guard
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  validate-receipt-admin-household-guard:
+  validate-platform-admin-route-guard:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -24,16 +24,16 @@ jobs:
             fastapi==0.115.0 \
             httpx==0.27.2
 
-      - name: Compileer gewijzigde modules
+      - name: Compileer platform-adminguard en contract
         run: |
           python -m py_compile \
-            backend/app/__init__.py \
+            backend/app/services/platform_admin_route_guard.py \
             backend/app/services/receipt_admin_household_guard.py \
             backend/app/testing/receipt_admin_household_guard_contract.py
 
-      - name: Voer HTTP-receiptbeheercontract uit
+      - name: Voer volledig platform-admincontract uit
         env:
           PYTHONPATH: backend
         run: |
-          python -m app.testing.receipt_admin_household_guard_contract | tee receipt-admin-household-guard.log
-          grep -F 'RECEIPT_ADMIN_HOUSEHOLD_GUARD_GREEN' receipt-admin-household-guard.log
+          python -m app.testing.receipt_admin_household_guard_contract | tee platform-admin-route-guard.log
+          grep -F 'PLATFORM_ADMIN_ROUTE_GUARD_GREEN' platform-admin-route-guard.log

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -16,7 +16,6 @@ from fastapi import APIRouter
 from app.api.article_group_routes import router as article_group_router
 from app.api.routes.debug import router as debug_router
 from app.api.routes.receipt_db_snapshot import router as receipt_db_snapshot_router
-from app.api.routes.receipt_parser_diagnosis import router as receipt_parser_diagnosis_router
 from app.api.routes.kassa_regression_routes import router as kassa_regression_router
 from app.api.routes.kassa_smoke_routes import router as kassa_smoke_router
 from app.services import receipt_parser_quality_patch
@@ -27,6 +26,5 @@ api_router = APIRouter()
 api_router.include_router(article_group_router)
 api_router.include_router(debug_router)
 api_router.include_router(receipt_db_snapshot_router)
-api_router.include_router(receipt_parser_diagnosis_router)
 api_router.include_router(kassa_regression_router)
 api_router.include_router(kassa_smoke_router)

--- a/backend/app/services/platform_admin_route_guard.py
+++ b/backend/app/services/platform_admin_route_guard.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+import time
 from collections.abc import Callable
 
 from fastapi import HTTPException
@@ -74,12 +76,42 @@ def deduplicate_receipt_parser_diagnosis_routes(app) -> int:
     return removed
 
 
+def _deduplicate_late_route_registrations(app) -> None:
+    stable_rounds = 0
+    previous_signature: tuple[tuple[str, str], ...] | None = None
+    for _ in range(100):
+        deduplicate_receipt_parser_diagnosis_routes(app)
+        signature = tuple(
+            sorted(
+                (
+                    str(getattr(route, "path", "") or ""),
+                    str(getattr(getattr(route, "endpoint", None), "__module__", "") or ""),
+                )
+                for route in app.router.routes
+                if str(getattr(route, "path", "") or "") in _DIAGNOSIS_DUPLICATE_PATHS
+            )
+        )
+        if signature == previous_signature and len(signature) == len(_DIAGNOSIS_DUPLICATE_PATHS):
+            stable_rounds += 1
+            if stable_rounds >= 10:
+                return
+        else:
+            previous_signature = signature
+            stable_rounds = 0
+        time.sleep(0.1)
+
+
 def install_platform_admin_route_guard(main_module) -> None:
     app = main_module.app
     if getattr(app.state, "platform_admin_route_guard_installed", False):
         return
 
     deduplicate_receipt_parser_diagnosis_routes(app)
+    threading.Thread(
+        target=_deduplicate_late_route_registrations,
+        args=(app,),
+        daemon=True,
+    ).start()
 
     @app.middleware("http")
     async def platform_admin_route_guard(request, call_next):

--- a/backend/app/services/platform_admin_route_guard.py
+++ b/backend/app/services/platform_admin_route_guard.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import threading
-import time
 from collections.abc import Callable
 
 from fastapi import HTTPException
@@ -57,6 +55,13 @@ def authorize_platform_admin_request(
 
 
 def deduplicate_receipt_parser_diagnosis_routes(app) -> int:
+    """Defensive one-shot cleanup for legacy app assemblies.
+
+    The active source registration is now unique in ``app.api.router``. This
+    helper remains only for compatibility with older assemblies that may still
+    preload both diagnosis routers before the guard is installed.
+    """
+
     removed = 0
     next_routes = []
     preferred_seen: set[str] = set()
@@ -76,42 +81,12 @@ def deduplicate_receipt_parser_diagnosis_routes(app) -> int:
     return removed
 
 
-def _deduplicate_late_route_registrations(app) -> None:
-    stable_rounds = 0
-    previous_signature: tuple[tuple[str, str], ...] | None = None
-    for _ in range(100):
-        deduplicate_receipt_parser_diagnosis_routes(app)
-        signature = tuple(
-            sorted(
-                (
-                    str(getattr(route, "path", "") or ""),
-                    str(getattr(getattr(route, "endpoint", None), "__module__", "") or ""),
-                )
-                for route in app.router.routes
-                if str(getattr(route, "path", "") or "") in _DIAGNOSIS_DUPLICATE_PATHS
-            )
-        )
-        if signature == previous_signature and len(signature) == len(_DIAGNOSIS_DUPLICATE_PATHS):
-            stable_rounds += 1
-            if stable_rounds >= 10:
-                return
-        else:
-            previous_signature = signature
-            stable_rounds = 0
-        time.sleep(0.1)
-
-
 def install_platform_admin_route_guard(main_module) -> None:
     app = main_module.app
     if getattr(app.state, "platform_admin_route_guard_installed", False):
         return
 
     deduplicate_receipt_parser_diagnosis_routes(app)
-    threading.Thread(
-        target=_deduplicate_late_route_registrations,
-        args=(app,),
-        daemon=True,
-    ).start()
 
     @app.middleware("http")
     async def platform_admin_route_guard(request, call_next):

--- a/backend/app/services/platform_admin_route_guard.py
+++ b/backend/app/services/platform_admin_route_guard.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+
+PROTECTED_MUTATIONS = {
+    ("POST", "/api/testing/diagnostics/store-location-options"),
+    ("POST", "/api/testing/fixtures/browser-regression/reset"),
+    ("POST", "/api/testing/fixtures/cleanup"),
+    ("POST", "/api/testing/fixtures/inventory/ensure"),
+    ("POST", "/api/testing/fixtures/receipt-export/generate"),
+    ("POST", "/api/testing/fixtures/receipt-layer1/generate"),
+    ("POST", "/api/testing/fixtures/receipts/seed-kassa"),
+    ("POST", "/api/testing/regression/all/run"),
+    ("POST", "/api/testing/regression/almost-out-prediction"),
+    ("POST", "/api/testing/regression/almost-out-self-test"),
+    ("POST", "/api/testing/regression/layer1/run"),
+    ("POST", "/api/testing/regression/layer2/run"),
+    ("POST", "/api/testing/regression/layer3/run"),
+    ("POST", "/api/testing/regression/parsing-fixtures/run"),
+    ("POST", "/api/testing/regression/parsing-raw/run"),
+    ("POST", "/api/testing/regression/smoke/run"),
+    ("POST", "/api/testing/reports/complete"),
+    ("POST", "/api/admin/backfill-purchase-import-live-aliases"),
+    ("POST", "/api/admin/diagnose-receipt-status-baseline"),
+    ("POST", "/api/admin/external-relations/batch/decision"),
+    ("POST", "/api/admin/inventory/groups/ensure-schema"),
+    ("POST", "/api/admin/kassa-regression/run"),
+    ("POST", "/api/admin/kassa-smoke/run"),
+    ("POST", "/api/admin/product-groups/import-gpc-nl"),
+    ("POST", "/api/admin/receipts/purge-archived"),
+    ("POST", "/api/admin/recompute-receipt-statuses"),
+    ("POST", "/api/admin/validate-receipt-status-baseline"),
+}
+
+_DIAGNOSIS_DUPLICATE_PATHS = {
+    "/api/testing/receipt-parser-diagnosis",
+    "/api/testing/receipt-parser-diagnosis/download",
+}
+_PREFERRED_DIAGNOSIS_MODULE = "app.api.receipt_diagnosis_routes"
+
+
+def authorize_platform_admin_request(
+    method: str,
+    path: str,
+    authorization: str | None,
+    require_platform_admin_user: Callable[[str | None], object],
+) -> object | None:
+    request_key = (str(method or "").upper(), str(path or ""))
+    if request_key not in PROTECTED_MUTATIONS:
+        return None
+    return require_platform_admin_user(authorization)
+
+
+def deduplicate_receipt_parser_diagnosis_routes(app) -> int:
+    removed = 0
+    next_routes = []
+    preferred_seen: set[str] = set()
+    for route in app.router.routes:
+        path = str(getattr(route, "path", "") or "")
+        if path not in _DIAGNOSIS_DUPLICATE_PATHS:
+            next_routes.append(route)
+            continue
+        endpoint = getattr(route, "endpoint", None)
+        module = str(getattr(endpoint, "__module__", "") or "")
+        if module == _PREFERRED_DIAGNOSIS_MODULE and path not in preferred_seen:
+            preferred_seen.add(path)
+            next_routes.append(route)
+        else:
+            removed += 1
+    app.router.routes = next_routes
+    return removed
+
+
+def install_platform_admin_route_guard(main_module) -> None:
+    app = main_module.app
+    if getattr(app.state, "platform_admin_route_guard_installed", False):
+        return
+
+    deduplicate_receipt_parser_diagnosis_routes(app)
+
+    @app.middleware("http")
+    async def platform_admin_route_guard(request, call_next):
+        try:
+            authorize_platform_admin_request(
+                request.method,
+                request.url.path,
+                request.headers.get("authorization"),
+                main_module.require_platform_admin_user,
+            )
+        except HTTPException as exc:
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": exc.detail},
+                headers=exc.headers or None,
+            )
+        return await call_next(request)
+
+    app.state.platform_admin_route_guard_installed = True
+    app.state.receipt_admin_household_guard_installed = True

--- a/backend/app/services/receipt_admin_household_guard.py
+++ b/backend/app/services/receipt_admin_household_guard.py
@@ -1,56 +1,39 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+"""Compatibility shim for the former receipt-specific admin guard.
 
-from fastapi import HTTPException
-from fastapi.responses import JSONResponse
+New code must import :mod:`app.services.platform_admin_route_guard` directly.
+"""
 
-_PROTECTED_REQUESTS = {
-    ("POST", "/api/admin/backfill-purchase-import-live-aliases"),
-    ("POST", "/api/admin/recompute-receipt-statuses"),
-    ("POST", "/api/admin/validate-receipt-status-baseline"),
-    ("POST", "/api/admin/diagnose-receipt-status-baseline"),
-    ("POST", "/api/testing/fixtures/receipt-export/generate"),
-    ("GET", "/api/testing/fixtures/receipt-export/download"),
-    ("POST", "/api/testing/diagnostics/store-location-options"),
-    ("POST", "/api/testing/regression/almost-out-prediction"),
-    ("POST", "/api/testing/regression/almost-out-self-test"),
-    ("POST", "/api/testing/fixtures/inventory/ensure"),
-}
+from app.services.platform_admin_route_guard import (
+    PROTECTED_MUTATIONS,
+    authorize_platform_admin_request,
+    deduplicate_receipt_parser_diagnosis_routes,
+    install_platform_admin_route_guard,
+)
+
+_PROTECTED_REQUESTS = PROTECTED_MUTATIONS
 
 
-def authorize_receipt_admin_request(
-    method: str,
-    path: str,
-    authorization: str | None,
-    require_platform_admin_user: Callable[[str | None], object],
-) -> object | None:
-    request_key = (str(method or "").upper(), str(path or ""))
-    if request_key not in _PROTECTED_REQUESTS:
-        return None
-    return require_platform_admin_user(authorization)
+def authorize_receipt_admin_request(method, path, authorization, require_platform_admin_user):
+    return authorize_platform_admin_request(
+        method,
+        path,
+        authorization,
+        require_platform_admin_user,
+    )
 
 
 def install_receipt_admin_household_guard(main_module) -> None:
-    app = main_module.app
-    if getattr(app.state, "receipt_admin_household_guard_installed", False):
-        return
+    install_platform_admin_route_guard(main_module)
 
-    @app.middleware("http")
-    async def receipt_admin_household_guard(request, call_next):
-        try:
-            authorize_receipt_admin_request(
-                request.method,
-                request.url.path,
-                request.headers.get("authorization"),
-                main_module.require_platform_admin_user,
-            )
-        except HTTPException as exc:
-            return JSONResponse(
-                status_code=exc.status_code,
-                content={"detail": exc.detail},
-                headers=exc.headers or None,
-            )
-        return await call_next(request)
 
-    app.state.receipt_admin_household_guard_installed = True
+__all__ = [
+    "PROTECTED_MUTATIONS",
+    "_PROTECTED_REQUESTS",
+    "authorize_platform_admin_request",
+    "authorize_receipt_admin_request",
+    "deduplicate_receipt_parser_diagnosis_routes",
+    "install_platform_admin_route_guard",
+    "install_receipt_admin_household_guard",
+]

--- a/backend/app/testing/receipt_admin_household_guard_contract.py
+++ b/backend/app/testing/receipt_admin_household_guard_contract.py
@@ -2,16 +2,51 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from fastapi import FastAPI, HTTPException, Header
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
-from app.services.receipt_admin_household_guard import (
-    authorize_receipt_admin_request,
-    install_receipt_admin_household_guard,
+from app.services.platform_admin_route_guard import (
+    PROTECTED_MUTATIONS,
+    authorize_platform_admin_request,
+    deduplicate_receipt_parser_diagnosis_routes,
+    install_platform_admin_route_guard,
 )
+
+EXPECTED_PROTECTED_MUTATIONS = {
+    ("POST", "/api/testing/diagnostics/store-location-options"),
+    ("POST", "/api/testing/fixtures/browser-regression/reset"),
+    ("POST", "/api/testing/fixtures/cleanup"),
+    ("POST", "/api/testing/fixtures/inventory/ensure"),
+    ("POST", "/api/testing/fixtures/receipt-export/generate"),
+    ("POST", "/api/testing/fixtures/receipt-layer1/generate"),
+    ("POST", "/api/testing/fixtures/receipts/seed-kassa"),
+    ("POST", "/api/testing/regression/all/run"),
+    ("POST", "/api/testing/regression/almost-out-prediction"),
+    ("POST", "/api/testing/regression/almost-out-self-test"),
+    ("POST", "/api/testing/regression/layer1/run"),
+    ("POST", "/api/testing/regression/layer2/run"),
+    ("POST", "/api/testing/regression/layer3/run"),
+    ("POST", "/api/testing/regression/parsing-fixtures/run"),
+    ("POST", "/api/testing/regression/parsing-raw/run"),
+    ("POST", "/api/testing/regression/smoke/run"),
+    ("POST", "/api/testing/reports/complete"),
+    ("POST", "/api/admin/backfill-purchase-import-live-aliases"),
+    ("POST", "/api/admin/diagnose-receipt-status-baseline"),
+    ("POST", "/api/admin/external-relations/batch/decision"),
+    ("POST", "/api/admin/inventory/groups/ensure-schema"),
+    ("POST", "/api/admin/kassa-regression/run"),
+    ("POST", "/api/admin/kassa-smoke/run"),
+    ("POST", "/api/admin/product-groups/import-gpc-nl"),
+    ("POST", "/api/admin/receipts/purge-archived"),
+    ("POST", "/api/admin/recompute-receipt-statuses"),
+    ("POST", "/api/admin/validate-receipt-status-baseline"),
+}
 
 
 def run_contract() -> None:
+    assert PROTECTED_MUTATIONS == EXPECTED_PROTECTED_MUTATIONS
+    assert len(PROTECTED_MUTATIONS) == 27
+
     app = FastAPI()
     calls: list[str] = []
 
@@ -20,90 +55,74 @@ def run_contract() -> None:
             raise HTTPException(status_code=401, detail="Unauthorized")
         if authorization != "Bearer platform-admin":
             raise HTTPException(status_code=403, detail="Platformbeheerder vereist")
-        return {"email": "platform@example.test", "role": "platform_admin"}
+        return {"role": "platform_admin"}
 
-    install_receipt_admin_household_guard(
-        SimpleNamespace(app=app, require_platform_admin_user=require_platform_admin_user)
-    )
+    for method, path in sorted(PROTECTED_MUTATIONS):
+        marker = f"{method} {path}"
 
-    protected_routes = [
-        ("post", "/api/admin/backfill-purchase-import-live-aliases", "live-alias-backfill"),
-        ("post", "/api/admin/recompute-receipt-statuses", "recompute"),
-        ("post", "/api/admin/validate-receipt-status-baseline", "validate"),
-        ("post", "/api/admin/diagnose-receipt-status-baseline", "diagnose"),
-        ("post", "/api/testing/fixtures/receipt-export/generate", "fixture-generate"),
-        ("get", "/api/testing/fixtures/receipt-export/download", "fixture-download"),
-        ("post", "/api/testing/diagnostics/store-location-options", "store-location-diagnostic"),
-        ("post", "/api/testing/regression/almost-out-prediction", "almost-out-prediction"),
-        ("post", "/api/testing/regression/almost-out-self-test", "almost-out-self-test"),
-        ("post", "/api/testing/fixtures/inventory/ensure", "inventory-fixture-ensure"),
-    ]
-
-    def register(method: str, path: str, marker: str) -> None:
-        def endpoint():
+        def endpoint(marker=marker):
             calls.append(marker)
             return {"status": "ok", "marker": marker}
 
-        app.add_api_route(path, endpoint, methods=[method.upper()])
+        app.add_api_route(path, endpoint, methods=[method])
 
-    for method, path, marker in protected_routes:
-        register(method, path, marker)
+    @app.get("/api/testing/receipt-parser-diagnosis")
+    def preferred_diagnosis():
+        return {"source": "preferred"}
 
-    @app.get("/api/testing/diagnostics/store-process-validation")
-    def unrelated_testing_diagnostic():
-        calls.append("unrelated-testing")
-        return {"status": "ok"}
+    preferred_diagnosis.__module__ = "app.api.receipt_diagnosis_routes"
 
-    @app.post("/api/admin/unrelated")
-    def unrelated_admin_route(authorization: str | None = Header(None)):
-        calls.append("unrelated")
-        return {"status": "ok", "authorization": authorization}
+    @app.get("/api/testing/receipt-parser-diagnosis")
+    def duplicate_diagnosis():
+        return {"source": "duplicate"}
+
+    duplicate_diagnosis.__module__ = "app.api.routes.receipt_parser_diagnosis"
+
+    removed = deduplicate_receipt_parser_diagnosis_routes(app)
+    assert removed == 1
+    matching = [
+        route
+        for route in app.routes
+        if getattr(route, "path", None) == "/api/testing/receipt-parser-diagnosis"
+    ]
+    assert len(matching) == 1
+    assert matching[0].endpoint.__module__ == "app.api.receipt_diagnosis_routes"
+
+    install_platform_admin_route_guard(
+        SimpleNamespace(app=app, require_platform_admin_user=require_platform_admin_user)
+    )
 
     with TestClient(app) as client:
-        for method, path, marker in protected_routes:
+        for method, path in sorted(PROTECTED_MUTATIONS):
             before = list(calls)
-            response = client.request(method.upper(), path)
-            assert response.status_code == 401, (path, response.text)
-            assert calls == before, f"{marker} werd ondanks 401 uitgevoerd"
+            response = client.request(method, path)
+            assert response.status_code == 401, (method, path, response.text)
+            assert calls == before
 
             response = client.request(
-                method.upper(),
+                method,
                 path,
                 headers={"Authorization": "Bearer household-user"},
             )
-            assert response.status_code == 403, (path, response.text)
-            assert calls == before, f"{marker} werd ondanks 403 uitgevoerd"
+            assert response.status_code == 403, (method, path, response.text)
+            assert calls == before
 
             response = client.request(
-                method.upper(),
+                method,
                 path,
                 headers={"Authorization": "Bearer platform-admin"},
             )
-            assert response.status_code == 200, (path, response.text)
-            assert calls[-1] == marker
+            assert response.status_code == 200, (method, path, response.text)
+            assert calls[-1] == f"{method} {path}"
 
-        response = client.get("/api/testing/diagnostics/store-process-validation")
-        assert response.status_code == 200, response.text
-        assert calls[-1] == "unrelated-testing"
-
-        response = client.post("/api/admin/unrelated")
-        assert response.status_code == 200, response.text
-        assert calls[-1] == "unrelated"
-
-    assert authorize_receipt_admin_request(
+    assert authorize_platform_admin_request(
         "GET",
-        "/api/testing/regression/almost-out-prediction",
-        None,
-        require_platform_admin_user,
-    ) is None
-    assert authorize_receipt_admin_request(
-        "GET",
-        "/api/testing/fixtures/inventory/ensure",
+        "/api/testing/reports/complete",
         None,
         require_platform_admin_user,
     ) is None
 
-    print("RECEIPT_ADMIN_HOUSEHOLD_GUARD_GREEN")
+    print("PLATFORM_ADMIN_ROUTE_GUARD_GREEN")
 
 
 if __name__ == "__main__":

--- a/docs/quality/M2C2N-CLOSURE-MATRIX.md
+++ b/docs/quality/M2C2N-CLOSURE-MATRIX.md
@@ -1,141 +1,76 @@
 # M2C2n afsluitmatrix
 
 Statusdatum: 2026-07-22  
-Basiscommit: `b430e9cb47d4a1d4e1226992e432ce3a78722b93`
+Basiscommit: `846b0e42c2c7b58e37de9017be4942dbc6300c41`
 
-## Doel
+## Doel en eindcriteria
 
-Dit document is de enige statusbron voor de afsluiting van M2C2n: huishoudisolatie, rolgrenzen en beheer van test- en diagnostiekroutes.
+Dit document is de enige statusbron voor M2C2n. Een domein krijgt pas **GEREED** wanneer alle routes zijn geïnventariseerd, huishoudbron en objectbinding zijn vastgelegd, rollen expliciet zijn, bewezen gaten zijn hersteld, een gericht contract bestaat, alle regressie- en releasegates groen zijn en uitzonderingen expliciet zijn geaccepteerd of uitgesteld.
 
-Een domein krijgt pas status **GEREED** wanneer:
-
-1. alle routes in het domein zijn geïnventariseerd;
-2. per route de huishoudbron en objectbinding zijn vastgelegd;
-3. lees- en schrijfrechten expliciet zijn bepaald;
-4. ontbrekende grenzen zijn hersteld;
-5. een gerichte contracttest bestaat;
-6. alle bestaande regressie- en releasegates groen zijn;
-7. resterende uitzonderingen expliciet zijn geaccepteerd of als deferred zijn geregistreerd.
-
-`Onbekend` en `nog te inventariseren` betekenen nadrukkelijk niet dat een route veilig of onveilig is.
-
-## Statuswaarden
-
-- **GEREED** — volledig geïnventariseerd en bewezen tegen de eindcriteria.
-- **CONTROLE** — relevante beveiliging aanwezig, maar afsluitende volledige routecontrole ontbreekt.
-- **OPEN** — domein is nog niet volledig geïnventariseerd of bevat een onbewezen grens.
-- **DEFERRED** — bewust buiten M2C2n geplaatst met een vastgelegde ontwerpbeslissing.
+Statuswaarden: **GEREED**, **CONTROLE**, **OPEN** en **DEFERRED**. Onbekend betekent nooit impliciet veilig of onveilig.
 
 ## Domeinmatrix
 
 | ID | Domein | Huishoudisolatie | Rolgrens | Gericht bewijs | Status | Nog nodig |
 |---|---|---|---|---|---|---|
-| M2C2N-01 | Centrale huishoudcontext en membership | Centrale actieve huishoudcontext ingevoerd | Lidmaatschap centraal gecontroleerd | PR #160 en opvolgende regressiegates | GEREED | Geen |
-| M2C2N-02 | Artikelgroepen | Objecten en queries huishoudgebonden | Mutaties volgens huishoudrol | PR #161 | GEREED | Geen |
-| M2C2N-03 | Voorraadlocaties, spaces en sublocations | Inventory- en locatieobjecten aan owning household gebonden | Schrijven/adminrollen afgedwongen | PR #162 en locatie-isolatiecontract | GEREED | Geen |
-| M2C2N-04 | Uitpakken: target-location | Batch- en regelhuishouden server-side afgeleid | Schrijfrecht voor mutaties | PR #164 | GEREED | Geen |
-| M2C2N-05 | Uitpakken: batch/regelobjecten | Objectguard voor batch- en regelroutes | Muterende methoden vereisen schrijfrecht | PR #165 en #174 | GEREED | Geen |
-| M2C2N-06 | Receipt share import | Geauthenticeerde import aan actieve huishoudcontext gebonden | Schrijfrecht afgedwongen | PR #166 | GEREED | Geen |
-| M2C2N-07 | Receipt admin- en onderhoudsroutes | Geen vrije huishoudkeuze voor beheeracties | Platform-admin vereist | PR #167 en latere guarduitbreidingen; WP-1-routebaseline | CONTROLE | WP-2: alle 10 adminmutaties valideren en guard consolideren |
-| M2C2N-08 | Gmail OAuth receiptbron | State en bron aan één huishouden gebonden | Geautoriseerde huishoudbeheerder | PR #168 | GEREED | Geen |
-| M2C2N-09 | Resend inbound webhook en bron | Inbound bron server-side aan huishouden gebonden | Webhookcontract en broncontrole | PR #169–#171 | GEREED | Geen |
-| M2C2N-10 | Purchase-import live alias backfill | Platformbeheeractie; geen vrije gebruikersscope | Platform-admin vereist | PR #172 | GEREED | Geen |
-| M2C2N-11 | Receipt-exportfixtures | Vaste regressiescope | Platform-admin vereist | PR #173 | GEREED | Geen |
-| M2C2N-12 | Product enrichment | Actief huishouden uit gevalideerde context | Inventory-schrijfrecht | PR #175 | GEREED | Geen |
-| M2C2N-13 | Artikel-ID-verrijking en detailmutaties | Artikel binnen actieve huishoudcontext opgelost | Inventory-schrijfrecht | PR #176 | GEREED | Geen |
-| M2C2N-14 | Externe productkoppeling via inventory/artikel | Inventory en household article worden binnen actief huishouden gezocht | Admin/lid, kijker geblokkeerd | Codecontrole; WP-1-routebaseline | CONTROLE | WP-3: gericht HTTP-contract toevoegen of bestaand bewijs aanwijzen |
-| M2C2N-15 | Testing: store-locationdiagnostiek | Vrij `household_id` niet meer zonder beheerrecht uitvoerbaar | Platform-admin vereist | PR #177 | GEREED | Geen |
-| M2C2N-16 | Testing: almost-out en inventoryfixtures | Vaste regressiescope | Platform-admin vereist | PR #178 | GEREED | Geen |
-| M2C2N-17 | Overige `/api/testing/*`-routes | 40 registraties reproduceerbaar gecatalogiseerd | 17 mutaties; rolgrens nog niet volledig gevalideerd | WP-1-routebaseline | OPEN | WP-2: alle 17 testingmutaties classificeren en testen; 2 dubbele GET-registraties oplossen |
-| M2C2N-18 | Product- en artikelroutes buiten reeds beschermde ingangen | Volledige routescope nu reproduceerbaar beschikbaar | Deels bewezen | PR #175/#176 en WP-1-routebaseline | CONTROLE | WP-3: domeinfilter en restcontract uitvoeren |
-| M2C2N-19 | Prognoses en AlmostOut-productieroutes | Volledige routescope nu reproduceerbaar beschikbaar | Nog niet domeinbreed gevalideerd | WP-1-routebaseline | OPEN | WP-4: relevante routes uit baseline selecteren en controleren |
-| M2C2N-20 | Inkoop, handmatige aankopen en importinstellingen | Volledige routescope nu reproduceerbaar beschikbaar | Deels schrijfrecht bewezen | Purchase-importguards en WP-1-routebaseline | OPEN | WP-4: productieroutes buiten batch/regelguard controleren |
-| M2C2N-21 | Meldingen en notificatieconfiguratie | Volledige routescope nu reproduceerbaar beschikbaar | Nog niet domeinbreed gevalideerd | WP-1-routebaseline | OPEN | WP-5: relevante routes uit baseline selecteren en controleren |
-| M2C2N-22 | Stille fallbacks `"1"` en `"demo-household"` | Routecatalogus beschikbaar; codevoorkomens nog niet geclassificeerd | Niet van toepassing | Gedeeltelijke codecontrole en WP-1-routebaseline | OPEN | WP-6: alle productievoorkomens classificeren of verwijderen |
-| M2C2N-23 | `/api/receipts/share-target` | Huidige vrije `household_id` is niet eindontwerp | Toekomstig signed-tokencontract | Ontwerpbesluit vastgelegd, geen implementatie | DEFERRED | Later: kortlevend signed token, aan exact één huishouden gebonden |
-| M2C2N-24 | Platform-admin-routeguard | Functioneel actief | Platform-admin | Contracttest en WP-1-routebaseline | CONTROLE | WP-2: hernoemen naar algemene guard en registratie centraliseren |
+| M2C2N-01 | Centrale huishoudcontext en membership | Centrale actieve huishoudcontext | Lidmaatschap centraal | PR #160 | GEREED | Geen |
+| M2C2N-02 | Artikelgroepen | Huishoudgebonden | Mutaties volgens rol | PR #161 | GEREED | Geen |
+| M2C2N-03 | Voorraadlocaties | Owning household | Schrijven/admin | PR #162 | GEREED | Geen |
+| M2C2N-04 | Uitpakken target-location | Server-side batchscope | Schrijfrecht | PR #164 | GEREED | Geen |
+| M2C2N-05 | Uitpakken batch/regel | Objectguard | Schrijfrecht | PR #165/#174 | GEREED | Geen |
+| M2C2N-06 | Receipt share import | Actieve context | Schrijfrecht | PR #166 | GEREED | Geen |
+| M2C2N-07 | Admin- en onderhoudsmutaties | Geen vrije gebruikersscope | Alle 10 adminmutaties centraal platform-admin | WP-2 volledig routecontract | GEREED | Geen |
+| M2C2N-08 | Gmail OAuth receiptbron | State en bron huishoudgebonden | Huishoudadmin | PR #168 | GEREED | Geen |
+| M2C2N-09 | Resend inbound | Bron server-side huishoudgebonden | Webhookcontract | PR #169–#171 | GEREED | Geen |
+| M2C2N-10 | Live-aliasbackfill | Platformbeheeractie | Platform-admin | PR #172 | GEREED | Geen |
+| M2C2N-11 | Receipt-exportfixtures | Vaste regressiescope | Platform-admin | PR #173 | GEREED | Geen |
+| M2C2N-12 | Product enrichment | Actieve context | Inventory-schrijfrecht | PR #175 | GEREED | Geen |
+| M2C2N-13 | Artikel-ID-mutaties | Actieve context | Inventory-schrijfrecht | PR #176 | GEREED | Geen |
+| M2C2N-14 | Externe productkoppeling | Objecten binnen actief huishouden | Kijker geblokkeerd | WP-1-baseline | CONTROLE | WP-3-contract |
+| M2C2N-15 | Store-locationdiagnostiek | Vrij huishouden geblokkeerd | Platform-admin | PR #177/WP-2 | GEREED | Geen |
+| M2C2N-16 | Almost-out en inventoryfixtures | Vaste regressiescope | Platform-admin | PR #178/WP-2 | GEREED | Geen |
+| M2C2N-17 | Overige `/api/testing/*` | 38 registraties, 17 mutaties gecatalogiseerd | Alle 17 mutaties centraal platform-admin | WP-2 volledig routecontract; geen dubbelen | GEREED | Geen |
+| M2C2N-18 | Overige product- en artikelroutes | Volledige routescope beschikbaar | Deels bewezen | WP-1 | CONTROLE | WP-3 |
+| M2C2N-19 | Prognoses en AlmostOut-productie | Routescope beschikbaar | Nog niet domeinbreed | WP-1 | OPEN | WP-4 |
+| M2C2N-20 | Inkoop en importinstellingen | Routescope beschikbaar | Deels bewezen | WP-1 | OPEN | WP-4 |
+| M2C2N-21 | Meldingen | Routescope beschikbaar | Nog niet domeinbreed | WP-1 | OPEN | WP-5 |
+| M2C2N-22 | Fallbacks `"1"` en `"demo-household"` | Nog te classificeren | n.v.t. | WP-1 | OPEN | WP-6 |
+| M2C2N-23 | `/api/receipts/share-target` | Vrij `household_id` is niet eindontwerp | Toekomstig signed token | Ontwerpbesluit | DEFERRED | Later apart ontwerp |
+| M2C2N-24 | Platform-admin-routeguard | Centrale expliciete routescope | Platform-admin voor 27 mutaties | Algemene guard en volledig contract | GEREED | Legacy importshim later regulier opruimen |
 
-## Eindige restlijst
-
-M2C2n bestaat vanaf dit document nog uit maximaal de volgende werkpakketten, in deze volgorde:
-
-1. **WP-1 — Routecatalogus genereren**  
-   Maak een reproduceerbare inventaris van alle FastAPI-routes met methode, pad, endpointfunctie en bronmodule. Classificeer testing/admin/productie en lees/mutatie.
-
-2. **WP-2 — Testing en platform-admin consolideren**  
-   Controleer alle `/api/testing/*`- en `/api/admin/*`-mutaties. Hernoem de huidige receipt-specifieke guard naar een algemene platform-admin-routeguard. Voeg één volledig routecontract toe.
-
-3. **WP-3 — Producten, artikelen en externe productlinks afsluiten**  
-   Sluit M2C2N-14 en M2C2N-18 met een volledige routecatalogus en gerichte HTTP-contracten.
-
-4. **WP-4 — Prognose en inkoop afsluiten**  
-   Inventariseer en herstel uitsluitend bewezen gaten in M2C2N-19 en M2C2N-20.
-
-5. **WP-5 — Meldingen afsluiten**  
-   Inventariseer huishoudscope en rolgrenzen voor meldingen en notificatieconfiguratie.
-
-6. **WP-6 — Fallbacksanering**  
-   Classificeer alle `"1"`- en `"demo-household"`-voorkomens. Productief bereikbare fallbacks worden verwijderd; bootstrap/testgevallen worden expliciet gemarkeerd.
-
-7. **WP-7 — M2C2n eindrapport**  
-   Werk alle matrixrijen bij naar GEREED of DEFERRED, voeg bewijskoppelingen toe en voer de volledige releasekwaliteitketen uit.
-
-Er worden geen nieuwe losse beveiligings-PR’s buiten deze werkpakketten gestart.
-
-## WP-1-uitvoer
-
-De runtimegenerator leest de werkelijk geregistreerde `app.routes` nadat de asynchrone route-installatie stabiel is. De vaste baseline staat in `docs/quality/M2C2N-ROUTE-CATALOG-BASELINE.json` en wordt bij iedere PR opnieuw gecontroleerd.
+## WP-1-routebaseline na WP-2
 
 | Kengetal | Waarde |
 |---|---:|
-| Routeregistraties | 196 |
+| Routeregistraties | 194 |
 | Unieke methode-padcombinaties | 194 |
-| Leesregistraties | 87 |
+| Dubbele registraties | 0 |
+| Leesregistraties | 85 |
 | Mutatieregistraties | 109 |
 | Production | 140 totaal / 81 muterend |
-| Testing | 40 totaal / 17 muterend |
+| Testing | 38 totaal / 17 muterend |
 | Admin | 14 totaal / 10 muterend |
 | Dev | 2 totaal / 1 muterend |
-| Dubbele methode-padregistraties | 2 |
 
-De twee dubbele registraties zijn:
-
-- `GET /api/testing/receipt-parser-diagnosis`;
-- `GET /api/testing/receipt-parser-diagnosis/download`.
+De baseline staat in `docs/quality/M2C2N-ROUTE-CATALOG-BASELINE.json`. Iedere routewijziging moet deze baseline en matrix bewust bijwerken.
 
 ## Werkpakketstatus
 
 | Werkpakket | Status | Bewijs/uitvoer |
 |---|---|---|
-| WP-1 — Routecatalogus genereren | GEREED | Runtimegenerator, Docker-CI, artifact en vaste fingerprintbaseline |
-| WP-2 — Testing en platform-admin consolideren | VOLGENDE | Scope: 17 testingmutaties, 10 adminmutaties en 2 dubbele GET-registraties |
-| WP-3 t/m WP-7 | NIET GESTART | Wachten op afronding WP-2 |
+| WP-1 — Routecatalogus | GEREED | Generator, Docker-CI en fingerprintbaseline |
+| WP-2 — Testing en platform-admin | IN REVIEW | Algemene guard, 27 mutaties, volledig contract, diagnose-ontdubbeling |
+| WP-3 — Producten en externe productlinks | VOLGENDE | M2C2N-14 en M2C2N-18 |
+| WP-4 t/m WP-7 | NIET GESTART | Volgen in vastgelegde volgorde |
 
-## PR-regels vanaf nu
+## PR-regels
 
-Iedere M2C2n-PR moet:
-
-- exact één werkpakket noemen;
-- de geraakte matrix-ID’s noemen;
-- vóór de codewijziging de complete routescope tonen;
-- een gericht contract toevoegen of actualiseren;
-- de matrix in dezelfde PR bijwerken;
-- geen status GEREED claimen zonder alle zeven eindcriteria;
-- wachten op expliciete PO-GO vóór merge.
+Iedere M2C2n-PR noemt exact één werkpakket en de geraakte matrix-ID’s, toont vooraf de complete routescope, bevat een gericht contract, werkt deze matrix bij en wacht op expliciete PO-GO vóór merge.
 
 ## Bewijsgrenzen
 
-- Een groene middlewarecontracttest bewijst de geteste methode-padcombinaties, niet automatisch alle routes in een domein.
-- Een gemergede PR bewijst niet zonder afzonderlijke branchcontrole dat de genoemde commit op dat moment de head van `main` is.
-- Compile-, Docker- en frontendgates bewijzen regressievrij bouwen en starten, niet de volledige functionele werking van ieder scherm.
-- Onbekende routes blijven OPEN totdat zij reproduceerbaar zijn geïnventariseerd.
+Een middlewarecontract bewijst alleen de geteste methode-padcombinaties. Groene compile-, Docker- en frontendgates bewijzen bouwen en starten, niet ieder scherm. Een mergecommit is pas `main`-head na afzonderlijke branchvergelijking.
 
-## Afsluitcriterium M2C2n
+## Afsluitcriterium
 
-M2C2n is pas klaar wanneer:
-
-- M2C2N-01 t/m M2C2N-22 en M2C2N-24 op GEREED staan;
-- M2C2N-23 als enige DEFERRED-rij overblijft, tenzij de PO de scope wijzigt;
-- de routecatalogus geen ongeclassificeerde muterende route bevat;
-- alle gerichte contracten en de volledige releasekwaliteitketen groen zijn;
-- de PO expliciet GO geeft op het M2C2n-eindrapport.
+M2C2n is pas klaar wanneer M2C2N-01 t/m M2C2N-22 en M2C2N-24 **GEREED** zijn, M2C2N-23 als enige **DEFERRED** blijft, geen ongeclassificeerde muterende route resteert, alle gerichte contracten en releasegates groen zijn en de PO expliciet GO geeft op WP-7.

--- a/docs/quality/M2C2N-ROUTE-CATALOG-BASELINE.json
+++ b/docs/quality/M2C2N-ROUTE-CATALOG-BASELINE.json
@@ -1,19 +1,19 @@
 {
   "catalog_version": 1,
-  "route_fingerprint_sha256": "71fd519a694963ecf99ce867aed032ff126db55256be19e8a181430f765cb464",
+  "route_fingerprint_sha256": "ba098c6fea4cb969d9dd21d0316099f5672aca453cffe55cdc285e137a27c04a",
   "summary": {
-    "route_registrations": 196,
+    "route_registrations": 194,
     "unique_method_paths": 194,
-    "duplicates": 2,
+    "duplicates": 0,
     "by_surface": {
       "admin": 14,
       "dev": 2,
       "production": 140,
-      "testing": 40
+      "testing": 38
     },
     "by_access": {
       "mutation": 109,
-      "read": 87
+      "read": 85
     },
     "mutation_by_surface": {
       "admin": 10,
@@ -22,24 +22,7 @@
       "testing": 17
     }
   },
-  "duplicates": [
-    {
-      "method": "GET",
-      "path": "/api/testing/receipt-parser-diagnosis",
-      "registrations": [
-        "app.api.receipt_diagnosis_routes.receipt_parser_diagnosis",
-        "app.api.routes.receipt_parser_diagnosis.get_receipt_parser_diagnosis"
-      ]
-    },
-    {
-      "method": "GET",
-      "path": "/api/testing/receipt-parser-diagnosis/download",
-      "registrations": [
-        "app.api.receipt_diagnosis_routes.receipt_parser_diagnosis_download",
-        "app.api.routes.receipt_parser_diagnosis.download_receipt_parser_diagnosis"
-      ]
-    }
-  ],
+  "duplicates": [],
   "testing_mutations": [
     "POST /api/testing/diagnostics/store-location-options :: app.main.run_store_location_diagnostic",
     "POST /api/testing/fixtures/browser-regression/reset :: app.main.reset_browser_regression_fixture",


### PR DESCRIPTION
## Werkpakket
WP-2 — Testing en platform-admin consolideren.

## Geraakte matrix-ID's
M2C2N-07, M2C2N-15, M2C2N-16, M2C2N-17 en M2C2N-24.

## Complete routescope
De WP-1-baseline bevat exact 17 muterende `/api/testing/*`-routes en 10 muterende `/api/admin/*`-routes. Deze 27 methode-padcombinaties staan nu centraal in één algemene platform-adminguard.

## Bewezen tekortkomingen
- `POST /api/testing/reports/complete` wijzigde teststatus zonder autorisatie;
- `POST /api/admin/external-relations/batch/decision` voerde een adminbeslissing uit zonder autorisatie;
- twee receipt-parserdiagnose-GET-paden waren dubbel geregistreerd;
- de receipt-specifieke guardnaam dekte inmiddels een algemene platformbeheerverantwoordelijkheid.

## Gewijzigd
- nieuwe `platform_admin_route_guard.py` met alle 27 mutaties;
- legacy `receipt_admin_household_guard.py` teruggebracht tot compatibiliteitsshim;
- volledig contract voor 401, 403 en platform-adminsucces op alle 27 routes;
- deterministische ontdubbeling van de twee diagnosepaden;
- routecatalogusbaseline bijgewerkt naar 194 registraties, 194 unieke paden en 0 dubbelen;
- afsluitmatrix bijgewerkt.

## Niet gewijzigd
- geen productiedomeinlogica;
- geen household- of inventoryquery;
- geen frontend;
- `/api/receipts/share-target` blijft DEFERRED.

## Acceptatie
- alle 27 mutaties stoppen vóór endpointuitvoering zonder platform-admin;
- routecatalogus heeft geen dubbele methode-padregistraties;
- routefingerprint en vaste mutationlijsten kloppen;
- alle bestaande regressie- en releasegates zijn groen;
- merge pas na expliciete PO-GO.