### PR TITLE
M2C2n WP-3: protect product and external product routes

### DIFF
--- a/.github/workflows/m2c2n-product-route-audit.yml
+++ b/.github/workflows/m2c2n-product-route-audit.yml
@@ -1,0 +1,43 @@
+name: M2C2n product route audit
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  audit-product-routes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Controleer Docker Compose
+        run: docker compose version
+
+      - name: Bouw backend-image
+        run: docker compose build backend
+
+      - name: Genereer productroute-audit
+        run: |
+          mkdir -p product-route-audit-output
+          docker compose run --rm --no-deps \
+            -v "$PWD/product-route-audit-output:/tmp/m2c2n-product-route-audit" \
+            backend \
+            python -m app.testing.product_route_audit \
+              --output /tmp/m2c2n-product-route-audit/M2C2N-PRODUCT-ROUTE-AUDIT.json \
+            | tee product-route-audit.log
+          grep -F 'M2C2N_PRODUCT_ROUTE_AUDIT_GREEN' product-route-audit.log
+          test -s product-route-audit-output/M2C2N-PRODUCT-ROUTE-AUDIT.json
+
+      - name: Publiceer productroute-audit
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: m2c2n-product-route-audit
+          path: |
+            product-route-audit-output/M2C2N-PRODUCT-ROUTE-AUDIT.json
+            product-route-audit.log
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/m2c2n-product-route-guard.yml
+++ b/.github/workflows/m2c2n-product-route-guard.yml
@@ -1,0 +1,30 @@
+name: M2C2n product route household guard
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  validate-product-route-household-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Installeer minimale backend-afhankelijkheden
+        run: pip install fastapi sqlalchemy
+
+      - name: Compileer guard en contract
+        run: python -m compileall backend/app/services/product_route_household_guard.py backend/app/testing/product_route_household_guard_contract.py
+
+      - name: Voer volledig productroutecontract uit
+        env:
+          PYTHONPATH: backend
+        run: python -m app.testing.product_route_household_guard_contract

--- a/backend/app/services/product_enrichment_write_guard.py
+++ b/backend/app/services/product_enrichment_write_guard.py
@@ -69,7 +69,18 @@ def install_product_enrichment_write_guard(main_module) -> None:
     app.state.product_enrichment_write_guard_installed = True
 
     from .article_detail_write_guard import install_article_detail_write_guard
-    from .product_route_household_guard import install_product_route_household_guard
 
     install_article_detail_write_guard(main_module)
-    install_product_route_household_guard(main_module)
+
+    if all(
+        hasattr(main_module, attribute)
+        for attribute in (
+            "engine",
+            "require_household_context",
+            "require_inventory_write_context",
+            "require_platform_admin_user",
+        )
+    ):
+        from .product_route_household_guard import install_product_route_household_guard
+
+        install_product_route_household_guard(main_module)

--- a/backend/app/services/product_enrichment_write_guard.py
+++ b/backend/app/services/product_enrichment_write_guard.py
@@ -69,5 +69,7 @@ def install_product_enrichment_write_guard(main_module) -> None:
     app.state.product_enrichment_write_guard_installed = True
 
     from .article_detail_write_guard import install_article_detail_write_guard
+    from .product_route_household_guard import install_product_route_household_guard
 
     install_article_detail_write_guard(main_module)
+    install_product_route_household_guard(main_module)

--- a/backend/app/services/product_route_household_guard.py
+++ b/backend/app/services/product_route_household_guard.py
@@ -166,9 +166,21 @@ def install_product_route_household_guard(main_module) -> None:
                         request.query_params.get("q", ""),
                     )
                 )
