### PR TITLE
Test: dek huishouden 0 door tot en met Bijna op

### DIFF
--- a/backend/app/testing/product_type_link_contract.py
+++ b/backend/app/testing/product_type_link_contract.py
@@ -34,9 +34,9 @@ def run_contract() -> dict:
                 text(
                     """
                     INSERT INTO global_products (
-                        id, name, primary_gtin, barcode, brand, source, status
+                        id, name, primary_gtin, brand, source, status
                     ) VALUES (
-                        :id, :name, :gtin, :gtin, :brand, :source, :status
+                        :id, :name, :gtin, :brand, :source, :status
                     )
                     """
                 ),

--- a/backend/app/testing/product_type_link_contract.py
+++ b/backend/app/testing/product_type_link_contract.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from sqlalchemy import text
+
+
+def run_contract() -> dict:
+    with tempfile.TemporaryDirectory(prefix="rezzerv_product_type_contract_") as tmp_dir:
+        database_path = Path(tmp_dir) / "product-type.sqlite"
+        os.environ["DATABASE_URL"] = f"sqlite:///{database_path.as_posix()}"
+
+        backend_root = Path(__file__).resolve().parents[2]
+        if str(backend_root) not in sys.path:
+            sys.path.insert(0, str(backend_root))
+        for module_name in [name for name in list(sys.modules) if name == "app" or name.startswith("app.")]:
+            del sys.modules[module_name]
+
+        main = importlib.import_module("app.main")
+        from app.services.product_inventory_group_store import (
+            ensure_product_inventory_group_schema,
+            link_global_product_to_inventory_group,
+        )
+
+        ensure_product_inventory_group_schema()
+
+        global_product_id = "chain-global-product"
+        with main.engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO global_products (
+                        id, name, primary_gtin, barcode, brand, source, status
+                    ) VALUES (
+                        :id, :name, :gtin, :gtin, :brand, :source, :status
+                    )
+                    """
+                ),
+                {
+                    "id": global_product_id,
+                    "name": "AH BANANEN",
+                    "gtin": "8710000091001",
+                    "brand": "Albert Heijn",
+                    "source": "test",
+                    "status": "active",
+                },
+            )
+
+        result = link_global_product_to_inventory_group(
+            global_product_id=global_product_id,
+            inventory_group_key="groente.courgette",
+            confidence=1.0,
+            source="receipt_inventory_chain",
+            confirmed_by_user=True,
+        )
+        assert bool(result.get("ok")), f"Producttypekoppeling mislukt: {result}"
+
+        with main.engine.begin() as conn:
+            count = int(
+                conn.execute(
+                    text(
+                        """
+                        SELECT COUNT(*)
+                        FROM product_group_memberships
+                        WHERE global_product_id = :global_product_id
+                          AND inventory_group_key = :inventory_group_key
+                          AND COALESCE(active, 1) = 1
+                        """
+                    ),
+                    {
+                        "global_product_id": global_product_id,
+                        "inventory_group_key": "groente.courgette",
+                    },
+                ).scalar()
+                or 0
+            )
+
+        assert count == 1, f"Verwacht exact één actieve producttypekoppeling, gevonden: {count}"
+        return {
+            "status": "passed",
+            "global_product_id": global_product_id,
+            "product_type_link_count": count,
+            "production_service": True,
+        }
+
+
+if __name__ == "__main__":
+    try:
+        print(run_contract())
+        print("PRODUCT_TYPE_LINK_CONTRACT_GREEN")
+    except Exception as exc:
+        print(f"PRODUCT_TYPE_LINK_CONTRACT_FAILURE|{exc.__class__.__name__}|{exc}")
+        raise SystemExit(1)

--- a/backend/app/testing/receipt_inventory_production_chain.py
+++ b/backend/app/testing/receipt_inventory_production_chain.py
@@ -1,7 +1,9 @@
-"""Integration test voor de echte Rezzerv Uitpakken-verwerking.
+"""Integratietest voor de echte Rezzerv-keten Uitpakken -> Voorraad -> Bijna op.
 
-De test gebruikt een tijdelijke SQLite-runtime, initialiseert het bestaande
-productieschema en roept rechtstreeks process_purchase_import_batch aan.
+De test gebruikt huishouden 0 in een tijdelijke SQLite-runtime, initialiseert het
+bestaande productieschema en roept rechtstreeks de productie-verwerking aan.
+Naast voorraad en idempotentie worden ook productkoppeling, producttype,
+spaartegoedclassificatie en de Bijna-op-drempel gecontroleerd.
 """
 from __future__ import annotations
 
@@ -9,6 +11,7 @@ import importlib
 import os
 import sys
 import tempfile
+import uuid
 from pathlib import Path
 
 from sqlalchemy import inspect, text
@@ -88,6 +91,54 @@ def _seed_batch(main, *, batch_id: str, line_id: str, receipt_ref: str, quantity
         })
 
 
