### PR TITLE
docs: complete Rezzerv project documentation

### DIFF
--- a/docs/project/ARCHITECTURE-AND-DATA.md
+++ b/docs/project/ARCHITECTURE-AND-DATA.md
@@ -1,0 +1,31 @@
+# Architectuur en datamodel
+
+## Technische hoofdlijn
+
+Rezzerv bestaat uit een React/Vite-frontend, FastAPI-backend, relationele database, Docker Compose-runtime en GitHub Actions-gates.
+
+Lokale runtime:
+
+- backend: `http://localhost:8011` naar containerpoort 8000;
+- frontend: `http://localhost:5174` naar containerpoort 80;
+- health: `http://localhost:8011/api/health`.
+
+## Datalaag
+
+De kernscheiding is:
+
+1. **Global product** - centrale productkennis, identiteit en verrijking.
+2. **Household article** - huishoudspecifieke representatie van een product.
+3. **Inventory** - actuele voorraad binnen een huishouden.
+4. **Inventory events** - aankopen, verbruik, correcties en verplaatsingen.
+5. **Receipt/import** - bronregels die naar product en huishoudartikel worden gekoppeld.
+
+Een centraal product mag nooit automatisch huishoudgegevens delen. Huishoudartikelen, locaties, voorraad en gebruik blijven per huishouden gescheiden.
+
+## Identiteiten
+
+Productidentiteiten omvatten onder meer GTIN/EAN/barcode, winkelartikelnummers, externe database-ID's en interne product-ID's. Normalisatie voorkomt duplicaten en ondersteunt koppeling.
+
+## Migraties
+
+Databasemigraties worden gefaseerd uitgevoerd. Per release geldt één hoofddoel met expliciete basisversie, doelversie, schemawijziging, backfill, compatibiliteit, herstelpad en regressietestscope.

--- a/docs/project/DEVELOPMENT-TEST-RELEASE.md
+++ b/docs/project/DEVELOPMENT-TEST-RELEASE.md
@@ -1,0 +1,29 @@
+# Ontwikkel-, test- en releaseproces
+
+## Hoofdregel
+
+Eén release of PR heeft één doel. UI-, backend-, infrastructuur-, styleguide- en patchwijzigingen worden niet onnodig gecombineerd.
+
+## Werkstroom
+
+1. scope en acceptatiecriteria vastleggen;
+2. actuele documentatie en runtime controleren;
+3. branch maken vanaf actuele `main`;
+4. wijziging bouwen;
+5. gerichte contracten en regressietests uitvoeren;
+6. QA/QC-scopecontrole;
+7. expliciete PO-GO;
+8. merge met verwachte head-SHA;
+9. mergecommit afzonderlijk tegen `main` verifiëren.
+
+## Verplichte technische controles
+
+Afhankelijk van wijzigingszwaarte: compile- en syntaxcontrole, backend/API-contracten, frontendbuild, Dockerbuild en start, healthcheck, databaseschema en migratiecontrole, Playwright-regressies, huishoud-/object-/rolcontracten, routecatalogus, kassabonketen-validatie en mergegate.
+
+## Releasegate
+
+Een release is technisch gereed wanneer relevante workflows groen zijn, scope en bestanden kloppen, geen onverklaarde route- of schemaafwijking bestaat, documentatie is bijgewerkt, QA/QC akkoord is en de PO expliciet GO geeft.
+
+## Huidige M2C2n-baseline
+
+Op 22 juli 2026: 194 routeregistraties, 194 unieke methode-padcombinaties, 0 dubbelen, 85 reads en 109 mutaties. Alle 16 afsluitworkflows waren groen op de definitieve WP-7-head.

--- a/docs/project/FUNCTIONAL-OVERVIEW.md
+++ b/docs/project/FUNCTIONAL-OVERVIEW.md
@@ -1,0 +1,25 @@
+# Functionele hoofdprocessen
+
+## Kassabon naar voorraad
+
+De beoogde keten is: kassabon ontvangen, OCR en parsing, regels controleren in Kassa, koppelen aan producten of huishoudartikelen, verwerken in Uitpakken, voorraadlocatie kiezen en voorraad plus historie bijwerken. De som van de artikelen is leidend; het bon-totaal is een controlewaarde.
+
+## Voorraad en artikelgroepen
+
+Voorraad, locaties en artikelgroepen zijn huishoudgebonden. Artikelgroep moet zichtbaar en volgens rol wijzigbaar zijn. Beheeracties mogen alleen aan bevoegde gebruikers worden aangeboden.
+
+## Productcatalogus en externe databases
+
+Rezzerv scheidt centrale productkennis van huishoudartikelen en voorraad. Externe bronnen kunnen productgegevens verrijken. Centrale catalogusmutaties zijn platformbeheeracties.
+
+## Prognoses en Bijna op
+
+Prognoses gebruiken huishoudgegevens en historische voorraadbewegingen. Instellingen en uitkomsten blijven aan het juiste huishouden en de juiste rol gebonden.
+
+## Winkels en importinstellingen
+
+Winkelkoppelingen en importinstellingen bepalen hoe aankopen en kassabonnen binnenkomen. Beheer hiervan is huishoudgebonden en voorbehouden aan de juiste beheerrol.
+
+## Meldingen
+
+Er bestaat op 22 juli 2026 nog geen actieve meldingen-API. Een toekomstig meldingsdomein moet eerst opnieuw worden geïnventariseerd en beveiligd.