-            with main_module.engine.begin() as conn:
+            if _INVENTORY_GROUP_ASSIGNMENT.match(request.url.path):
+                with main_module.engine.begin() as conn:
+                    authorize_product_route_request(
+                        conn,
+                        request.method,
+                        request.url.path,
+                        request.headers.get("authorization"),
+                        request.query_params.get("household_id"),
+                        main_module.require_household_context,
+                        main_module.require_inventory_write_context,
+                        main_module.require_platform_admin_user,
+                    )
+            else:
                 authorize_product_route_request(
-                    conn,
+                    None,
                     request.method,
                     request.url.path,
                     request.headers.get("authorization"),

--- a/backend/app/services/product_route_household_guard.py
+++ b/backend/app/services/product_route_household_guard.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Callable
+
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
+
+
+PLATFORM_ADMIN_MUTATIONS = {
+    ("POST", "/api/external-databases/catalog/promote-candidate-with-product-type"),
+    ("POST", "/api/external-products/off/link"),
+    ("POST", "/api/product-groups"),
+    ("PUT", "/api/product-groups/{inventory_group_key:path}"),
+    ("DELETE", "/api/product-groups/{inventory_group_key:path}"),
+    ("POST", "/api/products/{global_product_id}/inventory-group"),
+}
+AUTHENTICATED_ROUTES = {
+    ("GET", "/api/external-databases/catalog/products"),
+    ("POST", "/api/external-products/off/search"),
+    ("GET", "/api/product-groups"),
+}
+_INVENTORY_GROUP_ASSIGNMENT = re.compile(r"^/api/inventory/items/([^/]+)/group$")
+_PRODUCT_GROUP_ITEM = re.compile(r"^/api/product-groups/(.+)$")
+_PRODUCT_INVENTORY_GROUP = re.compile(r"^/api/products/([^/]+)/inventory-group$")
+
+
+def canonical_route_key(method: str, path: str) -> tuple[str, str]:
+    normalized_method = str(method or "").upper()
+    normalized_path = str(path or "")
+    if _PRODUCT_GROUP_ITEM.match(normalized_path):
+        return normalized_method, "/api/product-groups/{inventory_group_key:path}"
+    if _PRODUCT_INVENTORY_GROUP.match(normalized_path):
+        return normalized_method, "/api/products/{global_product_id}/inventory-group"
+    return normalized_method, normalized_path
+
+
+def resolve_inventory_household(conn, path: str) -> str | None:
+    match = _INVENTORY_GROUP_ASSIGNMENT.match(str(path or ""))
+    if not match:
+        return None
+    inventory_id = match.group(1).strip()
+    row = conn.execute(
+        text("SELECT household_id FROM inventory WHERE id = :inventory_id LIMIT 1"),
+        {"inventory_id": inventory_id},
+    ).mappings().first()
+    if not row or not str(row.get("household_id") or "").strip():
+        raise HTTPException(status_code=404, detail="Voorraadregel niet gevonden")
+    return str(row["household_id"]).strip()
+
+
+def authorize_product_route_request(
+    conn,
+    method: str,
+    path: str,
+    authorization: str | None,
+    requested_household_id: str | None,
+    require_household_context: Callable[[str | None, str | None], dict[str, Any]],
+    require_inventory_write_context: Callable[[str | None, str | None], dict[str, Any]],
+    require_platform_admin_user: Callable[[str | None], object],
+) -> dict[str, Any] | object | None:
+    route_key = canonical_route_key(method, path)
+    if route_key in PLATFORM_ADMIN_MUTATIONS:
+        return require_platform_admin_user(authorization)
+    if route_key == ("GET", "/api/inventory/groups"):
+        return require_household_context(authorization, requested_household_id)
+    if route_key in AUTHENTICATED_ROUTES:
+        return require_household_context(authorization, None)
+    inventory_household_id = resolve_inventory_household(conn, path)
+    if inventory_household_id is not None:
+        return require_inventory_write_context(authorization, inventory_household_id)
+    return None
+
+
+def build_store_review_articles(main_module, household_id: str, query: str) -> list[dict[str, Any]]:
+    normalized_query = str(query or "").strip().lower()
+    items = [dict(item) for item in main_module.MOCK_ARTICLE_OPTIONS]
+    seen_names = {str(item.get("name") or "").strip().lower() for item in items if item.get("name")}
+    with main_module.engine.begin() as conn:
+        household_rows = conn.execute(
+            text(
+                """
+                SELECT id, naam AS article_name, consumable, brand_or_maker
+                FROM household_articles
+                WHERE household_id = :household_id
+                  AND trim(COALESCE(naam, '')) <> ''
+                ORDER BY lower(naam) ASC, id ASC
+                """
+            ),
+            {"household_id": household_id},
+        ).mappings().all()
+        defaults_by_article = main_module.get_household_article_location_defaults(
+            conn,
+            [str(row.get("id") or "") for row in household_rows],
+        )
+        for row in household_rows:
+            article_name = str(row.get("article_name") or "").strip()
+            normalized = article_name.lower()
+            if not article_name or normalized in seen_names:
+                continue
+            defaults = defaults_by_article.get(str(row.get("id") or ""), {})
+            items.append(
+                {
+                    "id": str(row.get("id") or ""),
+                    "name": article_name,
+                    "brand": str(row.get("brand_or_maker") or "").strip(),
+                    "consumable": bool(row["consumable"]) if row.get("consumable") is not None else main_module.infer_consumable_from_name(article_name),
+                    "default_location_id": defaults.get("default_location_id") or "",
+                    "default_sublocation_id": defaults.get("default_sublocation_id") or "",
+                }
+            )
+            seen_names.add(normalized)
+        inventory_names = conn.execute(
+            text(
+                """
+                SELECT DISTINCT naam AS article_name
+                FROM inventory
+                WHERE household_id = :household_id
+                  AND trim(COALESCE(naam, '')) <> ''
+                ORDER BY lower(naam) ASC
+                """
+            ),
+            {"household_id": household_id},
+        ).mappings().all()
+        for row in inventory_names:
+            article_name = str(row.get("article_name") or "").strip()
+            normalized = article_name.lower()
+            if not article_name or normalized in seen_names:
+                continue
+            items.append(
+                {
+                    "id": main_module.build_live_article_option_id(article_name),
+                    "name": article_name,
+                    "brand": "",
+                    "consumable": main_module.infer_consumable_from_name(article_name),
+                }
+            )
+            seen_names.add(normalized)
+    return [
+        item
+        for item in items
+        if not normalized_query
+        or normalized_query in f"{item.get('name') or ''} {item.get('brand') or ''}".lower()
+    ]
+
+
+def install_product_route_household_guard(main_module) -> None:
+    app = main_module.app
+    if getattr(app.state, "product_route_household_guard_installed", False):
+        return
+
+    @app.middleware("http")
+    async def product_route_household_guard(request, call_next):
+        try:
+            if request.method.upper() == "GET" and request.url.path == "/api/store-review-articles":
+                context = main_module.require_household_context(
+                    request.headers.get("authorization"),
+                    None,
+                )
+                household_id = str(context["active_household_id"])
+                return JSONResponse(
+                    content=build_store_review_articles(
+                        main_module,
+                        household_id,
+                        request.query_params.get("q", ""),
+                    )
+                )
+            with main_module.engine.begin() as conn:
+                authorize_product_route_request(
+                    conn,
+                    request.method,
+                    request.url.path,
+                    request.headers.get("authorization"),
+                    request.query_params.get("household_id"),
+                    main_module.require_household_context,
+                    main_module.require_inventory_write_context,
+                    main_module.require_platform_admin_user,
+                )
+        except HTTPException as exc:
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": exc.detail},
+                headers=exc.headers or None,
+            )
+        return await call_next(request)
+
+    app.state.product_route_household_guard_installed = True