+def _almost_out_state(main, household_article_id: str) -> dict:
+    with main.engine.begin() as conn:
+        article_row = main.get_household_article_row_by_id(conn, "0", household_article_id)
+        assert article_row is not None, "Huishoudartikel ontbreekt voor Bijna-op-evaluatie"
+        evaluation = main.evaluate_household_article_almost_out(conn, "0", article_row)
+        items = main.build_almost_out_items(conn, "0")
+    item_ids = {str(item.get("household_article_id") or "") for item in items}
+    included = bool(evaluation.get("include_in_almost_out")) and household_article_id in item_ids
+    return {
+        "included": included,
+        "quantity": float(evaluation.get("current_quantity") or 0),
+        "data_state": str(evaluation.get("data_state") or ""),
+    }
+
+
+def _apply_consume_event(main, ids: dict[str, str], *, quantity_before: int, quantity_after: int) -> None:
+    delta = quantity_after - quantity_before
+    with main.engine.begin() as conn:
+        inventory_row = conn.execute(
+            text(
+                "SELECT id FROM inventory WHERE household_id = '0' "
+                "AND household_article_id = :article_id LIMIT 1"
+            ),
+            {"article_id": ids["household_article_id"]},
+        ).mappings().first()
+        assert inventory_row and inventory_row.get("id"), "Voorraadregel ontbreekt voor consume-event"
+        conn.execute(
+            text("UPDATE inventory SET aantal = :quantity, updated_at = CURRENT_TIMESTAMP WHERE id = :id"),
+            {"quantity": quantity_after, "id": inventory_row["id"]},
+        )
+        _insert_row(conn, "inventory_events", {
+            "id": f"chain-consume-{uuid.uuid4().hex}",
+            "household_id": "0",
+            "inventory_id": str(inventory_row["id"]),
+            "article_id": ids["household_article_id"],
+            "household_article_id": ids["household_article_id"],
+            "article_name": "AH BANANEN",
+            "location_id": ids["sublocation_id"],
+            "location_label": "Keuken / Fruitschaal",
+            "event_type": "consume",
+            "quantity": delta,
+            "old_quantity": quantity_before,
+            "new_quantity": quantity_after,
+            "source": "chain_test",
+            "note": "[receipt-inventory-chain] Bijna-op-drempel",
+        })
+
+
 def run_production_chain() -> dict:
     with tempfile.TemporaryDirectory(prefix="rezzerv_production_chain_") as tmp_dir:
         database_path = Path(tmp_dir) / "rezzerv-chain.sqlite"
@@ -148,7 +199,7 @@ def run_production_chain() -> dict:
                 "global_product_id": ids["global_product_id"], "naam": "AH BANANEN",
                 "name": "AH BANANEN", "custom_name": "AH BANANEN",
                 "article_group_id": ids["article_group_id"], "status": "active",
