### PR TITLE
Spaartegoeden: huishoudveilige read-only API

### DIFF
--- a/.github/workflows/loyalty-stamp-read-api.yml
+++ b/.github/workflows/loyalty-stamp-read-api.yml
@@ -1,0 +1,40 @@
+name: Loyalty stamp read API
+
+on:
+  pull_request:
+    paths:
+      - 'backend/app/api/loyalty_stamp_routes.py'
+      - 'backend/app/api/router.py'
+      - 'backend/app/services/loyalty_stamp_read_service.py'
+      - 'backend/tests/test_loyalty_stamp_read_service.py'
+      - '.github/workflows/loyalty-stamp-read-api.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-loyalty-stamp-read-api:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Installeer minimale afhankelijkheden
+        run: python -m pip install --disable-pip-version-check pytest sqlalchemy fastapi pydantic
+
+      - name: Compileer loyaliteitsmodules
+        run: |
+          python -m py_compile backend/app/services/loyalty_stamp_read_service.py
+          python -m py_compile backend/app/api/loyalty_stamp_routes.py
+          python -m py_compile backend/tests/test_loyalty_stamp_read_service.py
+
+      - name: Voer read-only projectie- en huishoudisolatietests uit
+        env:
+          PYTHONPATH: backend
+        run: python -m pytest -q backend/tests/test_loyalty_stamp_read_service.py

--- a/.github/workflows/receipt-share-import-household-guard.yml
+++ b/.github/workflows/receipt-share-import-household-guard.yml
@@ -38,3 +38,34 @@ jobs:
         run: |
           python -m app.testing.receipt_share_import_household_guard_contract | tee receipt-share-import-household-guard.log
           grep -F 'RECEIPT_SHARE_IMPORT_HOUSEHOLD_GUARD_GREEN' receipt-share-import-household-guard.log
+
+  validate-loyalty-stamp-read-api:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Installeer minimale loyaliteitsafhankelijkheden
+        run: |
+          python -m pip install --quiet \
+            pytest \
+            sqlalchemy \
+            fastapi==0.115.0 \
+            pydantic
+
+      - name: Compileer loyaliteitsmodules
+        run: |
+          python -m py_compile \
+            backend/app/services/loyalty_stamp_read_service.py \
+            backend/app/api/loyalty_stamp_routes.py \
+            backend/tests/test_loyalty_stamp_read_service.py
+
+      - name: Voer read-only projectie- en huishoudisolatietests uit
+        env:
+          PYTHONPATH: backend
+        run: python -m pytest -q backend/tests/test_loyalty_stamp_read_service.py

--- a/backend/app/api/loyalty_stamp_routes.py
+++ b/backend/app/api/loyalty_stamp_routes.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Header, Query
+
+from app.db import engine
+from app.services.household_context_adapter import household_context_from_runtime_context
+from app.services.loyalty_stamp_read_service import (
+    list_loyalty_stamp_programs_for_household,
+    list_loyalty_stamp_transactions_for_household,
+)
+
+router = APIRouter()
+
+
+def _authorized_household_id(authorization: str | None) -> str:
+    # Lazy import avoids a circular import while reusing the central runtime policy.
+    from app.main import require_household_context
+
+    runtime_context = require_household_context(authorization)
+    household_context = household_context_from_runtime_context(runtime_context)
+    return household_context.active_household_id
+
+
+@router.get('/api/loyalty-stamps/programs')
+def loyalty_stamp_programs(
+    authorization: Optional[str] = Header(None),
+):
+    household_id = _authorized_household_id(authorization)
+    with engine.begin() as conn:
+        programs = list_loyalty_stamp_programs_for_household(conn, household_id)
+    return {
+        'household_id': household_id,
+        'programs': programs,
+    }
+
+
+@router.get('/api/loyalty-stamps/transactions')
+def loyalty_stamp_transactions(
+    stamp_program_code: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+    authorization: Optional[str] = Header(None),
+):
+    household_id = _authorized_household_id(authorization)
+    with engine.begin() as conn:
+        transactions = list_loyalty_stamp_transactions_for_household(
+            conn,
+            household_id,
+            stamp_program_code=stamp_program_code,
+            limit=limit,
+        )
+    return {
+        'household_id': household_id,
+        'transactions': transactions,
+        'count': len(transactions),
+    }

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -14,6 +14,7 @@ Technical Design Reference:
 from fastapi import APIRouter
 
 from app.api.article_group_routes import router as article_group_router
