### PR TITLE
M2C2n WP-4: close forecast and purchase route audit

### DIFF
--- a/.github/workflows/m2c2n-forecast-purchase-route-audit.yml
+++ b/.github/workflows/m2c2n-forecast-purchase-route-audit.yml
@@ -31,6 +31,14 @@ jobs:
           grep -F 'M2C2N_FORECAST_PURCHASE_ROUTE_AUDIT_GREEN' forecast-purchase-route-audit.log
           test -s forecast-purchase-route-audit-output/M2C2N-FORECAST-PURCHASE-ROUTE-AUDIT.json
 
+      - name: Controleer volledige WP-4-routedekking
+        run: |
+          docker compose run --rm --no-deps \
+            backend \
+            python -m app.testing.forecast_purchase_route_contract \
+            | tee forecast-purchase-route-contract.log
+          grep -F 'M2C2N_FORECAST_PURCHASE_ROUTE_CONTRACT_GREEN' forecast-purchase-route-contract.log
+
       - name: Publiceer forecast- en purchaseroute-audit
         if: always()
         uses: actions/upload-artifact@v4
@@ -39,5 +47,6 @@ jobs:
           path: |
             forecast-purchase-route-audit-output/M2C2N-FORECAST-PURCHASE-ROUTE-AUDIT.json
             forecast-purchase-route-audit.log
+            forecast-purchase-route-contract.log
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/m2c2n-forecast-purchase-route-audit.yml
+++ b/.github/workflows/m2c2n-forecast-purchase-route-audit.yml
@@ -1,0 +1,43 @@
+name: M2C2n forecast and purchase route audit
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  audit-forecast-purchase-routes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Controleer Docker Compose
+        run: docker compose version
+
+      - name: Bouw backend-image
+        run: docker compose build backend
+
+      - name: Genereer forecast- en purchaseroute-audit
+        run: |
+          mkdir -p forecast-purchase-route-audit-output
+          docker compose run --rm --no-deps \
+            -v "$PWD/forecast-purchase-route-audit-output:/tmp/m2c2n-forecast-purchase-route-audit" \
+            backend \
+            python -m app.testing.forecast_purchase_route_audit \
+              --output /tmp/m2c2n-forecast-purchase-route-audit/M2C2N-FORECAST-PURCHASE-ROUTE-AUDIT.json \
+            | tee forecast-purchase-route-audit.log
+          grep -F 'M2C2N_FORECAST_PURCHASE_ROUTE_AUDIT_GREEN' forecast-purchase-route-audit.log
+          test -s forecast-purchase-route-audit-output/M2C2N-FORECAST-PURCHASE-ROUTE-AUDIT.json
+
+      - name: Publiceer forecast- en purchaseroute-audit
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: m2c2n-forecast-purchase-route-audit
+          path: |
+            forecast-purchase-route-audit-output/M2C2N-FORECAST-PURCHASE-ROUTE-AUDIT.json
+            forecast-purchase-route-audit.log
+          if-no-files-found: error
+          retention-days: 30