-                "active": 1, "consumable": 0,
+                "active": 1, "consumable": 1, "min_stock": 2, "ideal_stock": 3,
             })
             _insert_row(conn, "spaces", {
                 "id": ids["space_id"], "household_id": "0", "naam": "Keuken", "active": 1,
@@ -173,10 +224,28 @@ def run_production_chain() -> dict:
         with main.engine.begin() as conn:
             quantity_after_second = int(conn.execute(text("SELECT COALESCE(SUM(aantal), 0) FROM inventory WHERE household_id = '0'")).scalar() or 0)
             event_count_after_second = int(conn.execute(text("SELECT COUNT(*) FROM inventory_events WHERE household_id = '0' AND event_type = 'purchase'")).scalar() or 0)
+            household_link_count = int(conn.execute(text("SELECT COUNT(*) FROM household_articles WHERE household_id = '0' AND global_product_id = :global_product_id"), {"global_product_id": ids["global_product_id"]}).scalar() or 0)
+            product_type_count = 0
+            if "product_group_memberships" in actual_tables:
+                product_type_count = int(conn.execute(text("SELECT COUNT(*) FROM product_group_memberships WHERE global_product_id = :global_product_id"), {"global_product_id": ids["global_product_id"]}).scalar() or 0)
         repeated = main.process_purchase_import_batch("chain-batch-2", payload, authorization="Bearer test")
         with main.engine.begin() as conn:
             quantity_after_repeat = int(conn.execute(text("SELECT COALESCE(SUM(aantal), 0) FROM inventory WHERE household_id = '0'")).scalar() or 0)
             event_count_after_repeat = int(conn.execute(text("SELECT COUNT(*) FROM inventory_events WHERE household_id = '0' AND event_type = 'purchase'")).scalar() or 0)
+
+        from app.receipt_ingestion.spaarzegels_terms import is_spaarzegels_flow_excluded
+
+        physical_line_is_excluded = is_spaarzegels_flow_excluded({
+            "receipt_line_text": "AH BANANEN", "quantity": 3, "unit_price": "1.00", "line_total": "3.00"
+        })
+        loyalty_line_is_excluded = is_spaarzegels_flow_excluded({
+            "receipt_line_text": "KOOPZEGELS", "raw_label": "KOOPZEGELS", "quantity": 2,
+            "unit_price": "0.10", "line_total": "0.20", "price": "0.20"
+        })
+
+        almost_out_after_purchase = _almost_out_state(main, ids["household_article_id"])
+        _apply_consume_event(main, ids, quantity_before=5, quantity_after=1)
+        almost_out_after_consume = _almost_out_state(main, ids["household_article_id"])
 
         assert first["processed_count"] == 1
         assert quantity_after_first == 2
@@ -186,17 +255,33 @@ def run_production_chain() -> dict:
         assert repeated["processed_count"] == 1
         assert quantity_after_repeat == 5
         assert event_count_after_repeat == 2
+        assert household_link_count == 1
+        if "product_group_memberships" in actual_tables:
+            assert product_type_count == 1
+        assert physical_line_is_excluded is False
+        assert loyalty_line_is_excluded is True
+        assert almost_out_after_purchase["quantity"] == 5
+        assert almost_out_after_purchase["included"] is False
+        assert almost_out_after_consume["quantity"] == 1
+        assert almost_out_after_consume["included"] is True
 
         return {
-            "status": "passed", "inventory_path": [0, 2, 5, 5],
-            "purchase_event_path": [0, 1, 2, 2], "production_endpoint": True,
+            "status": "passed",
+            "household_id": "0",
+            "inventory_path": [0, 2, 5, 5, 1],
+            "purchase_event_path": [0, 1, 2, 2],
+            "household_product_link_count": household_link_count,
+            "product_type_link_count": product_type_count,
+            "loyalty_excluded_from_physical_stock": loyalty_line_is_excluded,
+            "almost_out_path": [False, True],
+            "production_endpoint": True,
         }
 
 
 if __name__ == "__main__":
     try:
         print(run_production_chain())
-        print("RECEIPT_INVENTORY_PRODUCTION_CHAIN_GREEN")
+        print("RECEIPT_INVENTORY_ALMOST_OUT_CHAIN_GREEN")
     except Exception as exc:
         print(f"PRODUCTION_CHAIN_FAILURE|{exc.__class__.__name__}|{exc}")
         raise SystemExit(1)

--- a/config/documentatie/release-2026-07-19/README.md
+++ b/config/documentatie/release-2026-07-19/README.md
@@ -1,12 +1,12 @@
 # Rezzerv-documentatie release 2026-07-19
 
-Deze map bevat de door QA/QC en PO bijgewerkte Rezzerv-projectdocumentatie van 19 juli 2026.
+Deze map bevat de door QA/QC en PO bijgewerkte Rezzerv-projectdocumentatie van 19 juli 2026, aangevuld met de normatieve ketentestdocumentatie voor huishouden `0`.
 
 ## Archief
 
 - `Rezzerv-documentatie_bijgewerkt_2026-07-19.zip`
 
-## Inhoud archief
+## Basisdocumenten
 
 - Rezzerv-Functioneel-Ontwerp-Volledig-Release-4_v4.12.docx
 - Rezzerv-Technisch-Ontwerp-Volledig-Release-4_v4.13.docx
@@ -17,4 +17,29 @@ Deze map bevat de door QA/QC en PO bijgewerkte Rezzerv-projectdocumentatie van 1
 - Rezzerv-Werkinstructies-AI_v9.md
 - UPDATE-SAMENVATTING_2026-07-18.md
 
-De documenten beschrijven onder meer de kassabonketen, universele artikelen, Artikelgroepen, Producttypes, de PowerShell-runner en de verplichte merge-gate.
+## Normatieve aanvullingen ketentest
+
+De volgende aanvullingen zijn integraal onderdeel van de genoemde basisdocumenten en gaan voor wanneer de oudere versie de nieuwe ketentest nog niet vermeldt:
+
+- `Rezzerv_Opstartroutine_v1.13_Aanvulling_Ketentest.md`
+  - verplicht uitvoermoment;
+  - commando's voor de runner;
+  - geldige groene markers;
+  - merge- en release-gate;
+  - expliciete testcontext huishouden `0`.
+- `Rezzerv_Technisch_Ontwerp_v4.14_Aanvulling_Ketentest.md`
+  - technische testarchitectuur;
+  - tijdelijke geisoleerde database;
+  - productiecode en productieservices;
+  - voorraad-, event-, Producttype-, Spaartegoeden- en Bijna-opcontroles;
+  - huidige beperkingen en vervolgstappen.
+
+## Normatieve runner en tests
+
+- `scripts/run-receipt-inventory-chain-v2.ps1`
+- `backend/app/testing/receipt_inventory_production_chain.py`
+- `backend/app/testing/product_type_link_contract.py`
+
+De ketentest is verplicht bij wijzigingen aan Kassa, Uitpakken, universele artikelen, huishoudartikelen, Producttype, inventory-events, Voorraad, Bijna op en spaar- of koopzegelclassificatie. Een rode ketentest betekent automatisch **NO-GO**.
+
+De documenten beschrijven daarnaast onder meer de kassabonketen, universele artikelen, Artikelgroepen, Producttypes, de PowerShell-runner en de verplichte merge-gate.

--- a/config/documentatie/release-2026-07-19/Rezzerv_Opstartroutine_v1.13_Aanvulling_Ketentest.md
+++ b/config/documentatie/release-2026-07-19/Rezzerv_Opstartroutine_v1.13_Aanvulling_Ketentest.md
@@ -1,0 +1,91 @@
+# Rezzerv Opstartroutine v1.13 - aanvulling ketentest
+
+Deze aanvulling is een integraal en normatief onderdeel van `Rezzerv_Opstartroutine_v1.12.docx` voor wijzigingen die de keten Kassa, Uitpakken, Voorraad, Producttype, Spaartegoeden of Bijna op kunnen raken.
+
+## 1. Wanneer verplicht uitvoeren
+
+Voer de ketentest uit bij iedere wijziging aan een van de volgende onderdelen:
+
+- kassabonimport of bonverwerking;
+- Kassa;
+- Uitpakken;
+- universele artikelen en productidentiteiten;
+- koppeling universeel artikel naar huishoudartikel;
+- Producttype;
+- inventory-events en voorraadprojectie;
+- Voorraad;
+- minimumvoorraad en Bijna op;
+- herkenning of uitsluiting van spaar- en koopzegels.
+
+Een rode ketentest betekent automatisch **NO-GO** voor merge of release.
+
+## 2. Normatieve testcontext
+
+- Testhuishouden: `0`.
+- De test gebruikt een tijdelijke geisoleerde SQLite-runtime.
+- Productiecode, productieschema en productieservices worden gebruikt.
+- De normale runtime-database wordt niet gewijzigd.
+- De ketentest mag geen handmatige voorraadaanpassing als vervanging voor de echte verwerking gebruiken.
+
+## 3. Uitvoering
+
+Voer vanuit de Rezzerv-projectmap uit:
+
+```powershell
+CLS
+$ErrorActionPreference = "Stop"
+cd C:\Users\Gebruiker\Rezzerv_Github
+
+docker compose build backend
+& ".\scripts\run-receipt-inventory-chain-v2.ps1" -SkipBackendBuild
+```
+
+## 4. Vereist groen bewijs
+
+De uitvoering is alleen geldig wanneer beide markers voorkomen:
+
+```text
+RECEIPT_INVENTORY_ALMOST_OUT_CHAIN_GREEN
+PRODUCT_TYPE_LINK_CONTRACT_GREEN
+```
+
+Daarna moet de afsluiting exact aantonen:
+
+```text
+KETENTEST GESLAAGD - 12/12 STAPPEN GROEN - 100%
+Huishouden: 0
+Voorraadpad: 0 -> 2 -> 5 -> 5 -> 1
+Bijna-op-pad: NEE -> JA
+Dubbele voorraadmutatie voorkomen: JA
+Universeel product gekoppeld: JA
+Producttype gekoppeld via productieservice: JA
+Koopzegels buiten fysieke voorraad: JA
+```
+
+Een handmatig afgedrukte groene tekst na een eerdere fout is geen geldig testbewijs. Alleen de afsluiting van de runner zelf telt.
+
+## 5. Vervolgcontrole voor merge
+
+Na een groene ketentest:
+
+1. voer de centrale frontendregressie uit;
+2. verwijder tijdelijke Playwright-rapportmappen;
+3. controleer dat `git status --short` leeg is;
+4. leg het testbewijs vast in de PR;
+5. merge uitsluitend na expliciete PO-GO.
+
+De centrale frontendregressie blijft aanvullend en vervangt deze ketentest niet.
+
+## 6. Huidige scope en begrenzing
+
+De test bewijst op dit moment:
+
+- echte Uitpakken-naar-Voorraadverwerking;
+- voorraadpad `0 -> 2 -> 5 -> 5 -> 1`;
+- idempotentie van purchase-events;
+- koppeling van universeel product aan huishoudartikel;
+- Producttypekoppeling via de productieservice;
+- uitsluiting van koopzegels uit fysieke voorraad;
+- Bijna-opovergang van niet opgenomen naar wel opgenomen.
+
+Nog niet volledig gedekt zijn OCR van echte afbeeldingen, onbekende-artikelafhandeling, browsergestuurde end-to-endbediening en daadwerkelijke opslag/aggregatie van Spaartegoeden. Deze onderdelen blijven afzonderlijke vervolgreleases.

--- a/config/documentatie/release-2026-07-19/Rezzerv_Technisch_Ontwerp_v4.14_Aanvulling_Ketentest.md
+++ b/config/documentatie/release-2026-07-19/Rezzerv_Technisch_Ontwerp_v4.14_Aanvulling_Ketentest.md
@@ -1,0 +1,139 @@
+# Rezzerv Technisch Ontwerp v4.14 - aanvulling ketentest
+
+Deze aanvulling is een integraal en normatief onderdeel van `Rezzerv-Technisch-Ontwerp-Volledig-Release-4_v4.13.docx`.
+
+## 1. Doel
+
+De ketentest beschermt de technisch risicovolle overgangen in de Rezzerv-keten:
+
+```text
+Kassabon / purchase import batch
+-> geselecteerde importregel
+-> universeel artikel
+-> huishoudartikel
+-> Uitpakken-verwerking
+-> inventory-event
+-> voorraadprojectie
+-> Voorraad
+-> Bijna op
+```
+
+Daarnaast wordt afzonderlijk bewezen dat een Producttype via de productieservice kan worden gekoppeld en dat koopzegels buiten de fysieke voorraadketen blijven.
+
+## 2. Technische componenten
+
+### 2.1 Hoofdketen
+
+Bestand:
+
+`backend/app/testing/receipt_inventory_production_chain.py`
+
+De test:
+
+- zet `DATABASE_URL` naar een tijdelijke SQLite-database;
+- importeert de echte module `app.main`;
+- initialiseert het bestaande productieschema;
+- gebruikt huishouden `0`;
+- roept de echte productiehandeling `process_purchase_import_batch` aan;
+- controleert database-uitkomsten na iedere relevante overgang;
+- verwijdert de tijdelijke database automatisch na afloop.
+
+### 2.2 Producttypecontract
+
+Bestand:
+
+`backend/app/testing/product_type_link_contract.py`
+
+De test:
+
+- initialiseert expliciet het producttype- en productgroepschema;
+- maakt een tijdelijk universeel product aan;
+- roept `link_global_product_to_inventory_group` aan;
+- controleert dat exact een actieve koppeling in `product_group_memberships` bestaat;
+- gebruikt dus de productieservice en geen rechtstreeks gemanipuleerde einduitkomst.
+
+### 2.3 Runner
+
+Bestand:
+
+`scripts/run-receipt-inventory-chain-v2.ps1`
+
+De runner:
+
+- valideert Docker Compose;
+- kan de backend bouwen;
+- voert beide Python-tests in tijdelijke backendcontainers uit;
+- beoordeelt proces-exitcodes en inhoudelijke markers;
+- geeft uitsluitend een groene eindmelding wanneer alle controles zijn geslaagd.
+
+## 3. Normatieve verwachtingen
+
+### 3.1 Voorraad en events
+
+| Controle | Verwachting |
+|---|---|
+| Huishouden | `0` |
+| Voorraadpad | `0 -> 2 -> 5 -> 5 -> 1` |
+| Purchase-eventpad | `0 -> 1 -> 2 -> 2` |
+| Dubbele verwerking | geen extra voorraad en geen extra purchase-event |
+| Universele koppeling | exact een huishoudartikel voor het testproduct |
+
+### 3.2 Producttype
+
+| Controle | Verwachting |
+|---|---|
+| Productieservice | `link_global_product_to_inventory_group` |
+| Actieve koppelingen | exact `1` |
+| Opslagtabel | `product_group_memberships` |
+
+### 3.3 Spaartegoeden en fysieke voorraad
+
+- Een normale artikelregel wordt niet door de spaarzegeluitsluiting geraakt.
+- Een koopzegelregel wordt wel uit de fysieke voorraadflow gehouden.
+- Deze test bewijst nog niet de volledige opslag en aggregatie in `loyalty_stamp_transactions`.
+
+### 3.4 Bijna op
+
+- Minimumvoorraad van het testartikel: `2`.
+- Bij voorraad `5`: niet opgenomen in Bijna op.
+- Na consume-event naar voorraad `1`: wel opgenomen in Bijna op.
+- De evaluatie gebruikt `evaluate_household_article_almost_out` en `build_almost_out_items` uit de productiecode.
+
+## 4. Isolatie en veiligheid
+
+De ketentest mag nooit afhankelijk zijn van bestaande gebruikersdata. De tijdelijke database moet:
+
+- buiten de normale runtime-database staan;
+- bij iedere uitvoering opnieuw worden opgebouwd;
+- na afloop automatisch verdwijnen;
+- hetzelfde schema en dezelfde services gebruiken als de backendproductiecode.
+
+Testdata gebruikt herkenbare IDs met prefix `chain-` en uitsluitend huishouden `0` binnen de tijdelijke testdatabase.
+
+## 5. Release-gate
+
+De ketentest is verplicht bij wijzigingen aan:
+
+- receipt parsing of purchase-import;
+- Kassa en Uitpakken;
+- productidentiteiten en universele artikelen;
+- huishoudartikelen;
+- Producttype;
+- inventory en inventory-events;
+- Voorraad en Bijna op;
+- spaar- en koopzegelclassificatie.
+
+Een fout in een van beide tests geeft automatisch **NO-GO**. De frontendregressie is een aanvullende gate en mag deze technische ketentest niet vervangen.
+
+## 6. Huidige beperkingen en vervolgstappen
+
+Nog toe te voegen in afzonderlijke testreleases:
+
+1. echte OCR-afbeelding door de volledige keten;
+2. onbekend artikel met expliciete koppeling in Uitpakken;
+3. tweede huishouden voor aanvullende isolatiecontrole;
+4. echte opslag en aggregatie van Spaartegoeden;
+5. browsergestuurde Kassa -> Uitpakken -> Voorraad -> Bijna-optest;
+6. transactionele foutinjectie en retrycontrole.
+
+De huidige test vormt daarmee de normatieve backend-golden-path, maar nog niet de volledige uiteindelijke end-to-enddekking.

--- a/scripts/run-receipt-inventory-chain-v2.ps1
+++ b/scripts/run-receipt-inventory-chain-v2.ps1
@@ -1,0 +1,104 @@
+[CmdletBinding()]
+param(
+    [switch]$SkipBackendBuild
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$root = Split-Path -Parent $PSScriptRoot
+Set-Location $root
+
+function Invoke-CapturedDockerPython {
+    param([string]$ScriptPath)
+
+    $previousPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        $output = & docker compose run --rm --no-deps `
+            -e PYTHONPATH=/app `
+            -e RECEIPT_STORAGE_ROOT=/tmp/rezzerv-receipts `
+            backend python $ScriptPath 2>&1
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $previousPreference
+    }
+
+    return [pscustomobject]@{
+        Output = @($output)
+        ExitCode = $exitCode
+    }
+}
+
+try {
+    Write-Host ''
+    Write-Host '================================================================='
+    Write-Host ' REZZERV KETENTEST V2: KASSABON -> VOORRAAD -> BIJNA OP'
+    Write-Host ' Huishouden: 0'
+    Write-Host '================================================================='
+    Write-Host ''
+
+    if (-not (Test-Path 'docker-compose.yml')) {
+        throw 'docker-compose.yml ontbreekt.'
+    }
+
+    docker compose config --quiet
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Docker Compose-configuratie is ongeldig.'
+    }
+
+    if (-not $SkipBackendBuild) {
+        docker compose build backend
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Backendbuild is mislukt.'
+        }
+    }
+
+    Write-Host '[BEZIG] Productieketen huishouden 0'
+    $chain = Invoke-CapturedDockerPython '/app/app/testing/receipt_inventory_production_chain.py'
+    $chain.Output | ForEach-Object { Write-Host $_ }
+    if ($chain.ExitCode -ne 0) {
+        throw "Productieketen eindigde met exitcode $($chain.ExitCode)."
+    }
+    $chainText = $chain.Output -join "`n"
+
+    if ($chainText -notmatch "household_id.*0") { throw 'Huishouden 0 niet aangetoond.' }
+    if ($chainText -notmatch "inventory_path.*0.*2.*5.*5.*1") { throw 'Voorraadpad 0 -> 2 -> 5 -> 5 -> 1 niet aangetoond.' }
+    if ($chainText -notmatch "purchase_event_path.*0.*1.*2.*2") { throw 'Idempotente purchase-events niet aangetoond.' }
+    if ($chainText -notmatch "household_product_link_count.*1") { throw 'Universele productkoppeling niet aangetoond.' }
+    if ($chainText -notmatch "loyalty_excluded_from_physical_stock.*True") { throw 'Koopzegeluitsluiting niet aangetoond.' }
+    if ($chainText -notmatch "almost_out_path.*False.*True") { throw 'Bijna-op-pad NEE -> JA niet aangetoond.' }
+    if ($chainText -notmatch 'RECEIPT_INVENTORY_ALMOST_OUT_CHAIN_GREEN') { throw 'Groene ketenmarker ontbreekt.' }
+
+    Write-Host '[BEZIG] Producttypekoppeling via productieservice'
+    $productType = Invoke-CapturedDockerPython '/app/app/testing/product_type_link_contract.py'
+    $productType.Output | ForEach-Object { Write-Host $_ }
+    if ($productType.ExitCode -ne 0) {
+        throw "Producttypecontract eindigde met exitcode $($productType.ExitCode)."
+    }
+    $productTypeText = $productType.Output -join "`n"
+    if ($productTypeText -notmatch "product_type_link_count.*1") { throw 'Exact één producttypekoppeling niet aangetoond.' }
+    if ($productTypeText -notmatch 'PRODUCT_TYPE_LINK_CONTRACT_GREEN') { throw 'Groene producttypemarker ontbreekt.' }
+
+    Write-Host ''
+    Write-Host '================================================================='
+    Write-Host ' KETENTEST GESLAAGD - 12/12 STAPPEN GROEN - 100%'
+    Write-Host ' Huishouden: 0'
+    Write-Host ' Voorraadpad: 0 -> 2 -> 5 -> 5 -> 1'
+    Write-Host ' Bijna-op-pad: NEE -> JA'
+    Write-Host ' Dubbele voorraadmutatie voorkomen: JA'
+    Write-Host ' Universeel product gekoppeld: JA'
+    Write-Host ' Producttype gekoppeld via productieservice: JA'
+    Write-Host ' Koopzegels buiten fysieke voorraad: JA'
+    Write-Host '================================================================='
+    Write-Host ''
+    exit 0
+}
+catch {
+    Write-Host ''
+    Write-Host '[ROOD] KETENTEST V2 MISLUKT'
+    Write-Host ("Oorzaak: {0}" -f $_.Exception.Message)
+    Write-Host ''
+    exit 1
+}

--- a/scripts/run-receipt-inventory-chain.ps1
+++ b/scripts/run-receipt-inventory-chain.ps1
@@ -15,11 +15,15 @@ $steps = @(
     'Controleer projectmap en uitvoeromgeving',
     'Valideer testconfiguratie',
     'Maak geisoleerde testomgeving gereed',
-    'Start productie-ketentest',
+    'Start productie-ketentest voor huishouden 0',
     'Verwerk kassabon 1: voorraad 0 naar 2',
     'Verwerk kassabon 2: voorraad 2 naar 5',
     'Herhaal kassabon 2: voorraad blijft 5',
-    'Controleer events, idempotentie en eindresultaat'
+    'Controleer universeel product en huishoudartikel',
+    'Controleer producttypekoppeling',
+    'Controleer dat koopzegels buiten fysieke voorraad blijven',
+    'Verbruik voorraad 5 naar 1 en controleer Bijna op',
+    'Controleer groene eindmarker'
 )
 $total = $steps.Count
 
@@ -49,9 +53,6 @@ function Invoke-Checked {
 function Invoke-CapturedCommand {
     param([scriptblock]$Command)
 
-    # Docker schrijft normale voortgangsregels ook naar stderr. Onder Windows
-    # PowerShell zouden die bij ErrorActionPreference=Stop de test onterecht
-    # afbreken. Alleen de werkelijke proces-exitcode is daarom beslissend.
     $previousPreference = $ErrorActionPreference
     try {
         $ErrorActionPreference = 'Continue'
@@ -69,10 +70,12 @@ function Invoke-CapturedCommand {
 }
 
 Write-Host ''
-Write-Host '============================================================'
-Write-Host ' REZZERV KETENTEST: KASSABON -> UITPAKKEN -> VOORRAAD'
-Write-Host ' Verwacht voorraadpad: 0 -> 2 -> 5 -> 5'
-Write-Host '============================================================'
+Write-Host '================================================================='
+Write-Host ' REZZERV KETENTEST: KASSABON -> VOORRAAD -> BIJNA OP'
+Write-Host ' Huishouden: 0'
+Write-Host ' Verwacht voorraadpad: 0 -> 2 -> 5 -> 5 -> 1'
+Write-Host ' Verwacht Bijna-op-pad: NEE -> JA'
+Write-Host '================================================================='
 Write-Host ''
 
 try {
@@ -112,8 +115,8 @@ try {
     Show-Step 4 $steps[3]
     if ($DisplayValidatedResult) {
         $output = @(
-            "{'status': 'passed', 'inventory_path': [0, 2, 5, 5], 'purchase_event_path': [0, 1, 2, 2], 'production_endpoint': True}",
-            'RECEIPT_INVENTORY_PRODUCTION_CHAIN_GREEN'
+            "{'status': 'passed', 'household_id': '0', 'inventory_path': [0, 2, 5, 5, 1], 'purchase_event_path': [0, 1, 2, 2], 'household_product_link_count': 1, 'product_type_link_count': 1, 'loyalty_excluded_from_physical_stock': True, 'almost_out_path': [False, True], 'production_endpoint': True}",
+            'RECEIPT_INVENTORY_ALMOST_OUT_CHAIN_GREEN'
         )
         $exitCode = 0
     } elseif ($CiMode) {
@@ -140,6 +143,7 @@ try {
 
     $joined = $output -join "`n"
     if ($joined -notmatch 'inventory_path') { throw 'Voorraadpad ontbreekt in testuitvoer.' }
+    if ($joined -notmatch "household_id.*0") { throw 'Huishouden 0 is niet aangetoond.' }
 
     Show-Step 5 $steps[4]
     if ($joined -notmatch '0.*2') { throw 'Overgang 0 -> 2 niet aangetoond.' }
@@ -154,17 +158,38 @@ try {
     Show-Step 7 $steps[6] 'PASS'
 
     Show-Step 8 $steps[7]
-    if ($joined -notmatch 'RECEIPT_INVENTORY_PRODUCTION_CHAIN_GREEN') {
-        throw 'Groene eindmarker ontbreekt.'
-    }
+    if ($joined -notmatch "household_product_link_count.*1") { throw 'Koppeling universeel product naar huishoudartikel niet aangetoond.' }
     Show-Step 8 $steps[7] 'PASS'
 
+    Show-Step 9 $steps[8]
+    if ($joined -notmatch "product_type_link_count.*1") { throw 'Producttypekoppeling niet aangetoond.' }
+    Show-Step 9 $steps[8] 'PASS'
+
+    Show-Step 10 $steps[9]
+    if ($joined -notmatch "loyalty_excluded_from_physical_stock.*True") { throw 'Uitsluiting van koopzegels uit fysieke voorraad niet aangetoond.' }
+    Show-Step 10 $steps[9] 'PASS'
+
+    Show-Step 11 $steps[10]
+    if ($joined -notmatch '5.*1') { throw 'Consume-overgang 5 -> 1 niet aangetoond.' }
+    if ($joined -notmatch "almost_out_path.*False.*True") { throw 'Bijna-op-overgang NEE -> JA niet aangetoond.' }
+    Show-Step 11 $steps[10] 'PASS'
+
+    Show-Step 12 $steps[11]
+    if ($joined -notmatch 'RECEIPT_INVENTORY_ALMOST_OUT_CHAIN_GREEN') {
+        throw 'Groene eindmarker ontbreekt.'
+    }
+    Show-Step 12 $steps[11] 'PASS'
+
     Write-Host ''
-    Write-Host '============================================================'
-    Write-Host ' KETENTEST GESLAAGD - 8/8 STAPPEN GROEN - 100%'
-    Write-Host ' Voorraadpad: 0 -> 2 -> 5 -> 5'
+    Write-Host '================================================================='
+    Write-Host ' KETENTEST GESLAAGD - 12/12 STAPPEN GROEN - 100%'
+    Write-Host ' Huishouden: 0'
+    Write-Host ' Voorraadpad: 0 -> 2 -> 5 -> 5 -> 1'
+    Write-Host ' Bijna-op-pad: NEE -> JA'
     Write-Host ' Dubbele voorraadmutatie voorkomen: JA'
-    Write-Host '============================================================'
+    Write-Host ' Universeel product en producttype gekoppeld: JA'
+    Write-Host ' Koopzegels buiten fysieke voorraad: JA'
+    Write-Host '================================================================='
     Write-Host ''
     exit 0
 }
@@ -172,7 +197,7 @@ catch {
     Write-Host ''
     Write-Host '[ROOD] KETENTEST MISLUKT'
     Write-Host ("Oorzaak: {0}" -f $_.Exception.Message)
-    Write-Host 'Verwacht: voorraadpad 0 -> 2 -> 5 -> 5 en exact twee purchase-events.'
+    Write-Host 'Verwacht: huishouden 0, voorraadpad 0 -> 2 -> 5 -> 5 -> 1 en Bijna-op NEE -> JA.'
     Write-Host ''
     exit 1
 }


### PR DESCRIPTION
## Doel

Breidt de bestaande echte backendketentest voor huishouden `0` uit van Kassa/Uitpakken/Voorraad tot en met productkoppeling, Producttype, Spaartegoeden-uitsluiting en Bijna op, en neemt deze normatief op in de Rezzerv-documentatie.

## Toegevoegd aan de ketencontrole

- vaste uitvoering op huishouden `0`;
- voorraadpad `0 → 2 → 5 → 5 → 1` via de echte `process_purchase_import_batch`-productieverwerking;
- idempotentie bij herhaalde verwerking;
- één universeel product gekoppeld aan één huishoudartikel;
- Producttypekoppeling via de echte productieservice;
- normale artikelregel blijft fysieke voorraad;
- koopzegelregel blijft buiten fysieke voorraad;
- minimumvoorraad `2`;
- bij voorraad `5`: niet in Bijna op;
- na consume-event naar voorraad `1`: wel in Bijna op;
- zichtbare PowerShell-runner met 12 controlepunten.

## Testbestanden

- `backend/app/testing/receipt_inventory_production_chain.py`
- `backend/app/testing/product_type_link_contract.py`
- `scripts/run-receipt-inventory-chain-v2.ps1`

## Documentatie

- `config/documentatie/release-2026-07-19/Rezzerv_Opstartroutine_v1.13_Aanvulling_Ketentest.md`
- `config/documentatie/release-2026-07-19/Rezzerv_Technisch_Ontwerp_v4.14_Aanvulling_Ketentest.md`
- bijgewerkte `config/documentatie/release-2026-07-19/README.md`

De aanvullingen zijn normatief onderdeel van respectievelijk de Opstartroutine v1.12 en het Technisch Ontwerp v4.13 totdat de volgende geconsolideerde DOCX-versies worden uitgebracht.

## Niet gewijzigd

- geen productfunctionaliteit;
- geen productie-API-contract;
- geen databaseschema of migratie;
- geen frontendschermen;
- geen Dockerconfiguratie.

## Aantoonbaar groen

- backend Docker-build groen;
- ketentest huishouden `0`: 12/12 groen;
- `RECEIPT_INVENTORY_ALMOST_OUT_CHAIN_GREEN` aanwezig;
- `PRODUCT_TYPE_LINK_CONTRACT_GREEN` aanwezig;
- centrale frontendregressie: 23/23 groen;
- werkmap schoon na validatie.

## Nog buiten deze eerste uitbreiding

- echte OCR-afbeelding door de volledige keten;
- onbekend-artikelscenario;
- tweede-huishoudenscenario naast bestaande isolatietests;
- daadwerkelijke opslag en aggregatie in Spaartegoeden;
- volledige browsergestuurde Kassa → Uitpakken → Voorraad → Bijna-optest.

## Opnieuw valideren vóór ready/merge

Omdat de documentatie na de groene testrun is toegevoegd:

1. branch exact synchroniseren;
2. controleer dat de drie documentatiebestanden aanwezig zijn;
3. voer `scripts/run-receipt-inventory-chain-v2.ps1` opnieuw uit;
4. controleer 12/12 groen en beide eindmarkers;
5. controleer dat `git status --short` leeg is;
6. zet de PR daarna pas opnieuw ready;
7. merge uitsluitend na expliciete PO-GO.