### PR TITLE
M2C2n WP-5: close notification route audit

### DIFF
--- a/.github/workflows/m2c2n-notification-route-audit.yml
+++ b/.github/workflows/m2c2n-notification-route-audit.yml
@@ -1,0 +1,43 @@
+name: M2C2n notification route audit
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  audit-notification-routes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Controleer Docker Compose
+        run: docker compose version
+
+      - name: Bouw backend-image
+        run: docker compose build backend
+
+      - name: Genereer notification-routeaudit
+        run: |
+          mkdir -p notification-route-audit-output
+          docker compose run --rm --no-deps \
+            -v "$PWD/notification-route-audit-output:/tmp/m2c2n-notification-route-audit" \
+            backend \
+            python -m app.testing.notification_route_audit \
+              --output /tmp/m2c2n-notification-route-audit/M2C2N-NOTIFICATION-ROUTE-AUDIT.json \
+            | tee notification-route-audit.log
+          grep -F 'M2C2N_NOTIFICATION_ROUTE_AUDIT_GREEN' notification-route-audit.log
+          test -s notification-route-audit-output/M2C2N-NOTIFICATION-ROUTE-AUDIT.json
+
+      - name: Publiceer notification-routeaudit
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: m2c2n-notification-route-audit
+          path: |
+            notification-route-audit-output/M2C2N-NOTIFICATION-ROUTE-AUDIT.json
+            notification-route-audit.log
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/m2c2n-notification-route-audit.yml
+++ b/.github/workflows/m2c2n-notification-route-audit.yml
@@ -31,6 +31,11 @@ jobs:
           grep -F 'M2C2N_NOTIFICATION_ROUTE_AUDIT_GREEN' notification-route-audit.log
           test -s notification-route-audit-output/M2C2N-NOTIFICATION-ROUTE-AUDIT.json
 
+      - name: Controleer actuele afwezigheid meldingsroutes
+        run: |
+          docker compose run --rm --no-deps backend \
+            python -m app.testing.notification_route_contract
+
       - name: Publiceer notification-routeaudit
         if: always()
         uses: actions/upload-artifact@v4

--- a/backend/app/testing/notification_route_audit.py
+++ b/backend/app/testing/notification_route_audit.py
@@ -10,7 +10,14 @@ from typing import Any
 from app.main import app
 
 MUTATION_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
-TARGET_TERMS = ("notification", "notifications", "melding", "meldingen")
+TARGET_TERMS = (
+    "notification",
+    "notifications",
+    "melding",
+    "meldingen",
+    "alert",
+    "alerts",
+)
 AUTH_MARKERS = (
     "require_household_context",
     "require_household_admin_context",
@@ -68,10 +75,10 @@ def endpoint_source(endpoint: Any) -> tuple[str, str | None, int | None]:
     return source, source_file, first_line
 
 
-def is_target_route(path: str, endpoint: Any) -> bool:
+def is_target_route(path: str, endpoint: Any, source: str) -> bool:
     endpoint_name = str(getattr(endpoint, "__qualname__", "") or "").lower()
     module_name = str(getattr(endpoint, "__module__", "") or "").lower()
-    haystack = " ".join((path.lower(), endpoint_name, module_name))
+    haystack = " ".join((path.lower(), endpoint_name, module_name, source.lower()))
     return any(term in haystack for term in TARGET_TERMS)
 
 
@@ -81,9 +88,9 @@ def audit_routes() -> dict[str, Any]:
     for route in app.routes:
         path = str(getattr(route, "path", "") or "")
         endpoint = getattr(route, "endpoint", None)
-        if not is_target_route(path, endpoint):
-            continue
         source, source_file, first_line = endpoint_source(endpoint)
+        if not is_target_route(path, endpoint, source):
+            continue
         lowered = source.lower()
         signature = str(inspect.signature(endpoint)) if endpoint is not None else ""
         for method in sorted(str(item) for item in (getattr(route, "methods", None) or [])):
@@ -102,6 +109,7 @@ def audit_routes() -> dict[str, Any]:
                     "authorization_parameter": "authorization" in signature.lower(),
                     "auth_markers": [marker for marker in AUTH_MARKERS if marker.lower() in lowered],
                     "household_markers": [marker for marker in HOUSEHOLD_MARKERS if marker.lower() in lowered],
+                    "matched_terms": [term for term in TARGET_TERMS if term in " ".join((path.lower(), str(getattr(endpoint, "__qualname__", "") or "").lower(), str(getattr(endpoint, "__module__", "") or "").lower(), lowered))],
                     "source": source,
                 }
             )