--- a/docs/project/GOVERNANCE-AND-ROLES.md
+++ b/docs/project/GOVERNANCE-AND-ROLES.md
@@ -1,0 +1,24 @@
+# Organisatie, rollen en besluitvorming
+
+## Product Owner
+
+De Product Owner bepaalt functionele prioriteit, acceptatiecriteria, scope, functionele acceptatie en GO of NO-GO voor functionele merges. De PO hoeft geen technische broncode- of runtimecontrole uit te voeren voordat engineering, regressie en QA/QC gereed zijn.
+
+## AI-productteam
+
+- **Tech Lead** - scope, architectuur en volgorde.
+- **Backend Engineer** - serverlogica en datatoegang.
+- **Frontend Engineer** - schermgedrag volgens de styleguide.
+- **Regression Test Agent** - bewijs dat bestaande processen blijven werken.
+- **QA/QC** - controle op scope, bewijs, risico en releasekwaliteit.
+- **Release Coordinator** - merge en release uitsluitend na geldige GO.
+
+## Besluitregels
+
+- Geen functionele merge zonder expliciete PO-GO.
+- Eén PR heeft één duidelijk doel.
+- Aannames worden niet als bewijs gepresenteerd.
+- Onbekend wordt onderzocht en niet impliciet veilig verklaard.
+- Uitgestelde onderwerpen blijven zichtbaar als `DEFERRED`.
+
+Een groene technische merge betekent niet automatisch functionele PO-acceptatie, gebruiksvriendelijkheid of productierelease.

--- a/docs/project/PO-ACCEPTANCE.md
+++ b/docs/project/PO-ACCEPTANCE.md
@@ -1,0 +1,50 @@
+# PO-test en acceptatie
+
+## Wat technische GO wel betekent
+
+- de afgesproken technische scope is uitgevoerd;
+- relevante automatische tests zijn groen;
+- QA/QC heeft scope en bewijs gecontroleerd;
+- de merge staat aantoonbaar op `main`.
+
+## Wat technische GO niet betekent
+
+- alle schermen zijn functioneel geaccepteerd;
+- alle gebruikersreizen zijn handmatig getest;
+- de applicatie is klaar voor productie;
+- alle teksten en bediening zijn gebruiksvriendelijk;
+- alle rollen sluiten al aan op de uiteindelijke bedrijfsregels.
+
+## PO-vinklijst
+
+### Begrijpelijkheid
+
+- Is duidelijk wat de gebruiker kan doen?
+- Zijn labels, meldingen en foutteksten begrijpelijk?
+- Is zichtbaar waarom een actie wel of niet beschikbaar is?
+
+### Rechten en huishoudscheiding
+
+- Kan een kijker alleen lezen?
+- Kan een bevoegde gebruiker wijzigen?
+- Kan alleen een beheerder instellingen beheren?
+- Zie ik uitsluitend gegevens uit het actieve huishouden?
+- Verandert een huishoudwissel alle relevante schermgegevens?
+
+### Kernprocessen
+
+- Kassabon komt correct binnen.
+- Kassa toont de juiste regels.
+- Goedkeuren en verwerken werkt zonder handmatig verversen.
+- Uitpakken actualiseert verwerkte regels correct.
+- Voorraad en locaties worden correct bijgewerkt.
+- Artikelgroep is zichtbaar en volgens rol wijzigbaar.
+
+### Kwaliteit
+
+- Geen zichtbare console- of startfouten.
+- Geen regressie in login of navigatie.
+- Geen verlies van bestaande data.
+- Geen onverwachte wijzigingen buiten de afgesproken scope.
+
+De PO geeft per PR expliciet `GO - PR #... mergen` of `NO-GO - PR #... niet mergen`.