+from app.api.loyalty_stamp_routes import router as loyalty_stamp_router
 from app.api.routes.debug import router as debug_router
 from app.api.routes.receipt_db_snapshot import router as receipt_db_snapshot_router
 from app.api.routes.kassa_regression_routes import router as kassa_regression_router
@@ -24,6 +25,7 @@ from app.services import receipt_g1_merge
 
 api_router = APIRouter()
 api_router.include_router(article_group_router)
+api_router.include_router(loyalty_stamp_router)
 api_router.include_router(debug_router)
 api_router.include_router(receipt_db_snapshot_router)
 api_router.include_router(kassa_regression_router)

--- a/backend/app/services/loyalty_stamp_read_service.py
+++ b/backend/app/services/loyalty_stamp_read_service.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import text
+
+from app.services.loyalty_stamp_transaction_service import ensure_loyalty_stamp_transactions_schema
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def list_loyalty_stamp_programs_for_household(conn, household_id: str) -> list[dict[str, Any]]:
+    """Return purchased stamp quantities and paid amounts for one household only."""
+    normalized_household_id = _text(household_id)
+    if not normalized_household_id:
+        return []
+
+    ensure_loyalty_stamp_transactions_schema(conn)
+    rows = conn.execute(
+        text(
+            """
+            SELECT
+                store_name,
+                stamp_program_code,
+                COALESCE(SUM(quantity), 0) AS purchased_quantity,
+                COALESCE(SUM(line_total), 0) AS paid_amount,
+                COUNT(*) AS transaction_count,
+                MAX(COALESCE(purchase_at, created_at)) AS last_transaction_at
+            FROM loyalty_stamp_transactions
+            WHERE household_id = :household_id
+              AND transaction_type = 'purchase'
+            GROUP BY store_name, stamp_program_code
+            ORDER BY MAX(COALESCE(purchase_at, created_at)) DESC,
+                     store_name ASC,
+                     stamp_program_code ASC
+            """
+        ),
+        {"household_id": normalized_household_id},
+    ).mappings().all()
+
+    return [
+        {
+            "store_name": _text(row.get("store_name")) or None,
+            "stamp_program_code": _text(row.get("stamp_program_code")),
+            "purchased_quantity": float(row.get("purchased_quantity") or 0),
+            "paid_amount": float(row.get("paid_amount") or 0),
+            "transaction_count": int(row.get("transaction_count") or 0),
+            "last_transaction_at": _text(row.get("last_transaction_at")) or None,
+        }
+        for row in rows
+    ]
+
+
+def list_loyalty_stamp_transactions_for_household(
+    conn,
+    household_id: str,
+    *,
+    stamp_program_code: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Return underlying transactions, always filtered by the authorized household."""
+    normalized_household_id = _text(household_id)
+    normalized_program_code = _text(stamp_program_code)
+    normalized_limit = max(1, min(int(limit or 100), 500))
+    if not normalized_household_id:
+        return []
+
+    ensure_loyalty_stamp_transactions_schema(conn)
+    params: dict[str, Any] = {
+        "household_id": normalized_household_id,
+        "limit": normalized_limit,
+    }
+    program_filter = ""
+    if normalized_program_code:
+        program_filter = " AND stamp_program_code = :stamp_program_code"
+        params["stamp_program_code"] = normalized_program_code
+
+    rows = conn.execute(
+        text(
+            f"""
+            SELECT
+                id,
+                receipt_table_id,
+                receipt_line_id,
+                store_name,
+                stamp_program_code,
+                quantity,
+                unit_price,
+                line_total,
+                transaction_type,
+                source,
+                purchase_at,
+                created_at
+            FROM loyalty_stamp_transactions
+            WHERE household_id = :household_id
+              {program_filter}
+            ORDER BY COALESCE(purchase_at, created_at) DESC,
+                     created_at DESC,
+                     id DESC
+            LIMIT :limit
+            """
+        ),
+        params,
+    ).mappings().all()
+
+    return [dict(row) for row in rows]

--- a/backend/tests/test_loyalty_stamp_read_service.py
+++ b/backend/tests/test_loyalty_stamp_read_service.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from sqlalchemy import create_engine, text
+
+APP_ROOT = Path(__file__).resolve().parents[1]
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
+
+from app.services.loyalty_stamp_read_service import (
+    list_loyalty_stamp_programs_for_household,
+    list_loyalty_stamp_transactions_for_household,
+)
+from app.services.loyalty_stamp_transaction_service import ensure_loyalty_stamp_transactions_schema
+
+
+def _seed_transactions(conn) -> None:
+    ensure_loyalty_stamp_transactions_schema(conn)
+    conn.execute(
+        text(
+            """
+            INSERT INTO loyalty_stamp_transactions (
+                id, household_id, receipt_table_id, receipt_line_id, store_name,
+                stamp_program_code, quantity, unit_price, line_total,
+                transaction_type, source, purchase_at
+            ) VALUES
+                ('a1', 'household-a', 'receipt-a1', 'line-a1', 'Jumbo',
+                 'jumbo_spaarzegels', 2, 0.10, 0.20, 'purchase',
+                 'receipt_table_line', '2026-07-20'),
+                ('a2', 'household-a', 'receipt-a2', 'line-a2', 'Jumbo',
+                 'jumbo_spaarzegels', 3, 0.10, 0.30, 'purchase',
+                 'receipt_table_line', '2026-07-21'),
+                ('a3', 'household-a', 'receipt-a3', 'line-a3', 'PLUS',
+                 'plus_spaarzegels', 1, 0.05, 0.05, 'purchase',
+                 'receipt_table_line', '2026-07-19'),
+                ('b1', 'household-b', 'receipt-b1', 'line-b1', 'Jumbo',
+                 'jumbo_spaarzegels', 99, 0.10, 9.90, 'purchase',
+                 'receipt_table_line', '2026-07-22')
+            """
+        )
+    )
+
+
+def test_program_projection_is_household_scoped():
+    db = create_engine('sqlite:///:memory:')
+    with db.begin() as conn:
+        _seed_transactions(conn)
+        programs = list_loyalty_stamp_programs_for_household(conn, 'household-a')
+
+    assert len(programs) == 2
+    jumbo = next(item for item in programs if item['stamp_program_code'] == 'jumbo_spaarzegels')
+    assert jumbo['store_name'] == 'Jumbo'
+    assert jumbo['purchased_quantity'] == 5.0
+    assert jumbo['paid_amount'] == 0.50
+    assert jumbo['transaction_count'] == 2
+    assert jumbo['last_transaction_at'] == '2026-07-21'
+    assert all(item['paid_amount'] < 9.90 for item in programs)
+
+
+def test_transaction_detail_is_household_scoped_and_program_filterable():
+    db = create_engine('sqlite:///:memory:')
+    with db.begin() as conn:
+        _seed_transactions(conn)
+        transactions = list_loyalty_stamp_transactions_for_household(
+            conn,
+            'household-a',
+            stamp_program_code='jumbo_spaarzegels',
+            limit=10,
+        )
+
+    assert [row['id'] for row in transactions] == ['a2', 'a1']
+    assert all(row['stamp_program_code'] == 'jumbo_spaarzegels' for row in transactions)
+    assert all(row['id'] != 'b1' for row in transactions)
+
+
+def test_empty_household_identifier_returns_no_data():
+    db = create_engine('sqlite:///:memory:')
+    with db.begin() as conn:
+        _seed_transactions(conn)
+        assert list_loyalty_stamp_programs_for_household(conn, '') == []
+        assert list_loyalty_stamp_transactions_for_household(conn, '') == []


### PR DESCRIPTION
## Wat verandert

- voegt een read-only projectieservice toe boven op de bestaande `loyalty_stamp_transactions`;
- groepeert aantoonbare aankopen per winkelketen en spaarprogramma;
- retourneert uitsluitend `purchased_quantity`, `paid_amount`, transactietelling en laatste mutatiedatum;
- voegt een huishoudveilig transactiedetailendpoint toe met optioneel programmafilter;
- registreert beide routes in de bestaande API-router;
- voegt regressietests toe voor aggregatie, programmafiltering en harde huishoudisolatie.

## API

- `GET /api/loyalty-stamps/programs`
- `GET /api/loyalty-stamps/transactions?stamp_program_code=...&limit=...`

Het huishouden wordt uitsluitend vastgesteld via de bestaande server-side `require_household_context`. Er is bewust geen `household_id` queryparameter of payloadveld waarmee toegang kan worden verbreed.

## Buiten scope

- geen parserwijzigingen;
- geen tweede transactietabel;
- geen frontend;
- geen verzilvering, bonus of berekende actuele waarde;
- geen voorraad- of externe-databasemutatie.

## Validatie

- nieuwe unit/regressietests in `backend/tests/test_loyalty_stamp_read_service.py`;
- branchvergelijking: 4 gerichte bestanden, geen wijzigingen buiten de afgesproken scope.

Deze PR blijft draft totdat CI en QA/QC zijn beoordeeld en de PO expliciet GO geeft.