@@ -114,7 +122,7 @@ def audit_routes() -> dict[str, Any]:
         if not item["authorization_parameter"] and not item["auth_markers"]
     ]
     return {
-        "audit_version": 1,
+        "audit_version": 2,
         "summary": {
             "route_registrations": len(rows),
             "reads": len(reads),

--- a/backend/app/testing/notification_route_audit.py
+++ b/backend/app/testing/notification_route_audit.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import argparse
+import inspect
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from app.main import app
+
+MUTATION_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+TARGET_TERMS = ("notification", "notifications", "melding", "meldingen")
+AUTH_MARKERS = (
+    "require_household_context",
+    "require_household_admin_context",
+    "require_inventory_write_context",
+    "require_household_permission",
+    "require_platform_admin_user",
+    "get_request_household_id",
+)
+HOUSEHOLD_MARKERS = (
+    "household_id",
+    "active_household_id",
+    "notification_id",
+    "message_id",
+    "user_id",
+)
+
+
+def wait_for_stable_routes() -> None:
+    previous: tuple[tuple[str, tuple[str, ...]], ...] | None = None
+    stable_rounds = 0
+    for _ in range(200):
+        signature = tuple(
+            sorted(
+                (
+                    str(getattr(route, "path", "") or ""),
+                    tuple(sorted(str(method) for method in (getattr(route, "methods", None) or []))),
+                )
+                for route in app.routes
+            )
+        )
+        if signature == previous:
+            stable_rounds += 1
+            if stable_rounds >= 10:
+                return
+        else:
+            previous = signature
+            stable_rounds = 0
+        time.sleep(0.1)
+    raise RuntimeError("FastAPI-routeset werd niet stabiel")
+
+
+def endpoint_source(endpoint: Any) -> tuple[str, str | None, int | None]:
+    try:
+        source = inspect.getsource(endpoint)
+    except (OSError, TypeError):
+        source = ""
+    try:
+        source_file = inspect.getsourcefile(endpoint)
+    except (OSError, TypeError):
+        source_file = None
+    try:
+        first_line = inspect.getsourcelines(endpoint)[1]
+    except (OSError, TypeError):
+        first_line = None
+    return source, source_file, first_line
+
+
+def is_target_route(path: str, endpoint: Any) -> bool:
+    endpoint_name = str(getattr(endpoint, "__qualname__", "") or "").lower()
+    module_name = str(getattr(endpoint, "__module__", "") or "").lower()
+    haystack = " ".join((path.lower(), endpoint_name, module_name))
+    return any(term in haystack for term in TARGET_TERMS)
+
+
+def audit_routes() -> dict[str, Any]:
+    wait_for_stable_routes()
+    rows: list[dict[str, Any]] = []
+    for route in app.routes:
+        path = str(getattr(route, "path", "") or "")
+        endpoint = getattr(route, "endpoint", None)
+        if not is_target_route(path, endpoint):
+            continue
+        source, source_file, first_line = endpoint_source(endpoint)
+        lowered = source.lower()
+        signature = str(inspect.signature(endpoint)) if endpoint is not None else ""
+        for method in sorted(str(item) for item in (getattr(route, "methods", None) or [])):
+            if method in {"HEAD", "OPTIONS"}:
+                continue
+            rows.append(
+                {
+                    "method": method,
+                    "path": path,
+                    "access": "mutation" if method in MUTATION_METHODS else "read",
+                    "endpoint": str(getattr(endpoint, "__qualname__", "") or ""),
+                    "module": str(getattr(endpoint, "__module__", "") or ""),
+                    "signature": signature,
+                    "source_file": source_file,
+                    "first_line": first_line,
+                    "authorization_parameter": "authorization" in signature.lower(),
+                    "auth_markers": [marker for marker in AUTH_MARKERS if marker.lower() in lowered],
+                    "household_markers": [marker for marker in HOUSEHOLD_MARKERS if marker.lower() in lowered],
+                    "source": source,
+                }
+            )
+    rows.sort(key=lambda item: (item["path"], item["method"], item["module"], item["endpoint"]))
+    reads = [item for item in rows if item["access"] == "read"]
+    mutations = [item for item in rows if item["access"] == "mutation"]
+    mutation_without_auth_marker = [
+        f"{item['method']} {item['path']} :: {item['module']}.{item['endpoint']}"
+        for item in mutations
+        if not item["authorization_parameter"] and not item["auth_markers"]
+    ]
+    return {
+        "audit_version": 1,
+        "summary": {
+            "route_registrations": len(rows),
+            "reads": len(reads),
+            "mutations": len(mutations),
+            "mutation_without_auth_marker": len(mutation_without_auth_marker),
+        },
+        "mutation_without_auth_marker": mutation_without_auth_marker,
+        "routes": rows,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    payload = audit_routes()
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(json.dumps(payload["summary"], ensure_ascii=False, sort_keys=True))
+    print("M2C2N_NOTIFICATION_ROUTE_AUDIT_GREEN")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/testing/notification_route_contract.py
+++ b/backend/app/testing/notification_route_contract.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from app.testing.notification_route_audit import audit_routes
+
+
+def main() -> None:
+    payload = audit_routes()
+    summary = payload["summary"]
+    assert summary == {
+        "route_registrations": 0,
+        "reads": 0,
+        "mutations": 0,
+        "mutation_without_auth_marker": 0,
+    }, summary
+    assert payload["routes"] == [], payload["routes"]
+    assert payload["mutation_without_auth_marker"] == [], payload["mutation_without_auth_marker"]
+    print("M2C2N_NOTIFICATION_ROUTE_CONTRACT_GREEN")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/quality/M2C2N-CLOSURE-MATRIX.md
+++ b/docs/quality/M2C2N-CLOSURE-MATRIX.md
@@ -1,7 +1,7 @@
 # M2C2n afsluitmatrix
 
 Statusdatum: 2026-07-22  
-Basiscommit: `6f6993166676d9c75be3d83452ffe95b9ba785e3`
+Basiscommit: `9fc9da6da6b327a76f7e6eea3da61698aca93491`
 
 ## Doel en eindcriteria
 
@@ -33,7 +33,7 @@ Statuswaarden: **GEREED**, **CONTROLE**, **OPEN** en **DEFERRED**. Onbekend bete
 | M2C2N-18 | Overige product- en artikelroutes | 38 routes beoordeeld: 14 reads en 24 mutaties; huishoudreads gefilterd; purchase-importmutaties via bestaande objectguard | Login voor catalogusreads; inventory-schrijfrecht voor huishoudobject; platform-admin voor globale catalogusmutaties | WP-3 Docker-audit, gericht HTTP-contract en groene regressiegates | GEREED | Geen |
 | M2C2N-19 | Prognoses en AlmostOut-productie | 5 huishoudroutes gebruiken actieve of expliciet gevalideerde huishoudcontext; testingmutaties hebben geen huishoudscope | Reads vereisen membership; instellingenmutatie vereist huishoudadmin; testingmutaties platform-admin | WP-4 Docker-audit en volledig 23-routecontract | GEREED | Geen |
 | M2C2N-20 | Inkoop en importinstellingen | 11 batch-/regelroutes bepalen owning household server-side; aankopen gebruiken actieve huishoudcontext; winkelimportkoppeling is huishoudadmin | Reads membership; batch-/regelmutaties inventory-schrijfrecht; importinstellingen en winkelpull huishoudadmin; adminbackfill platform-admin | WP-4 Docker-audit, bestaande Uitpakken-objectguard en volledig 23-routecontract | GEREED | Geen |
-| M2C2N-21 | Meldingen | Routescope beschikbaar | Nog niet domeinbreed | WP-1 | OPEN | WP-5 |
+| M2C2N-21 | Meldingen | Actuele runtime bevat geen notification-, melding- of alertroutes; er bestaat dus geen huishoudgebonden meldingsobject | Geen lees-, markeer-, verwijder- of beheerroute aanwezig | WP-5 Docker-audit doorzoekt pad, endpoint, module en endpointbron; nul routes contractueel afgedwongen | GEREED | Bij toekomstige implementatie nieuwe matrixcontrole verplicht |
 | M2C2N-22 | Fallbacks `"1"` en `"demo-household"` | Nog te classificeren | n.v.t. | WP-1 | OPEN | WP-6 |
 | M2C2N-23 | `/api/receipts/share-target` | Vrij `household_id` is niet eindontwerp | Toekomstig signed token | Ontwerpbesluit | DEFERRED | Later apart ontwerp |
 | M2C2N-24 | Platform-admin-routeguard | Centrale expliciete routescope | Platform-admin voor 27 mutaties | Algemene guard en volledig contract | GEREED | Legacy importshim later regulier opruimen |
@@ -83,6 +83,16 @@ Er is geen nieuw onbeveiligd productiepad bewezen. WP-4 voegt daarom geen extra 
 
 Gericht bewijs: `backend/app/testing/forecast_purchase_route_contract.py` en `.github/workflows/m2c2n-forecast-purchase-route-audit.yml`.
 
+## WP-5 routescope en bevindingen
+
+De reproduceerbare Docker-audit doorzoekt alle actieve FastAPI-routes op notification-, melding- en alerttermen in pad, endpointnaam, module en volledige endpointbron.
+
+Uitkomst: nul leesroutes en nul mutaties. Ook het actuele Startscherm bevat geen meldingentabel of meldingen-API-aanroep. Er is daarom geen bestaand meldingsobject waarop huishoudisolatie of rolgrenzen kunnen worden toegepast.
+
+Het contract faalt zodra later wel een meldingsroute wordt toegevoegd. Die toekomstige implementatie moet dan eerst opnieuw worden geïnventariseerd en beveiligd voordat de matrix kan worden bijgewerkt.
+
+Gericht bewijs: `backend/app/testing/notification_route_contract.py` en `.github/workflows/m2c2n-notification-route-audit.yml`.
+
 ## Werkpakketstatus
 
 | Werkpakket | Status | Bewijs/uitvoer |
@@ -90,9 +100,10 @@ Gericht bewijs: `backend/app/testing/forecast_purchase_route_contract.py` en `.g
 | WP-1 — Routecatalogus | GEREED | Generator, Docker-CI en fingerprintbaseline |
 | WP-2 — Testing en platform-admin | GEREED | Algemene guard, 27 mutaties, volledig contract, diagnose-ontdubbeling; PR #181 gemerged |
 | WP-3 — Producten en externe productlinks | GEREED | 38 routes, Docker-audit, productrouteguard, gericht contract en groene regressiegates; PR #182 gemerged |
-| WP-4 — Prognoses en inkoop | GEREED | 23 routes, Docker-audit, drie bewezen beschermingslagen en volledig dekkingscontract |
-| WP-5 — Meldingen | VOLGENDE | M2C2N-21 |
-| WP-6 en WP-7 | NIET GESTART | Volgen in vastgelegde volgorde |
+| WP-4 — Prognoses en inkoop | GEREED | 23 routes, Docker-audit, drie bewezen beschermingslagen en volledig dekkingscontract; PR #183 gemerged |
+| WP-5 — Meldingen | GEREED | Nul actuele meldingsroutes, brede Docker-audit en afwezigheidscontract |
+| WP-6 — Fallbacks | VOLGENDE | M2C2N-22 |
+| WP-7 — Eindrapport | NIET GESTART | Volgt na WP-6 |
 
 ## PR-regels
 


### PR DESCRIPTION
## Werkpakket
WP-5 — Meldingen.

## Geraakte matrix-ID
M2C2N-21.

## Complete routescope
De reproduceerbare Docker-audit doorzoekt alle actieve FastAPI-routes op notification-, melding- en alerttermen in pad, endpointnaam, module en volledige endpointbron.

## Uitkomst
De actuele runtime bevat 0 meldingsroutes: 0 reads en 0 mutaties. Ook het huidige Startscherm gebruikt geen meldingen-API.

Er is daarom geen bestaand huishoudgebonden meldingsobject en geen lees-, markeer-, verwijder- of beheerroute om aanvullend te beveiligen.

## Gewijzigd
- brede reproduceerbare notification-routeaudit;
- Docker-workflow en artifact;
- afwezigheidscontract dat faalt zodra een meldingsroute wordt toegevoegd;
- M2C2N-21 en WP-5 in de afsluitmatrix op GEREED.

## Niet gewijzigd
- geen productiecode;
- geen frontend;
- geen databaseschema;
- geen route-URL's of routefingerprint;
- `/api/receipts/share-target` blijft DEFERRED.

## Acceptatie
- alle 14 workflows op headcommit `2a0d40a209953bdbc1ad92892c6668b3dcc31087` groen;
- routecatalogus blijft 194 registraties, 194 unieke methode-padcombinaties en 0 dubbelen;
- QA/QC-goedkeuring wordt vastgelegd;
- merge pas na expliciete PO-GO.