--- a/docs/project/PRODUCT-VISION.md
+++ b/docs/project/PRODUCT-VISION.md
@@ -1,0 +1,34 @@
+# Productvisie en scope
+
+## Kernidee
+
+Rezzerv geeft een huishouden overzicht over wat het bezit, koopt, gebruikt en waarschijnlijk binnenkort nodig heeft. De oorspronkelijke aanleiding was eenvoudig: in de winkel niet meer weten of er nog mosterd in huis is. Dat probleem staat symbool voor verspilling, dubbele aankopen en versnipperde persoonlijke informatie.
+
+## Waarde voor de gebruiker
+
+Rezzerv moet helpen bij:
+
+- inzicht in voorraad en bezittingen;
+- minder verspilling en dubbele aankopen;
+- boodschappen en aankopen slimmer plannen;
+- kassabonnen automatisch omzetten naar bruikbare artikel- en voorraadgegevens;
+- bewaren van productinformatie, handleidingen en later garanties;
+- voorspellen wat bijna op is;
+- gecontroleerd delen van gegevens met winkels of dienstverleners, uitsluitend na toestemming van de gebruiker.
+
+## Productprincipes
+
+1. De gebruiker blijft eigenaar van zijn gegevens.
+2. Standaard wordt niets breder gedeeld dan nodig.
+3. Automatisering moet handmatig onderhoud beperken.
+4. Productkennis en huishoudgebruik worden gescheiden.
+5. Rezzerv moet uitlegbaar en controleerbaar zijn.
+6. Nieuwe functionaliteit mag bestaande kernprocessen niet breken.
+
+## Huidige functionele kern
+
+De huidige ontwikkeling concentreert zich op kassabonnen, Kassa, Uitpakken, Voorraad, locaties, artikelgroepen, winkels, externe productdatabases, prognoses, Bijna op, instellingen en rollen.
+
+## Buiten de huidige technische afsluiting
+
+De M2C2n-afsluiting is geen bewijs dat alle schermen functioneel compleet zijn. Ook receptenmatching, uitgebreide prijsvergelijking, garanties, serviceproviders, uitleenregistratie en een volledige productierelease zijn nog geen afgerond productresultaat.

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -1,0 +1,27 @@
+# Rezzerv projectdocumentatie
+
+Statusdatum: 22 juli 2026  
+Actuele technische baseline: `main@9385354c1c92e80a9ca210da3d9b3f095896e5c2`
+
+Deze map is de leesbare ingang voor product, ontwikkeling, kwaliteit, release en beheer van Rezzerv.
+
+## Documenten
+
+1. [Productvisie en scope](PRODUCT-VISION.md)
+2. [Organisatie, rollen en besluitvorming](GOVERNANCE-AND-ROLES.md)
+3. [Functionele hoofdprocessen](FUNCTIONAL-OVERVIEW.md)
+4. [Architectuur en datamodel](ARCHITECTURE-AND-DATA.md)
+5. [Ontwikkel-, test- en releaseproces](DEVELOPMENT-TEST-RELEASE.md)
+6. [Beveiliging en huishoudisolatie](SECURITY-AND-HOUSEHOLD-ISOLATION.md)
+7. [PO-test en acceptatie](PO-ACCEPTANCE.md)
+8. [UI-richtlijnen](UI-STYLEGUIDE-SUMMARY.md)
+
+## Bestaande formele kwaliteitsdocumenten
+
+- `docs/quality/M2C2N-CLOSURE-MATRIX.md`
+- `docs/quality/M2C2N-FINAL-REPORT.md`
+- `docs/quality/M2C2N-ROUTE-CATALOG-BASELINE.json`
+
+## Status in gewone taal
+
+De recente M2C2n-reeks heeft geen grote nieuwe schermfunctie opgeleverd. De reeks heeft vooral geregeld dat huishoudgegevens, objecten en rollen technisch beter van elkaar zijn gescheiden en dat nieuwe afwijkingen automatisch worden geblokkeerd. Functionele PO-acceptatie en een algemene productierelease blijven afzonderlijke besluiten.