--- a/backend/app/testing/forecast_purchase_route_audit.py
+++ b/backend/app/testing/forecast_purchase_route_audit.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import argparse
+import inspect
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from app.main import app
+
+TARGET_TERMS = (
+    "almost-out",
+    "almost_out",
+    "prediction",
+    "forecast",
+    "prognos",
+    "purchase",
+    "procurement",
+    "inkoop",
+    "import-setting",
+    "import_setting",
+)
+AUTH_MARKERS = (
+    "require_household_context",
+    "require_inventory_write_context",
+    "require_household_admin_context",
+    "require_household_permission",
+    "require_platform_admin_user",
+    "get_request_household_id",
+)
+HOUSEHOLD_MARKERS = (
+    "household_id",
+    "active_household_id",
+    "inventory_id",
+    "batch_id",
+    "line_id",
+    "article_id",
+)
+MUTATION_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+
+
+def wait_for_stable_routes() -> None:
+    previous: tuple[tuple[str, tuple[str, ...]], ...] | None = None
+    stable_rounds = 0
+    for _ in range(200):
+        signature = tuple(
+            sorted(
+                (
+                    str(getattr(route, "path", "") or ""),
+                    tuple(sorted(str(method) for method in (getattr(route, "methods", None) or []))),
+                )
+                for route in app.routes
+            )
+        )
+        if signature == previous:
+            stable_rounds += 1
+            if stable_rounds >= 10:
+                return
+        else:
+            previous = signature
+            stable_rounds = 0
+        time.sleep(0.1)
+    raise RuntimeError("FastAPI-routeset werd niet stabiel")
+
+
+def is_target_path(path: str) -> bool:
+    lowered = str(path or "").lower()
+    return any(term in lowered for term in TARGET_TERMS)
+
+
+def endpoint_source(endpoint: Any) -> tuple[str, str | None, int | None]:
+    try:
+        source = inspect.getsource(endpoint)
+    except (OSError, TypeError):
+        source = ""
+    try:
+        file_name = inspect.getsourcefile(endpoint)
+    except (OSError, TypeError):
+        file_name = None
+    try:
+        first_line = inspect.getsourcelines(endpoint)[1]
+    except (OSError, TypeError):
+        first_line = None
+    return source, file_name, first_line
+
+
+def audit_routes() -> dict[str, Any]:
+    wait_for_stable_routes()
+    rows: list[dict[str, Any]] = []
+    for route in app.routes:
+        path = str(getattr(route, "path", "") or "")
+        if not is_target_path(path):
+            continue
+        endpoint = getattr(route, "endpoint", None)
+        source, source_file, first_line = endpoint_source(endpoint)
+        lowered = source.lower()
+        signature = str(inspect.signature(endpoint)) if endpoint is not None else ""
+        for method in sorted(str(item) for item in (getattr(route, "methods", None) or [])):
+            if method in {"HEAD", "OPTIONS"}:
+                continue
+            rows.append(
+                {
+                    "method": method,
+                    "path": path,
+                    "access": "mutation" if method in MUTATION_METHODS else "read",
+                    "endpoint": str(getattr(endpoint, "__qualname__", "") or ""),
+                    "module": str(getattr(endpoint, "__module__", "") or ""),
+                    "signature": signature,
+                    "source_file": source_file,
+                    "first_line": first_line,
+                    "authorization_parameter": "authorization" in signature.lower(),
+                    "auth_markers": [marker for marker in AUTH_MARKERS if marker.lower() in lowered],
+                    "household_markers": [marker for marker in HOUSEHOLD_MARKERS if marker.lower() in lowered],
+                    "source": source,
+                }
+            )
+    rows.sort(key=lambda item: (item["path"], item["method"], item["module"], item["endpoint"]))
+    mutations = [item for item in rows if item["access"] == "mutation"]
+    reads = [item for item in rows if item["access"] == "read"]
+    without_auth = [
+        f"{item['method']} {item['path']} :: {item['module']}.{item['endpoint']}"
+        for item in rows
+        if not item["authorization_parameter"] and not item["auth_markers"]
+    ]
+    mutation_without_auth = [
+        f"{item['method']} {item['path']} :: {item['module']}.{item['endpoint']}"
+        for item in mutations
+        if not item["authorization_parameter"] and not item["auth_markers"]
+    ]
+    return {
+        "audit_version": 1,
+        "summary": {
+            "route_registrations": len(rows),
+            "reads": len(reads),
+            "mutations": len(mutations),
+            "routes_without_auth_marker": len(without_auth),
+            "mutations_without_auth_marker": len(mutation_without_auth),
+        },
+        "routes_without_auth_marker": without_auth,
+        "mutations_without_auth_marker": mutation_without_auth,
+        "routes": rows,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    payload = audit_routes()
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(json.dumps(payload["summary"], ensure_ascii=False, sort_keys=True))
+    print("M2C2N_FORECAST_PURCHASE_ROUTE_AUDIT_GREEN")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/testing/forecast_purchase_route_contract.py
+++ b/backend/app/testing/forecast_purchase_route_contract.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from app.services.platform_admin_route_guard import PROTECTED_MUTATIONS
+from app.services.unpacking_household_object_guard import authorize_purchase_import_request
+from app.testing.forecast_purchase_route_audit import audit_routes
+
+
+EXPECTED_ROUTE_KEYS = {
+    ("POST", "/api/admin/backfill-purchase-import-live-aliases"),
+    ("GET", "/api/household/almost-out-settings"),
+    ("PUT", "/api/household/almost-out-settings"),
+    ("GET", "/api/household/store-import-settings"),
+    ("PUT", "/api/household/store-import-settings"),
+    ("GET", "/api/households/{household_id}/almost-out"),
+    ("GET", "/api/purchase-import-batches/{batch_id}"),
+    ("POST", "/api/purchase-import-batches/{batch_id}/complete-review"),
+    ("POST", "/api/purchase-import-batches/{batch_id}/prefill"),
+    ("POST", "/api/purchase-import-batches/{batch_id}/process"),
+    ("POST", "/api/purchase-import-lines/{line_id}/article-group"),
+    ("POST", "/api/purchase-import-lines/{line_id}/create-article"),
+    ("GET", "/api/purchase-import-lines/{line_id}/external-product-candidates"),
+    ("POST", "/api/purchase-import-lines/{line_id}/external-product-candidates/search"),
+    ("POST", "/api/purchase-import-lines/{line_id}/map"),
+    ("POST", "/api/purchase-import-lines/{line_id}/review"),
+    ("POST", "/api/purchase-import-lines/{line_id}/target-location"),
+    ("POST", "/api/purchases/barcode"),
+    ("POST", "/api/purchases/manual"),
+    ("POST", "/api/store-connections/{connection_id}/pull-purchases"),
+    ("GET", "/api/testing/diagnostics/purchase-import-batches/{batch_id}"),
+    ("POST", "/api/testing/regression/almost-out-prediction"),
+    ("POST", "/api/testing/regression/almost-out-self-test"),
+}
+
+PLATFORM_ADMIN_KEYS = {
+    ("POST", "/api/admin/backfill-purchase-import-live-aliases"),
+    ("POST", "/api/testing/regression/almost-out-prediction"),
+    ("POST", "/api/testing/regression/almost-out-self-test"),
+}
+
+OBJECT_GUARD_KEYS = {
+    key
+    for key in EXPECTED_ROUTE_KEYS
+    if key[1].startswith("/api/purchase-import-batches/")
+    or key[1].startswith("/api/purchase-import-lines/")
+}
+
+INLINE_KEYS = EXPECTED_ROUTE_KEYS - PLATFORM_ADMIN_KEYS - OBJECT_GUARD_KEYS
+
+EXPECTED_INLINE_MARKERS = {
+    ("GET", "/api/household/almost-out-settings"): {"require_household_context"},
+    ("PUT", "/api/household/almost-out-settings"): {"require_household_admin_context"},
+    ("GET", "/api/household/store-import-settings"): {"require_household_context"},
+    ("PUT", "/api/household/store-import-settings"): {"require_household_admin_context"},
+    ("GET", "/api/households/{household_id}/almost-out"): {"require_household_context"},
+    ("POST", "/api/purchases/barcode"): {"require_inventory_write_context"},
+    ("POST", "/api/purchases/manual"): {"require_inventory_write_context"},
+    ("POST", "/api/store-connections/{connection_id}/pull-purchases"): {"require_household_admin_context"},
+    ("GET", "/api/testing/diagnostics/purchase-import-batches/{batch_id}"): {"require_platform_admin_user"},
+}
+
+
+@dataclass
+class _Result:
+    household_id: str
+
+    def mappings(self) -> "_Result":
+        return self
+
+    def first(self) -> dict[str, str]:
+        return {"household_id": self.household_id}
+
+
+class _Connection:
+    def __init__(self, household_id: str = "household-a") -> None:
+        self.household_id = household_id
+
+    def execute(self, _statement: Any, _params: dict[str, Any]) -> _Result:
+        return _Result(self.household_id)
+
+
+def _assert_object_guard_contract() -> None:
+    calls: list[tuple[str, str | None, str | None]] = []
+
+    def require_context(authorization: str | None, household_id: str | None) -> dict[str, str | None]:
+        calls.append(("read", authorization, household_id))
+        return {"active_household_id": household_id}
+
+    def require_write(authorization: str | None, household_id: str | None) -> dict[str, str | None]:
+        calls.append(("write", authorization, household_id))
+        return {"active_household_id": household_id}
+
+    conn = _Connection()
+    authorize_purchase_import_request(
+        conn,
+        "GET",
+        "/api/purchase-import-batches/batch-1",
+        "Bearer member",
+        require_context,
+        require_write,
+    )
+    authorize_purchase_import_request(
+        conn,
+        "POST",
+        "/api/purchase-import-lines/line-1/review",
+        "Bearer member",
+        require_context,
+        require_write,
+    )
+    assert calls == [
+        ("read", "Bearer member", "household-a"),
+        ("write", "Bearer member", "household-a"),
+    ], calls
+
+
+def main() -> None:
+    payload = audit_routes()
+    rows = payload["routes"]
+    route_map = {(row["method"], row["path"]): row for row in rows}
+    actual_keys = set(route_map)
+
+    assert actual_keys == EXPECTED_ROUTE_KEYS, {
+        "missing": sorted(EXPECTED_ROUTE_KEYS - actual_keys),
+        "unexpected": sorted(actual_keys - EXPECTED_ROUTE_KEYS),
+    }
+    assert payload["summary"] == {
+        "route_registrations": 23,
+        "reads": 6,
+        "mutations": 17,
+        "routes_without_auth_marker": 11,
+        "mutations_without_auth_marker": 9,
+    }, payload["summary"]
+
+    assert len(OBJECT_GUARD_KEYS) == 11, OBJECT_GUARD_KEYS
+    assert len(PLATFORM_ADMIN_KEYS) == 3, PLATFORM_ADMIN_KEYS
+    assert len(INLINE_KEYS) == 9, INLINE_KEYS
+
+    for key in PLATFORM_ADMIN_KEYS:
+        assert key in PROTECTED_MUTATIONS, key
+
+    for key, expected_markers in EXPECTED_INLINE_MARKERS.items():
+        row = route_map[key]
+        assert row["authorization_parameter"], key
+        assert expected_markers.issubset(set(row["auth_markers"])), {
+            "route": key,
+            "expected": sorted(expected_markers),
+            "actual": row["auth_markers"],
+        }
+
+    for key in OBJECT_GUARD_KEYS:
+        row = route_map[key]
+        assert row["path"].startswith(
+            ("/api/purchase-import-batches/", "/api/purchase-import-lines/")
+        ), key
+
+    _assert_object_guard_contract()
+    print("M2C2N_FORECAST_PURCHASE_ROUTE_CONTRACT_GREEN")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/quality/M2C2N-CLOSURE-MATRIX.md
+++ b/docs/quality/M2C2N-CLOSURE-MATRIX.md
@@ -1,7 +1,7 @@
 # M2C2n afsluitmatrix
 
 Statusdatum: 2026-07-22  
-Basiscommit: `e1f67f8606b71a2d18a3fb32b25e9516ef2a07d6`
+Basiscommit: `6f6993166676d9c75be3d83452ffe95b9ba785e3`
 
 ## Doel en eindcriteria
 
@@ -31,8 +31,8 @@ Statuswaarden: **GEREED**, **CONTROLE**, **OPEN** en **DEFERRED**. Onbekend bete
 | M2C2N-16 | Almost-out en inventoryfixtures | Vaste regressiescope | Platform-admin | PR #178/WP-2 | GEREED | Geen |
 | M2C2N-17 | Overige `/api/testing/*` | 38 registraties, 17 mutaties gecatalogiseerd | Alle 17 mutaties centraal platform-admin | WP-2 volledig routecontract; geen dubbelen | GEREED | Geen |
 | M2C2N-18 | Overige product- en artikelroutes | 38 routes beoordeeld: 14 reads en 24 mutaties; huishoudreads gefilterd; purchase-importmutaties via bestaande objectguard | Login voor catalogusreads; inventory-schrijfrecht voor huishoudobject; platform-admin voor globale catalogusmutaties | WP-3 Docker-audit, gericht HTTP-contract en groene regressiegates | GEREED | Geen |
-| M2C2N-19 | Prognoses en AlmostOut-productie | Routescope beschikbaar | Nog niet domeinbreed | WP-1 | OPEN | WP-4 |
-| M2C2N-20 | Inkoop en importinstellingen | Routescope beschikbaar | Deels bewezen | WP-1 | OPEN | WP-4 |
+| M2C2N-19 | Prognoses en AlmostOut-productie | 5 huishoudroutes gebruiken actieve of expliciet gevalideerde huishoudcontext; testingmutaties hebben geen huishoudscope | Reads vereisen membership; instellingenmutatie vereist huishoudadmin; testingmutaties platform-admin | WP-4 Docker-audit en volledig 23-routecontract | GEREED | Geen |
+| M2C2N-20 | Inkoop en importinstellingen | 11 batch-/regelroutes bepalen owning household server-side; aankopen gebruiken actieve huishoudcontext; winkelimportkoppeling is huishoudadmin | Reads membership; batch-/regelmutaties inventory-schrijfrecht; importinstellingen en winkelpull huishoudadmin; adminbackfill platform-admin | WP-4 Docker-audit, bestaande Uitpakken-objectguard en volledig 23-routecontract | GEREED | Geen |
 | M2C2N-21 | Meldingen | Routescope beschikbaar | Nog niet domeinbreed | WP-1 | OPEN | WP-5 |
 | M2C2N-22 | Fallbacks `"1"` en `"demo-household"` | Nog te classificeren | n.v.t. | WP-1 | OPEN | WP-6 |
 | M2C2N-23 | `/api/receipts/share-target` | Vrij `household_id` is niet eindontwerp | Toekomstig signed token | Ontwerpbesluit | DEFERRED | Later apart ontwerp |
@@ -69,15 +69,30 @@ Bewezen en hersteld:
 
 Gericht bewijs: `backend/app/testing/product_route_household_guard_contract.py`, de Docker-auditworkflow en alle groene regressie- en releaseworkflows op de WP-3-head.
 
+## WP-4 routescope en bevindingen
+
+De reproduceerbare Docker-audit van WP-4 omvat 23 registraties: 6 leesroutes en 17 mutaties.
+
+De volledige routescope valt in drie bewezen beschermingslagen:
+
+- 11 purchase-import batch-/regelroutes worden door `unpacking_household_object_guard.py` server-side aan het owning household gebonden; reads vereisen membership en mutaties inventory-schrijfrecht;
+- 3 admin/testingmutaties staan in de centrale `platform_admin_route_guard.py`;
+- 9 overige routes hebben expliciete endpointcontrole: huishoudcontext, huishoudadmin, inventory-schrijfrecht of platform-admin.
+
+Er is geen nieuw onbeveiligd productiepad bewezen. WP-4 voegt daarom geen extra productiemiddleware toe. Het gerichte contract legt de exacte 23 methode-padcombinaties, hun beschermingslaag en de read/write-afhandeling van de Uitpakken-objectguard vast.
+
+Gericht bewijs: `backend/app/testing/forecast_purchase_route_contract.py` en `.github/workflows/m2c2n-forecast-purchase-route-audit.yml`.
+
 ## Werkpakketstatus
 
 | Werkpakket | Status | Bewijs/uitvoer |
 |---|---|---|
 | WP-1 — Routecatalogus | GEREED | Generator, Docker-CI en fingerprintbaseline |
 | WP-2 — Testing en platform-admin | GEREED | Algemene guard, 27 mutaties, volledig contract, diagnose-ontdubbeling; PR #181 gemerged |
-| WP-3 — Producten en externe productlinks | GEREED | 38 routes, Docker-audit, productrouteguard, gericht contract en groene regressiegates |
-| WP-4 — Prognoses en inkoop | VOLGENDE | M2C2N-19 en M2C2N-20 |
-| WP-5 t/m WP-7 | NIET GESTART | Volgen in vastgelegde volgorde |
+| WP-3 — Producten en externe productlinks | GEREED | 38 routes, Docker-audit, productrouteguard, gericht contract en groene regressiegates; PR #182 gemerged |
+| WP-4 — Prognoses en inkoop | GEREED | 23 routes, Docker-audit, drie bewezen beschermingslagen en volledig dekkingscontract |
+| WP-5 — Meldingen | VOLGENDE | M2C2N-21 |
+| WP-6 en WP-7 | NIET GESTART | Volgen in vastgelegde volgorde |
 
 ## PR-regels
 


### PR DESCRIPTION
## Werkpakket
WP-4 — Prognoses en inkoop/importinstellingen.

## Geraakte matrix-ID's
M2C2N-19 en M2C2N-20.

## Complete routescope
De reproduceerbare Docker-audit omvat 23 registraties: 6 reads en 17 mutaties.

## Bewezen beschermingslagen
- 11 purchase-import batch-/regelroutes vallen onder de server-side Uitpakken-objectguard: reads vereisen membership, mutaties inventory-schrijfrecht;
- 3 admin/testingmutaties vallen onder de centrale platform-adminguard;
- 9 overige routes hebben expliciete endpointcontrole via huishoudcontext, huishoudadmin, inventory-schrijfrecht of platform-admin.

## Uitkomst
Er is geen nieuw onbeveiligd productiepad bewezen. WP-4 voegt daarom geen nieuwe productiemiddleware toe.

## Gewijzigd
- reproduceerbare forecast- en purchaseroute-audit;
- Docker-workflow en artifact;
- volledig 23-routesdekkingscontract;
- M2C2N-19, M2C2N-20 en WP-4 in de afsluitmatrix op GEREED.

## Niet gewijzigd
- geen productiecode;
- geen frontend;
- geen databaseschema;
- geen route-URL's of routefingerprint;
- `/api/receipts/share-target` blijft DEFERRED.

## Acceptatie
- alle 13 workflows op headcommit `a4dc873761afec39c520133f23146fee1dffa41c` groen;
- routecatalogus blijft 194 registraties, 194 unieke methode-padcombinaties en 0 dubbelen;
- QA/QC-goedkeuring wordt vastgelegd;
- merge pas na expliciete PO-GO.