--- a/backend/app/services/product_route_household_guard.py
+++ b/backend/app/services/product_route_household_guard.py
@@ -36,6 +36,17 @@ def canonical_route_key(method: str, path: str) -> tuple[str, str]:
     return normalized_method, normalized_path
 
 
+def is_guarded_product_route(method: str, path: str) -> bool:
+    route_key = canonical_route_key(method, path)
+    return bool(
+        route_key in PLATFORM_ADMIN_MUTATIONS
+        or route_key in AUTHENTICATED_ROUTES
+        or route_key == ("GET", "/api/inventory/groups")
+        or (str(method or "").upper() == "GET" and str(path or "") == "/api/store-review-articles")
+        or _INVENTORY_GROUP_ASSIGNMENT.match(str(path or ""))
+    )
+
+
 def resolve_inventory_household(conn, path: str) -> str | None:
     match = _INVENTORY_GROUP_ASSIGNMENT.match(str(path or ""))
     if not match:
@@ -152,6 +163,8 @@ def install_product_route_household_guard(main_module) -> None:
 
     @app.middleware("http")
     async def product_route_household_guard(request, call_next):
+        if not is_guarded_product_route(request.method, request.url.path):
+            return await call_next(request)
         try:
             if request.method.upper() == "GET" and request.url.path == "/api/store-review-articles":
                 context = main_module.require_household_context(

--- a/backend/app/testing/product_route_audit.py
+++ b/backend/app/testing/product_route_audit.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import argparse
+import inspect
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from app.main import app
+
+
+TARGET_PREFIXES = (
+    "/api/household-articles/",
+    "/api/products/",
+    "/api/product-identities/",
+    "/api/product-groups",
+    "/api/inventory/groups",
+    "/api/external-products/",
+    "/api/external-databases/catalog/products",
+    "/api/purchase-import-lines/",
+)
+TARGET_EXACT_PATHS = {
+    "/api/inventory/{inventory_id}/article-detail",
+    "/api/inventory/{inventory_id}/external-product-link",
+    "/api/store-review-articles",
+}
+EXCLUDED_PATH_PARTS = {
+    "/article-group",
+    "/api/article-groups",
+}
+AUTH_MARKERS = (
+    "require_household_context",
+    "require_inventory_write_context",
+    "require_household_admin_context",
+    "require_household_permission",
+    "require_platform_admin_user",
+    "get_request_household_id",
+)
+HOUSEHOLD_MARKERS = (
+    "household_id",
+    "active_household_id",
+    "household_article_id",
+    "inventory_id",
+    "batch_id",
+    "line_id",
+    "global_product_id",
+)
+MUTATION_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+
+
+def wait_for_stable_routes() -> None:
+    previous: tuple[tuple[str, tuple[str, ...]], ...] | None = None
+    stable_rounds = 0
+    for _ in range(200):
+        signature = tuple(
+            sorted(
+                (
+                    str(getattr(route, "path", "") or ""),
+                    tuple(sorted(str(method) for method in (getattr(route, "methods", None) or []))),
+                )
+                for route in app.routes
+            )
+        )
+        if signature == previous:
+            stable_rounds += 1
+            if stable_rounds >= 10:
+                return
+        else:
+            previous = signature
+            stable_rounds = 0
+        time.sleep(0.1)
+    raise RuntimeError("FastAPI-routeset werd niet stabiel")
+
+
+def is_target_path(path: str) -> bool:
+    if path in TARGET_EXACT_PATHS:
+        return True
+    if any(part in path for part in EXCLUDED_PATH_PARTS):
+        return False
+    return any(path.startswith(prefix) for prefix in TARGET_PREFIXES)
+
+
+def endpoint_source(endpoint: Any) -> tuple[str, str | None, int | None]:
+    try:
+        source = inspect.getsource(endpoint)
+    except (OSError, TypeError):
+        source = ""
+    try:
+        file_name = inspect.getsourcefile(endpoint)
+    except (OSError, TypeError):
+        file_name = None
+    try:
+        first_line = inspect.getsourcelines(endpoint)[1]
+    except (OSError, TypeError):
+        first_line = None
+    return source, file_name, first_line
+
+
+def audit_routes() -> dict[str, Any]:
+    wait_for_stable_routes()
+    rows: list[dict[str, Any]] = []
+    for route in app.routes:
+        path = str(getattr(route, "path", "") or "")
+        if not is_target_path(path):
+            continue
+        endpoint = getattr(route, "endpoint", None)
+        source, source_file, first_line = endpoint_source(endpoint)
+        lowered = source.lower()
+        signature = str(inspect.signature(endpoint)) if endpoint is not None else ""
+        for method in sorted(str(item) for item in (getattr(route, "methods", None) or [])):
+            if method in {"HEAD", "OPTIONS"}:
+                continue
+            rows.append(
+                {
+                    "method": method,
+                    "path": path,
+                    "access": "mutation" if method in MUTATION_METHODS else "read",
+                    "endpoint": str(getattr(endpoint, "__qualname__", "") or ""),
+                    "module": str(getattr(endpoint, "__module__", "") or ""),
+                    "signature": signature,
+                    "source_file": source_file,
+                    "first_line": first_line,
+                    "authorization_parameter": "authorization" in signature.lower(),
+                    "auth_markers": [marker for marker in AUTH_MARKERS if marker.lower() in lowered],
+                    "household_markers": [marker for marker in HOUSEHOLD_MARKERS if marker.lower() in lowered],
+                    "source": source,
+                }
+            )
+    rows.sort(key=lambda item: (item["path"], item["method"], item["module"], item["endpoint"]))
+    mutations = [item for item in rows if item["access"] == "mutation"]
+    reads = [item for item in rows if item["access"] == "read"]
+    mutation_without_auth_marker = [
+        f"{item['method']} {item['path']} :: {item['module']}.{item['endpoint']}"
+        for item in mutations
+        if not item["authorization_parameter"] and not item["auth_markers"]
+    ]
+    return {
+        "audit_version": 1,
+        "summary": {
+            "route_registrations": len(rows),
+            "reads": len(reads),
+            "mutations": len(mutations),
+            "mutation_without_auth_marker": len(mutation_without_auth_marker),
+        },
+        "mutation_without_auth_marker": mutation_without_auth_marker,
+        "routes": rows,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    payload = audit_routes()
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(json.dumps(payload["summary"], ensure_ascii=False, sort_keys=True))
+    print("M2C2N_PRODUCT_ROUTE_AUDIT_GREEN")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/testing/product_route_audit.py
+++ b/backend/app/testing/product_route_audit.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+import app.main as main_module
 from app.main import app
 
 
@@ -23,6 +24,8 @@ TARGET_PREFIXES = (
 TARGET_EXACT_PATHS = {
     "/api/inventory/{inventory_id}/article-detail",
     "/api/inventory/{inventory_id}/external-product-link",
+    "/api/inventory/items/{inventory_id}/group",
+    "/api/external-databases/catalog/promote-candidate-with-product-type",
     "/api/store-review-articles",
 }
 EXCLUDED_PATH_PARTS = {
@@ -47,6 +50,10 @@ HOUSEHOLD_MARKERS = (
     "global_product_id",
 )
 MUTATION_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+DEPENDENCY_NAMES = (
+    "get_store_review_article_options",
+    "get_household_article_row_by_id",
+)
 
 
 def wait_for_stable_routes() -> None:
@@ -97,6 +104,19 @@ def endpoint_source(endpoint: Any) -> tuple[str, str | None, int | None]:
     return source, file_name, first_line
 
 
+def dependency_sources() -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for name in DEPENDENCY_NAMES:
+        value = getattr(main_module, name, None)
+        source, source_file, first_line = endpoint_source(value)
+        result[name] = {
+            "source_file": source_file,
+            "first_line": first_line,
+            "source": source,
+        }
+    return result
+
+
 def audit_routes() -> dict[str, Any]:
     wait_for_stable_routes()
     rows: list[dict[str, Any]] = []
@@ -136,7 +156,7 @@ def audit_routes() -> dict[str, Any]:
         if not item["authorization_parameter"] and not item["auth_markers"]
     ]
     return {
-        "audit_version": 1,
+        "audit_version": 2,
         "summary": {
             "route_registrations": len(rows),
             "reads": len(reads),
@@ -145,6 +165,7 @@ def audit_routes() -> dict[str, Any]:
         },
         "mutation_without_auth_marker": mutation_without_auth_marker,
         "routes": rows,
+        "dependency_sources": dependency_sources(),
     }
 
 

--- a/backend/app/testing/product_route_household_guard_contract.py
+++ b/backend/app/testing/product_route_household_guard_contract.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi import HTTPException
+from sqlalchemy import create_engine, text
+
+from app.services.product_route_household_guard import (
+    AUTHENTICATED_ROUTES,
+    PLATFORM_ADMIN_MUTATIONS,
+    authorize_product_route_request,
+    build_store_review_articles,
+    canonical_route_key,
+)
+
+
+def require_household_context(authorization: str | None, requested_household_id: str | None):
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    if authorization == "Bearer other-household" and requested_household_id == "h1":
+        raise HTTPException(status_code=403, detail="Geen toegang tot huishouden")
+    return {"active_household_id": requested_household_id or "h1", "display_role": "lid"}
+
+
+def require_inventory_write_context(authorization: str | None, requested_household_id: str | None):
+    context = require_household_context(authorization, requested_household_id)
+    if authorization == "Bearer viewer":
+        raise HTTPException(status_code=403, detail="Schrijfrecht vereist")
+    return context
+
+
+def require_platform_admin_user(authorization: str | None):
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    if authorization != "Bearer platform-admin":
+        raise HTTPException(status_code=403, detail="Platformbeheerder vereist")
+    return {"role": "platform_admin"}
+
+
+def assert_http_error(status_code: int, callback) -> None:
+    try:
+        callback()
+    except HTTPException as exc:
+        assert exc.status_code == status_code, exc
+    else:
+        raise AssertionError(f"HTTP {status_code} verwacht")
+
+
+def run_contract() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE inventory (id TEXT PRIMARY KEY, household_id TEXT, naam TEXT)"))
+        conn.execute(text("CREATE TABLE household_articles (id TEXT PRIMARY KEY, household_id TEXT, naam TEXT, consumable INTEGER, brand_or_maker TEXT)"))
+        conn.execute(text("INSERT INTO inventory (id, household_id, naam) VALUES ('i-h1', 'h1', 'H1 voorraad'), ('i-h2', 'h2', 'H2 geheim')"))
+        conn.execute(text("INSERT INTO household_articles (id, household_id, naam, consumable, brand_or_maker) VALUES ('a-h1', 'h1', 'H1 artikel', 1, 'Merk 1'), ('a-h2', 'h2', 'H2 geheim artikel', 1, 'Merk 2')"))
+
+    assert canonical_route_key("PUT", "/api/product-groups/foo/bar") == (
+        "PUT",
+        "/api/product-groups/{inventory_group_key:path}",
+    )
+    assert canonical_route_key("POST", "/api/products/gp-1/inventory-group") == (
+        "POST",
+        "/api/products/{global_product_id}/inventory-group",
+    )
+
+    with engine.begin() as conn:
+        for method, template_path in sorted(PLATFORM_ADMIN_MUTATIONS):
+            path = template_path.replace("{inventory_group_key:path}", "groep/x").replace("{global_product_id}", "gp-1")
+            assert_http_error(
+                401,
+                lambda method=method, path=path: authorize_product_route_request(
+                    conn, method, path, None, None,
+                    require_household_context, require_inventory_write_context, require_platform_admin_user,
+                ),
+            )
+            assert_http_error(
+                403,
+                lambda method=method, path=path: authorize_product_route_request(
+                    conn, method, path, "Bearer household-user", None,
+                    require_household_context, require_inventory_write_context, require_platform_admin_user,
+                ),
+            )
+            result = authorize_product_route_request(
+                conn, method, path, "Bearer platform-admin", None,
+                require_household_context, require_inventory_write_context, require_platform_admin_user,
+            )
+            assert result == {"role": "platform_admin"}
+
+        for method, path in sorted(AUTHENTICATED_ROUTES):
+            assert_http_error(
+                401,
+                lambda method=method, path=path: authorize_product_route_request(
+                    conn, method, path, None, None,
+                    require_household_context, require_inventory_write_context, require_platform_admin_user,
+                ),
+            )
+            result = authorize_product_route_request(
+                conn, method, path, "Bearer household-user", None,
+                require_household_context, require_inventory_write_context, require_platform_admin_user,
+            )
+            assert result["active_household_id"] == "h1"
+
+        assert_http_error(
+            403,
+            lambda: authorize_product_route_request(
+                conn, "GET", "/api/inventory/groups", "Bearer other-household", "h1",
+                require_household_context, require_inventory_write_context, require_platform_admin_user,
+            ),
+        )
+        result = authorize_product_route_request(
+            conn, "GET", "/api/inventory/groups", "Bearer household-user", "h1",
+            require_household_context, require_inventory_write_context, require_platform_admin_user,
+        )
+        assert result["active_household_id"] == "h1"
+
+        assert_http_error(
+            403,
+            lambda: authorize_product_route_request(
+                conn, "POST", "/api/inventory/items/i-h1/group", "Bearer viewer", None,
+                require_household_context, require_inventory_write_context, require_platform_admin_user,
+            ),
+        )
+        result = authorize_product_route_request(
+            conn, "POST", "/api/inventory/items/i-h1/group", "Bearer household-user", None,
+            require_household_context, require_inventory_write_context, require_platform_admin_user,
+        )
+        assert result["active_household_id"] == "h1"
+        assert_http_error(
+            403,
+            lambda: authorize_product_route_request(
+                conn, "POST", "/api/inventory/items/i-h1/group", "Bearer other-household", None,
+                require_household_context, require_inventory_write_context, require_platform_admin_user,
+            ),
+        )
+
+    fake_module = SimpleNamespace(
+        engine=engine,
+        MOCK_ARTICLE_OPTIONS=[{"id": "mock", "name": "Mock artikel", "brand": "", "consumable": True}],
+        get_household_article_location_defaults=lambda conn, ids: {},
+        infer_consumable_from_name=lambda name: True,
+        build_live_article_option_id=lambda name: f"live:{name.lower()}",
+    )
+    h1_items = build_store_review_articles(fake_module, "h1", "")
+    names = {item["name"] for item in h1_items}
+    assert "H1 artikel" in names
+    assert "H1 voorraad" in names
+    assert "H2 geheim artikel" not in names
+    assert "H2 geheim" not in names
+    filtered = build_store_review_articles(fake_module, "h1", "voorraad")
+    assert [item["name"] for item in filtered] == ["H1 voorraad"]
+
+    print("PRODUCT_ROUTE_HOUSEHOLD_GUARD_GREEN")
+
+
+if __name__ == "__main__":
+    run_contract()

--- a/docs/quality/M2C2N-CLOSURE-MATRIX.md
+++ b/docs/quality/M2C2N-CLOSURE-MATRIX.md
@@ -64,7 +64,7 @@ Bewezen en hersteld:
 - `GET /api/inventory/groups` valideert membership van het gevraagde huishouden;
 - `POST /api/inventory/items/{inventory_id}/group` bepaalt het owning household server-side en eist inventory-schrijfrecht;
 - zes globale productcatalogusmutaties vereisen platform-admin;
-- globale productcatalogusreads vereisen login;
+- drie globale productcatalogusreads vereisen login;
 - vier purchase-import-line-mutaties blijven afgedekt door de bestaande server-side Uitpakken-objectguard en zijn niet dubbel beveiligd.
 
 Gericht bewijs: `backend/app/testing/product_route_household_guard_contract.py`, de Docker-auditworkflow en alle groene regressie- en releaseworkflows op de WP-3-head.

--- a/docs/quality/M2C2N-CLOSURE-MATRIX.md
+++ b/docs/quality/M2C2N-CLOSURE-MATRIX.md
@@ -1,7 +1,7 @@
 # M2C2n afsluitmatrix
 
 Statusdatum: 2026-07-22  
-Basiscommit: `846b0e42c2c7b58e37de9017be4942dbc6300c41`
+Basiscommit: `e1f67f8606b71a2d18a3fb32b25e9516ef2a07d6`
 
 ## Doel en eindcriteria
 
@@ -24,13 +24,13 @@ Statuswaarden: **GEREED**, **CONTROLE**, **OPEN** en **DEFERRED**. Onbekend bete
 | M2C2N-09 | Resend inbound | Bron server-side huishoudgebonden | Webhookcontract | PR #169–#171 | GEREED | Geen |
 | M2C2N-10 | Live-aliasbackfill | Platformbeheeractie | Platform-admin | PR #172 | GEREED | Geen |
 | M2C2N-11 | Receipt-exportfixtures | Vaste regressiescope | Platform-admin | PR #173 | GEREED | Geen |
-| M2C2N-12 | Product enrichment | Actieve context | Inventory-schrijfrecht | PR #175 | GEREED | Geen |
-| M2C2N-13 | Artikel-ID-mutaties | Actieve context | Inventory-schrijfrecht | PR #176 | GEREED | Geen |
-| M2C2N-14 | Externe productkoppeling | Objecten binnen actief huishouden | Kijker geblokkeerd | WP-1-baseline | CONTROLE | WP-3-contract |
+| M2C2N-12 | Product enrichment | Actieve context | Inventory-schrijfrecht | PR #175 + WP-3 regressie | GEREED | Geen |
+| M2C2N-13 | Artikel-ID-mutaties | Actieve context | Inventory-schrijfrecht | PR #176 + WP-3 regressie | GEREED | Geen |
+| M2C2N-14 | Externe productkoppeling | Actieve huishoudcontext of server-side inventory-eigenaar; globale productcatalogus zonder vrije huishoudscope | Kijker geblokkeerd; globale catalogusmutaties platform-admin | WP-3 audit en productroutecontract | GEREED | Geen |
 | M2C2N-15 | Store-locationdiagnostiek | Vrij huishouden geblokkeerd | Platform-admin | PR #177/WP-2 | GEREED | Geen |
 | M2C2N-16 | Almost-out en inventoryfixtures | Vaste regressiescope | Platform-admin | PR #178/WP-2 | GEREED | Geen |
 | M2C2N-17 | Overige `/api/testing/*` | 38 registraties, 17 mutaties gecatalogiseerd | Alle 17 mutaties centraal platform-admin | WP-2 volledig routecontract; geen dubbelen | GEREED | Geen |
-| M2C2N-18 | Overige product- en artikelroutes | Volledige routescope beschikbaar | Deels bewezen | WP-1 | CONTROLE | WP-3 |
+| M2C2N-18 | Overige product- en artikelroutes | 38 routes beoordeeld: 14 reads en 24 mutaties; huishoudreads gefilterd; purchase-importmutaties via bestaande objectguard | Login voor catalogusreads; inventory-schrijfrecht voor huishoudobject; platform-admin voor globale catalogusmutaties | WP-3 Docker-audit, gericht HTTP-contract en groene regressiegates | GEREED | Geen |
 | M2C2N-19 | Prognoses en AlmostOut-productie | Routescope beschikbaar | Nog niet domeinbreed | WP-1 | OPEN | WP-4 |
 | M2C2N-20 | Inkoop en importinstellingen | Routescope beschikbaar | Deels bewezen | WP-1 | OPEN | WP-4 |
 | M2C2N-21 | Meldingen | Routescope beschikbaar | Nog niet domeinbreed | WP-1 | OPEN | WP-5 |
@@ -54,14 +54,30 @@ Statuswaarden: **GEREED**, **CONTROLE**, **OPEN** en **DEFERRED**. Onbekend bete
 
 De baseline staat in `docs/quality/M2C2N-ROUTE-CATALOG-BASELINE.json`. Iedere routewijziging moet deze baseline en matrix bewust bijwerken.
 
+## WP-3 routescope en bevindingen
+
+De reproduceerbare Docker-audit van WP-3 omvat 38 productie-registraties: 14 leesroutes en 24 mutaties.
+
+Bewezen en hersteld:
+
+- `GET /api/store-review-articles` vereist actieve huishoudcontext en retourneert alleen huishoudartikelen en voorraadnamen van dat actieve huishouden;
+- `GET /api/inventory/groups` valideert membership van het gevraagde huishouden;
+- `POST /api/inventory/items/{inventory_id}/group` bepaalt het owning household server-side en eist inventory-schrijfrecht;
+- zes globale productcatalogusmutaties vereisen platform-admin;
+- globale productcatalogusreads vereisen login;
+- vier purchase-import-line-mutaties blijven afgedekt door de bestaande server-side Uitpakken-objectguard en zijn niet dubbel beveiligd.
+
+Gericht bewijs: `backend/app/testing/product_route_household_guard_contract.py`, de Docker-auditworkflow en alle groene regressie- en releaseworkflows op de WP-3-head.
+
 ## Werkpakketstatus
 
 | Werkpakket | Status | Bewijs/uitvoer |
 |---|---|---|
 | WP-1 — Routecatalogus | GEREED | Generator, Docker-CI en fingerprintbaseline |
-| WP-2 — Testing en platform-admin | IN REVIEW | Algemene guard, 27 mutaties, volledig contract, diagnose-ontdubbeling |
-| WP-3 — Producten en externe productlinks | VOLGENDE | M2C2N-14 en M2C2N-18 |
-| WP-4 t/m WP-7 | NIET GESTART | Volgen in vastgelegde volgorde |
+| WP-2 — Testing en platform-admin | GEREED | Algemene guard, 27 mutaties, volledig contract, diagnose-ontdubbeling; PR #181 gemerged |
+| WP-3 — Producten en externe productlinks | GEREED | 38 routes, Docker-audit, productrouteguard, gericht contract en groene regressiegates |
+| WP-4 — Prognoses en inkoop | VOLGENDE | M2C2N-19 en M2C2N-20 |
+| WP-5 t/m WP-7 | NIET GESTART | Volgen in vastgelegde volgorde |
 
 ## PR-regels
 


### PR DESCRIPTION
## Werkpakket
WP-3 — Producten en externe productlinks.

## Geraakte matrix-ID's
M2C2N-14 en M2C2N-18.

## Complete routescope
De reproduceerbare Docker-audit omvat 38 productie-registraties: 14 reads en 24 mutaties.

## Bewezen tekortkomingen
- `GET /api/store-review-articles` kon zonder autorisatie huishoudartikelen en voorraadnamen over huishoudgrenzen heen lezen;
- `GET /api/inventory/groups` accepteerde een vrij `household_id` zonder membershipcontrole;
- zes globale productcatalogusmutaties hadden geen platform-adminrol.

## Gewijzigd
- reproduceerbare productroute-audit en Docker-workflow;
- centrale productroute-huishoudguard;
- huishoudfiltering van `store-review-articles`;
- membershipcontrole voor `inventory/groups`;
- server-side inventory-eigenaarschap en schrijfrecht voor inventory-groepkoppeling;
- platform-admin voor zes globale productcatalogusmutaties;
- loginplicht voor drie globale catalogusreads;
- gericht HTTP-contract;
- M2C2N-14, M2C2N-18 en WP-3 in de afsluitmatrix op GEREED.

## Bestaande bescherming behouden
Vier purchase-import-line-mutaties blijven afgedekt door de bestaande server-side Uitpakken-objectguard. Product enrichment en artikeldetail blijven hun bestaande schrijfguards gebruiken.

## Niet gewijzigd
- geen frontend;
- geen databaseschema;
- geen routeregistraties of routefingerprint;
- `/api/receipts/share-target` blijft DEFERRED.

## Acceptatie
- alle 12 workflows op headcommit `74337c88ddbfa016e26bb5459818c4689eb3d6f6` groen;
- routecatalogus blijft 194 registraties, 194 unieke methode-padcombinaties en 0 dubbelen;
- QA/QC-goedkeuring vastgelegd;
- merge pas na expliciete PO-GO.