--- a/docs/project/SECURITY-AND-HOUSEHOLD-ISOLATION.md
+++ b/docs/project/SECURITY-AND-HOUSEHOLD-ISOLATION.md
@@ -1,0 +1,29 @@
+# Beveiliging en huishoudisolatie
+
+## Doel
+
+Een gebruiker mag alleen gegevens lezen of wijzigen waarvoor hij binnen het juiste huishouden bevoegd is. Technische test- en platformbeheerfuncties mogen niet door gewone gebruikers worden uitgevoerd.
+
+## Rollen
+
+- niet ingelogd: geen afgeschermde huishoudgegevens;
+- kijker: uitsluitend toegestane reads;
+- gebruiker met schrijfrecht: huishoudelijke voorraadmutaties;
+- huishoudbeheerder: huishoudinstellingen en koppelingen;
+- platformbeheerder: centrale catalogus-, diagnose-, test- en onderhoudsmutaties.
+
+## Server-side objectbinding
+
+Bij batches, importregels, voorraadobjecten en locaties bepaalt de backend het owning household waar mogelijk op basis van het object zelf. Een vrij meegestuurde huishoud-ID is geen bewijs van bevoegdheid.
+
+## Afgesloten M2C2n-scope
+
+Geregeld zijn centrale huishoudcontext, artikelgroepen, voorraadlocaties, Uitpakken, receipt share import, Gmail- en Resend-bronnen, admin- en testingmutaties, productverrijking, artikelmutaties, externe productkoppelingen, prognoses, AlmostOut, aankopen, importinstellingen en fallbackwaarden.
+
+## Bewaking
+
+De routecatalogus en gerichte contracten blokkeren nieuwe afwijkingen. De actuele fallbackaudit bevat 94 geclassificeerde runtimeverwijzingen en nul ongeclassificeerde verwijzingen.
+
+## Enige uitgestelde uitzondering
+
+`POST /api/receipts/share-target` blijft `DEFERRED`. Het vrije `household_id` moet later worden vervangen door een kortlevend, ondertekend token dat aan precies één huishouden is gebonden.

--- a/docs/project/UI-STYLEGUIDE-SUMMARY.md
+++ b/docs/project/UI-STYLEGUIDE-SUMMARY.md
@@ -1,0 +1,30 @@
+# UI-richtlijnen
+
+## Basis
+
+- lichtgroene schermachtergrond;
+- donkergroene header van 56 px;
+- witte titel links en Rezzerv-logo rechts;
+- tekstkleur `#1A1A1A`;
+- inputs, filters en knoppen niet vet.
+
+## Tabellen
+
+- zoek- en filterregel direct boven kolomtitels;
+- eerste veld heet `Zoek`;
+- filters tonen `Filter` zonder extra label erboven;
+- tekst links, numeriek rechts, checkbox gecentreerd;
+- Nederlandse decimaalnotatie en twee decimalen waar van toepassing;
+- lege cellen grijs;
+- sortering op alle kolommen;
+- actieve kolom donkergroen;
+- paginering direct onder de tabel;
+- horizontale scroll toegestaan wanneer nodig.
+
+## Knoppen en grafieken
+
+Knoppen zijn donkergroen met witte, niet-vette tekst en hergebruiken bestaande componenten. De exitknop staat rechtsonder buiten het tabelkader. Grafieken gebruiken gestapelde kolommen, drilldown, `Niveau omhoog`, een weken/maanden-toggle en de afgesproken groen-, oker- en grijstinten.
+
+## Wijzigingsregel
+
+Nieuwe schermen en aanpassingen worden vanuit de bestaande componenten en styleguide opgebouwd. Geen lokale afwijking zonder expliciete styleguidebeslissing.


### PR DESCRIPTION
## Doel
De volledige Rezzerv-projectdocumentatie actualiseren na de formele M2C2n-afsluiting en begrijpelijk maken voor Product Owner, AI-productteam, QA/QC en releasebeheer.

## Toegevoegd
Een nieuwe centrale documentatieset onder `docs/project/`:

- documentatie-index;
- productvisie en scope;
- organisatie, rollen en besluitvorming;
- functionele hoofdprocessen;
- architectuur en datamodel;
- ontwikkel-, test- en releaseproces;
- beveiliging en huishoudisolatie;
- PO-test en acceptatie;
- UI-richtlijnen.

## Verwerkt
- actuele `main`-baseline `9385354c1c92e80a9ca210da3d9b3f095896e5c2`;
- M2C2n-eindstatus en routebaseline;
- enige `DEFERRED` uitzondering `/api/receipts/share-target`;
- bestaande productvisie, teamrollen, releasekwaliteit, QA/QC, releaseprotocol, releasegate, styleguide en databaseblueprint;
- expliciet onderscheid tussen technische GO, functionele PO-acceptatie en productierelease.

## Niet gewijzigd
- geen productiecode;
- geen frontend;
- geen databaseschema;
- geen routes;
- geen bestaande formele M2C2n-bewijsdocumenten.

## Download
Dezelfde set is gegenereerd als DOCX, PDF en ZIP voor de PO.