### PR TITLE
Fase 1: read-only Catalogus met structurele doublurepreventie

### DIFF
--- a/backend/app/api/catalog_routes.py
+++ b/backend/app/api/catalog_routes.py
@@ -1,0 +1,251 @@
+﻿from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+from sqlalchemy import inspect, text
+
+from app.db import engine
+
+router = APIRouter(prefix="/api/catalog", tags=["catalog"])
+
+
+def _tables() -> set[str]:
+    return set(inspect(engine).get_table_names())
+
+
+def _columns(table_name: str) -> set[str]:
+    if table_name not in _tables():
+        return set()
+    return {str(column.get("name") or "") for column in inspect(engine).get_columns(table_name)}
+
+
+def _quality_status(row: dict[str, Any]) -> str:
+    if not str(row.get("primary_gtin") or "").strip():
+        return "Controle nodig"
+    if not str(row.get("product_type") or "").strip():
+        return "Controle nodig"
+    return "Compleet"
+
+
+def _household_table() -> str | None:
+    tables = _tables()
+    for candidate in ("household_articles", "household_products"):
+        if candidate in tables and "global_product_id" in _columns(candidate):
+            return candidate
+    return None
+
+
+def _catalog_base_rows() -> list[dict[str, Any]]:
+    tables = _tables()
+    if "global_products" not in tables:
+        return []
+
+    gp_columns = _columns("global_products")
+    selectable = {
+        "id": "gp.id",
+        "name": "gp.name",
+        "brand": "gp.brand",
+        "primary_gtin": "gp.primary_gtin",
+        "source": "gp.source",
+        "status": "gp.status",
+        "created_at": "gp.created_at",
+        "updated_at": "gp.updated_at",
+    }
+    select_parts = [
+        f"{expression} AS {alias}" if alias in gp_columns else f"NULL AS {alias}"
+        for alias, expression in selectable.items()
+    ]
+
+    joins: list[str] = []
+    if {"product_group_memberships", "product_inventory_groups"}.issubset(tables):
+        joins.extend(
+            [
+                """
+                LEFT JOIN product_group_memberships pgm
+                  ON pgm.global_product_id = gp.id
+                 AND COALESCE(pgm.active, 1) = 1
+                """,
+                """
+                LEFT JOIN product_inventory_groups pig
+                  ON pig.inventory_group_key = pgm.inventory_group_key
+                 AND COALESCE(pig.active, 1) = 1
+                """,
+            ]
+        )
+        select_parts.extend(
+            [
+                "pgm.inventory_group_key AS product_type_id",
+                "pig.display_name AS product_type",
+            ]
+        )
+    else:
+        select_parts.extend(["NULL AS product_type_id", "NULL AS product_type"])
+
+    household_table = _household_table()
+    if household_table:
+        joins.append(
+            f"""
+            LEFT JOIN (
+                SELECT global_product_id, COUNT(*) AS household_article_count
+                FROM {household_table}
+                WHERE global_product_id IS NOT NULL
+                GROUP BY global_product_id
+            ) hac ON hac.global_product_id = gp.id
+            """
+        )
+        select_parts.append("COALESCE(hac.household_article_count, 0) AS household_article_count")
+    else:
+        select_parts.append("0 AS household_article_count")
+
+    if "product_identities" in tables and "global_product_id" in _columns("product_identities"):
+        joins.append(
+            """
+            LEFT JOIN (
+                SELECT global_product_id, COUNT(*) AS identity_count
+                FROM product_identities
+                GROUP BY global_product_id
+            ) pic ON pic.global_product_id = gp.id
+            """
+        )
+        select_parts.append("COALESCE(pic.identity_count, 0) AS identity_count")
+    else:
+        select_parts.append("0 AS identity_count")
+
+    query = f"""
+        SELECT {", ".join(select_parts)}
+        FROM global_products gp
+        {" ".join(joins)}
+        ORDER BY COALESCE(gp.name, ''), gp.id
+    """
+
+    with engine.begin() as conn:
+        rows = [dict(row) for row in conn.execute(text(query)).mappings().all()]
+
+    for row in rows:
+        row["quality_status"] = _quality_status(row)
+    return rows
+
+
+@router.get("")
+def list_catalog(
+    query: str = Query(default="", max_length=200),
+    product_type: str = Query(default="", max_length=200),
+    quality_status: str = Query(default="", max_length=50),
+    limit: int = Query(default=500, ge=1, le=2000),
+):
+    rows = _catalog_base_rows()
+    query_value = query.strip().lower()
+    product_type_value = product_type.strip().lower()
+    quality_value = quality_status.strip().lower()
+
+    if query_value:
+        rows = [
+            row
+            for row in rows
+            if query_value
+            in " ".join(
+                [
+                    str(row.get("name") or ""),
+                    str(row.get("brand") or ""),
+                    str(row.get("primary_gtin") or ""),
+                    str(row.get("product_type") or ""),
+                ]
+            ).lower()
+        ]
+    if product_type_value:
+        rows = [
+            row
+            for row in rows
+            if product_type_value in str(row.get("product_type") or "").lower()
+        ]
+    if quality_value:
+        rows = [
+            row
+            for row in rows
+            if quality_value == str(row.get("quality_status") or "").lower()
+        ]
+
+    return {"items": rows[:limit], "total": len(rows)}
+
+
+@router.get("/{global_product_id}")
+def get_catalog_product(global_product_id: str):
+    rows = _catalog_base_rows()
+    product = next(
+        (row for row in rows if str(row.get("id") or "") == str(global_product_id)),
+        None,
+    )
+    if not product:
+        raise HTTPException(status_code=404, detail="Universeel artikel niet gevonden")
+
+    tables = _tables()
+    identities: list[dict[str, Any]] = []
+    if "product_identities" in tables and "global_product_id" in _columns("product_identities"):
+        identity_columns = _columns("product_identities")
+        requested = [
+            "id",
+            "identity_type",
+            "identity_value",
+            "is_primary",
+            "source",
+            "created_at",
+        ]
+        select_parts = [
+            column if column in identity_columns else f"NULL AS {column}"
+            for column in requested
+        ]
+        with engine.begin() as conn:
+            identities = [
+                dict(row)
+                for row in conn.execute(
+                    text(
+                        f"""
+                        SELECT {", ".join(select_parts)}
+                        FROM product_identities
+                        WHERE global_product_id = :global_product_id
+                        ORDER BY COALESCE(is_primary, 0) DESC, identity_type, identity_value
+                        """
+                    ),
+                    {"global_product_id": global_product_id},
+                ).mappings().all()
+            ]
+
+    household_articles: list[dict[str, Any]] = []
+    household_table = _household_table()
+    if household_table:
+        table_columns = _columns(household_table)
+        requested = [
+            "id",
+            "household_id",
+            "name",
+            "article_name",
+            "minimum_stock",
+            "ideal_stock",
+            "article_group_id",
+        ]
+        select_parts = [
+            column if column in table_columns else f"NULL AS {column}"
+            for column in requested
+        ]
+        with engine.begin() as conn:
+            household_articles = [
+                dict(row)
+                for row in conn.execute(
+                    text(
+                        f"""
+                        SELECT {", ".join(select_parts)}
+                        FROM {household_table}
+                        WHERE global_product_id = :global_product_id
+                        ORDER BY household_id, id
+                        """
+                    ),
+                    {"global_product_id": global_product_id},
+                ).mappings().all()
+            ]
+
+    return {
+        "product": product,
+        "identities": identities,
+        "household_articles": household_articles,
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -68,6 +68,7 @@ from app.services.external_article_product_link_service import (
 )
 from app.api.system_routes import router as system_router
 from app.api.product_inventory_group_routes import router as product_inventory_group_router
+from app.api.catalog_routes import router as catalog_router
 from app.api.receipt_diagnosis_routes import router as receipt_diagnosis_router
 from app.api.receipt_kpi_routes import router as receipt_kpi_router
 from app.api.receipt_import_diagnosis_routes import router as receipt_import_diagnosis_router
@@ -444,6 +445,7 @@ users = {email: dict(profile) for email, profile in DEFAULT_AUTH_USERS.items()}
 
 app.include_router(system_router)
 app.include_router(product_inventory_group_router)
+app.include_router(catalog_router)
 app.include_router(receipt_diagnosis_router)
 app.include_router(receipt_kpi_router)
 app.include_router(receipt_import_diagnosis_router)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -62,6 +62,10 @@ import tempfile
 import cv2
 
 from app.db import engine, get_runtime_datastore_info
+from app.services.global_product_service import (
+    build_global_product_fingerprint,
+    get_or_create_global_product,
+)
 from app.services.external_article_product_link_service import (
     ensure_external_article_product_link_schema,
     get_confirmed_external_article_product_link,
@@ -1618,6 +1622,7 @@ def ensure_global_product_catalog_schema():
                 category TEXT,
                 size_value NUMERIC,
                 size_unit TEXT,
+                product_fingerprint TEXT,
                 source TEXT NOT NULL DEFAULT 'user',
                 status TEXT NOT NULL DEFAULT 'active',
                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -1626,6 +1631,44 @@ def ensure_global_product_catalog_schema():
             """
         ))
         conn.execute(text("CREATE UNIQUE INDEX IF NOT EXISTS idx_global_products_primary_gtin ON global_products (primary_gtin) WHERE primary_gtin IS NOT NULL AND trim(primary_gtin) <> ''"))
+        ensure_table_column(conn, 'global_products', 'product_fingerprint', 'TEXT')
+        product_rows_for_fingerprint = conn.execute(text(
+            """
+            SELECT id, name, brand, variant, size_value, size_unit
+            FROM global_products
+            WHERE status = 'active'
+              AND COALESCE(trim(primary_gtin), '') = ''
+            ORDER BY datetime(created_at) ASC, id ASC
+            """
+        )).mappings().all()
+        seen_fingerprints: dict[str, str] = {}
+        for product_row in product_rows_for_fingerprint:
+            fingerprint = build_global_product_fingerprint(
+                product_row.get('name'), product_row.get('brand'), product_row.get('variant'),
+                product_row.get('size_value'), product_row.get('size_unit'),
+            )
+            if not fingerprint:
+                continue
+            existing_product_id = seen_fingerprints.get(fingerprint)
+            if existing_product_id and existing_product_id != str(product_row.get('id')):
+                raise RuntimeError(
+                    'Catalogus bevat nog inhoudelijke doublures zonder GTIN; '
+                    f"fingerprint={fingerprint}, ids={existing_product_id},{product_row.get('id')}"
+                )
+            seen_fingerprints[fingerprint] = str(product_row.get('id'))
+            conn.execute(
+                text("UPDATE global_products SET product_fingerprint = :product_fingerprint WHERE id = :id"),
+                {'id': str(product_row.get('id')), 'product_fingerprint': fingerprint},
+            )
+        conn.execute(text(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_global_products_active_fingerprint
+            ON global_products (product_fingerprint)
+            WHERE status = 'active'
+              AND COALESCE(trim(primary_gtin), '') = ''
+              AND COALESCE(trim(product_fingerprint), '') <> ''
+            """
+        ))
         product_identity_columns = ensure_table_column(conn, 'product_identities', 'global_product_id', 'TEXT')
         enrichment_columns = ensure_table_column(conn, 'product_enrichments', 'global_product_id', 'TEXT')
         if 'updated_at' not in enrichment_columns:
@@ -1803,53 +1846,24 @@ def normalize_global_product_status(value: str | None) -> str:
     return normalized if normalized in {'active', 'merged', 'archived'} else 'active'
 
 
-def ensure_global_product_record(conn, gtin: str | None, article_name: str | None, source: str = 'user', brand: str | None = None, category: str | None = None, size_value = None, size_unit: str | None = None) -> str | None:
+def ensure_global_product_record(conn, gtin: str | None, article_name: str | None, source: str = 'user', brand: str | None = None, category: str | None = None, size_value = None, size_unit: str | None = None, variant: str | None = None) -> str | None:
     normalized_gtin = normalize_barcode_value(gtin) if gtin else None
     normalized_name = normalize_household_article_name(article_name) or (f'Product {normalized_gtin}' if normalized_gtin else '')
     if not normalized_name:
         return None
-    existing = None
-    if normalized_gtin:
-        existing = conn.execute(text(
-            """
-            SELECT id, name, brand, category, size_value, size_unit
-            FROM global_products
-            WHERE primary_gtin = :primary_gtin
-            LIMIT 1
-            """
-        ), {'primary_gtin': normalized_gtin}).mappings().first()
-    if existing:
-        conn.execute(text(
-            """
-            UPDATE global_products
-            SET name = CASE WHEN COALESCE(trim(name), '') = '' THEN :name ELSE name END,
-                brand = COALESCE(brand, :brand),
-                category = COALESCE(category, :category),
-                size_value = COALESCE(size_value, :size_value),
-                size_unit = COALESCE(size_unit, :size_unit),
-                updated_at = CURRENT_TIMESTAMP
-            WHERE id = :id
-            """
-        ), {'id': existing.get('id'), 'name': normalized_name, 'brand': brand, 'category': category, 'size_value': size_value, 'size_unit': size_unit})
-        return str(existing.get('id'))
-    product_id = str(uuid.uuid4())
-    conn.execute(text(
-        """
-        INSERT INTO global_products (id, primary_gtin, name, brand, category, size_value, size_unit, source, status, created_at, updated_at)
-        VALUES (:id, :primary_gtin, :name, :brand, :category, :size_value, :size_unit, :source, :status, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-        """
-    ), {
-        'id': product_id,
-        'primary_gtin': normalized_gtin,
-        'name': normalized_name,
-        'brand': brand,
-        'category': category,
-        'size_value': size_value,
-        'size_unit': size_unit,
-        'source': normalize_global_product_source(source),
-        'status': normalize_global_product_status('active'),
-    })
-    return product_id
+    return get_or_create_global_product(
+        conn,
+        gtin=normalized_gtin,
+        name=normalized_name,
+        brand=normalize_optional_text_field(brand),
+        variant=normalize_optional_text_field(variant),
+        category=normalize_optional_text_field(category),
+        size_value=size_value,
+        size_unit=normalize_optional_text_field(size_unit),
+        source=normalize_global_product_source(source),
+        status=normalize_global_product_status('active'),
+        normalize_gtin=normalize_barcode_value,
+    )
 
 
 def resolve_global_product_id_for_article(conn, household_article_id: str, barcode: str | None = None) -> str | None:

--- a/backend/app/services/external_product_candidate_store.py
+++ b/backend/app/services/external_product_candidate_store.py
@@ -11,6 +11,7 @@ from app.services.external_article_ui_projection import (
 )
 
 from app.db import engine
+from app.services.global_product_service import get_or_create_global_product
 from app.services.external_database_matchers import match_retailer_receipt_line
 
 PROTECTED_CANDIDATE_STATUSES = {
@@ -1096,28 +1097,17 @@ def _m2c2i_fix7b_create_or_reuse_catalog_product_for_candidate(conn, candidate: 
             global_product_id = str(existing.get("global_product_id") or "").strip()
 
     if not global_product_id:
-        global_product_id = str(uuid.uuid4())
-        conn.execute(
-            text(
-                """
-                INSERT INTO global_products (
-                    id, primary_gtin, name, brand, variant, category,
-                    size_value, size_unit, source, status, created_at, updated_at
-                )
-                VALUES (
-                    :id, NULL, :name, :brand, :variant, :category,
-                    NULL, NULL, :source, 'active', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
-                )
-                """
-            ),
-            {
-                "id": global_product_id,
-                "name": _m2c2i_fix7b_best_candidate_name(candidate),
-                "brand": _m2c2i_fix7b_best_candidate_brand(candidate),
-                "variant": str(candidate.get("variant") or "").strip() or None,
-                "category": str(candidate.get("candidate_category") or candidate.get("variant") or "").strip() or None,
-                "source": str(candidate.get("candidate_source_name") or candidate.get("source_name") or "external_product_candidate").strip(),
-            },
+        global_product_id = get_or_create_global_product(
+            conn,
+            gtin=None,
+            name=_m2c2i_fix7b_best_candidate_name(candidate),
+            brand=_m2c2i_fix7b_best_candidate_brand(candidate),
+            variant=str(candidate.get("variant") or "").strip() or None,
+            category=str(candidate.get("candidate_category") or "").strip() or None,
+            size_value=None,
+            size_unit=None,
+            source=str(candidate.get("candidate_source_name") or candidate.get("source_name") or "external_product_candidate").strip(),
+            status="active",
         )
 
     primary_identity = _m2c2i_fix7b_identity_value(candidate)

--- a/backend/app/services/global_product_service.py
+++ b/backend/app/services/global_product_service.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import hashlib
+import uuid
+from decimal import Decimal, InvalidOperation
+from typing import Any, Callable
+
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+
+def normalize_product_fingerprint_text(value: Any) -> str:
+    return " ".join(str(value or "").strip().casefold().split())
+
+
+def normalize_product_fingerprint_number(value: Any) -> str:
+    if value is None or str(value).strip() == "":
+        return ""
+    try:
+        number = Decimal(str(value).replace(",", "."))
+    except (InvalidOperation, ValueError):
+        return normalize_product_fingerprint_text(value)
+    normalized = format(number.normalize(), "f")
+    return normalized.rstrip("0").rstrip(".") if "." in normalized else normalized
+
+
+def build_global_product_fingerprint(name: Any, brand: Any = None, variant: Any = None, size_value: Any = None, size_unit: Any = None) -> str:
+    normalized_name = normalize_product_fingerprint_text(name)
+    if not normalized_name:
+        return ""
+    canonical = "|".join((
+        normalized_name,
+        normalize_product_fingerprint_text(brand),
+        normalize_product_fingerprint_text(variant),
+        normalize_product_fingerprint_number(size_value),
+        normalize_product_fingerprint_text(size_unit),
+    ))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def get_or_create_global_product(
+    conn,
+    *,
+    gtin: str | None,
+    name: str,
+    brand: str | None = None,
+    variant: str | None = None,
+    category: str | None = None,
+    size_value: Any = None,
+    size_unit: str | None = None,
+    source: str = "user",
+    status: str = "active",
+    normalize_gtin: Callable[[str], str | None] | None = None,
+) -> str:
+    normalized_gtin = normalize_gtin(gtin) if gtin and normalize_gtin else (str(gtin).strip() if gtin else None)
+    normalized_gtin = normalized_gtin or None
+    normalized_name = " ".join(str(name or "").strip().split())
+    if not normalized_name:
+        raise ValueError("Productnaam is verplicht")
+
+    fingerprint = build_global_product_fingerprint(normalized_name, brand, variant, size_value, size_unit)
+
+    existing = None
+    if normalized_gtin:
+        existing = conn.execute(
+            text("SELECT id FROM global_products WHERE primary_gtin = :primary_gtin LIMIT 1"),
+            {"primary_gtin": normalized_gtin},
+        ).mappings().first()
+    elif fingerprint:
+        existing = conn.execute(
+            text("""
+                SELECT id FROM global_products
+                WHERE product_fingerprint = :product_fingerprint
+                  AND status = 'active'
+                  AND COALESCE(trim(primary_gtin), '') = ''
+                LIMIT 1
+            """),
+            {"product_fingerprint": fingerprint},
+        ).mappings().first()
+
+    if existing:
+        product_id = str(existing["id"])
+        conn.execute(
+            text("""
+                UPDATE global_products
+                SET name = CASE WHEN COALESCE(trim(name), '') = '' THEN :name ELSE name END,
+                    brand = COALESCE(brand, :brand),
+                    variant = COALESCE(variant, :variant),
+                    category = COALESCE(category, :category),
+                    size_value = COALESCE(size_value, :size_value),
+                    size_unit = COALESCE(size_unit, :size_unit),
+                    product_fingerprint = COALESCE(NULLIF(product_fingerprint, ''), :product_fingerprint),
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE id = :id
+            """),
+            {
+                "id": product_id,
+                "name": normalized_name,
+                "brand": brand,
+                "variant": variant,
+                "category": category,
+                "size_value": size_value,
+                "size_unit": size_unit,
+                "product_fingerprint": fingerprint or None,
+            },
+        )
+        return product_id
+
+    product_id = str(uuid.uuid4())
+    try:
+        conn.execute(
+            text("""
+                INSERT INTO global_products (
+                    id, primary_gtin, name, brand, variant, category,
+                    size_value, size_unit, product_fingerprint,
+                    source, status, created_at, updated_at
+                ) VALUES (
+                    :id, :primary_gtin, :name, :brand, :variant, :category,
+                    :size_value, :size_unit, :product_fingerprint,
+                    :source, :status, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                )
+            """),
+            {
+                "id": product_id,
+                "primary_gtin": normalized_gtin,
+                "name": normalized_name,
+                "brand": brand,
+                "variant": variant,
+                "category": category,
+                "size_value": size_value,
+                "size_unit": size_unit,
+                "product_fingerprint": fingerprint or None,
+                "source": source,
+                "status": status,
+            },
+        )
+        return product_id
+    except IntegrityError:
+        if normalized_gtin:
+            winner = conn.execute(text("SELECT id FROM global_products WHERE primary_gtin = :value LIMIT 1"), {"value": normalized_gtin}).mappings().first()
+        else:
+            winner = conn.execute(
+                text("""
+                    SELECT id FROM global_products
+                    WHERE product_fingerprint = :value
+                      AND status = 'active'
+                      AND COALESCE(trim(primary_gtin), '') = ''
+                    LIMIT 1
+                """),
+                {"value": fingerprint},
+            ).mappings().first()
+        if winner:
+            return str(winner["id"])
+        raise

--- a/backend/app/services/off_product_link_service.py
+++ b/backend/app/services/off_product_link_service.py
@@ -8,6 +8,7 @@ from typing import Any
 from sqlalchemy import text
 
 from app.db import engine
+from app.services.global_product_service import get_or_create_global_product
 from app.services.external_article_confirmation_service import (
     confirm_external_article_for_receipt_item,
 )
@@ -112,63 +113,19 @@ def _upsert_global_product(conn, off_product: dict[str, Any]) -> tuple[str, str,
     )
     size_value, size_unit = _parse_quantity_label(quantity_label)
 
-    existing = conn.execute(
-        text("SELECT id FROM global_products WHERE primary_gtin = :gtin LIMIT 1"),
-        {"gtin": gtin},
-    ).mappings().first()
-
-    if existing:
-        global_product_id = str(existing.get("id"))
-        conn.execute(
-            text(
-                """
-                UPDATE global_products
-                SET name = :name,
-                    brand = COALESCE(:brand, brand),
-                    category = COALESCE(:category, category),
-                    size_value = COALESCE(:size_value, size_value),
-                    size_unit = COALESCE(:size_unit, size_unit),
-                    source = 'open_food_facts',
-                    status = 'active',
-                    updated_at = CURRENT_TIMESTAMP
-                WHERE id = :id
-                """
-            ),
-            {
-                "id": global_product_id,
-                "name": product_name,
-                "brand": brand,
-                "category": category,
-                "size_value": size_value,
-                "size_unit": size_unit,
-            },
-        )
-    else:
-        global_product_id = str(uuid.uuid4())
-        conn.execute(
-            text(
-                """
-                INSERT INTO global_products (
-                    id, primary_gtin, name, brand, variant, category,
-                    size_value, size_unit, source, status, created_at, updated_at
-                ) VALUES (
-                    :id, :gtin, :name, :brand, :variant, :category,
-                    :size_value, :size_unit, 'open_food_facts', 'active',
-                    CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
-                )
-                """
-            ),
-            {
-                "id": global_product_id,
-                "gtin": gtin,
-                "name": product_name,
-                "brand": brand,
-                "variant": _clean_text(off_product.get("variant")) or None,
-                "category": category,
-                "size_value": size_value,
-                "size_unit": size_unit,
-            },
-        )
+    global_product_id = get_or_create_global_product(
+        conn,
+        gtin=gtin,
+        name=product_name,
+        brand=brand,
+        variant=_clean_text(off_product.get("variant")) or None,
+        category=category,
+        size_value=size_value,
+        size_unit=size_unit,
+        source="open_food_facts",
+        status="active",
+        normalize_gtin=lambda value: _normalize_gtin(value),
+    )
 
     identity = conn.execute(
         text(

--- a/backend/app/testing/global_product_deduplication_contract.py
+++ b/backend/app/testing/global_product_deduplication_contract.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine, text
+
+from app.services.global_product_service import build_global_product_fingerprint, get_or_create_global_product
+
+
+def run() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    with engine.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE global_products (
+                id TEXT PRIMARY KEY,
+                primary_gtin TEXT,
+                name TEXT NOT NULL,
+                brand TEXT,
+                variant TEXT,
+                category TEXT,
+                size_value NUMERIC,
+                size_unit TEXT,
+                product_fingerprint TEXT,
+                source TEXT NOT NULL DEFAULT 'user',
+                status TEXT NOT NULL DEFAULT 'active',
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT
+            )
+        """))
+        conn.execute(text("""
+            CREATE UNIQUE INDEX idx_global_products_primary_gtin
+            ON global_products(primary_gtin)
+            WHERE primary_gtin IS NOT NULL AND trim(primary_gtin) <> ''
+        """))
+        conn.execute(text("""
+            CREATE UNIQUE INDEX uq_global_products_active_fingerprint
+            ON global_products(product_fingerprint)
+            WHERE status = 'active'
+              AND COALESCE(trim(primary_gtin), '') = ''
+              AND COALESCE(trim(product_fingerprint), '') <> ''
+        """))
+
+        pizza_ids = {get_or_create_global_product(conn, gtin=None, name=value, source="test") for value in ("Pizza", " pizza ", "PIZZA")}
+        assert len(pizza_ids) == 1, pizza_ids
+
+        rice_plain = get_or_create_global_product(conn, gtin=None, name="Rijstwafel", variant=None, source="test")
+        rice_chocolate = get_or_create_global_product(conn, gtin=None, name="Rijstwafel", variant="Chocolade", source="test")
+        assert rice_plain != rice_chocolate
+
+        gtin_one = get_or_create_global_product(conn, gtin="8712345678901", name="Vruchtendrank", source="test")
+        gtin_two = get_or_create_global_product(conn, gtin="8712345678901", name="Vruchtendrank vernieuwd", source="test")
+        assert gtin_one == gtin_two
+
+        total = conn.execute(text("SELECT COUNT(*) FROM global_products")).scalar_one()
+        assert total == 4, total
+
+        pizza_fingerprint = build_global_product_fingerprint("Pizza")
+        pizza_count = conn.execute(text("SELECT COUNT(*) FROM global_products WHERE product_fingerprint=:fp"), {"fp": pizza_fingerprint}).scalar_one()
+        assert pizza_count == 1, pizza_count
+
+    print("PASS: generieke catalogusproducten worden centraal hergebruikt")
+    print("PASS: relevante varianten blijven afzonderlijke producten")
+    print("PASS: gelijke GTIN wordt hergebruikt")
+    print("PASS: unieke fingerprint-index blokkeert inhoudelijke doublures")
+
+
+if __name__ == "__main__":
+    run()

--- a/frontend/src/app/router/AppRouter.jsx
+++ b/frontend/src/app/router/AppRouter.jsx
@@ -24,6 +24,8 @@ import AlmostOutPage from '../../features/almostOut/AlmostOutPage.jsx'
 import ExternalDatabasesPage from '../../features/externalDatabases/ExternalDatabasesPage.jsx'
 import ProductGroupsPage from '../../features/productGroups/ProductGroupsPage.jsx'
 import LoyaltyStampsPage from '../../features/loyaltyStamps/LoyaltyStampsPage.jsx'
+import CatalogPage from '../../features/catalog/CatalogPage.jsx'
+import CatalogDetailPage from '../../features/catalog/CatalogDetailPage.jsx'
 import AuthGuard from './AuthGuard'
 import AdminGuard from './AdminGuard'
 import SettingsGuard from './SettingsGuard'
@@ -79,6 +81,8 @@ const router = createBrowserRouter([
   { path: '/kassa', element: <Protected><KassaPage /></Protected> },
   { path: '/kassa/nieuw', element: <Protected><KassaPage /></Protected> },
   { path: '/externe-databases', element: <Protected><ExternalDatabasesPage /></Protected> },
+  { path: '/catalogus', element: <ProtectedAdmin><CatalogPage /></ProtectedAdmin> },
+  { path: '/catalogus/:globalProductId', element: <ProtectedAdmin><CatalogDetailPage /></ProtectedAdmin> },
   { path: '/kassabon', element: <Protected><Navigate to="/kassa" replace /></Protected> },
   { path: '/import-kassabon', element: <Protected><Navigate to="/kassabonnen" replace /></Protected> },
   { path: '/kassabonnen/batch/:batchId', element: <Protected><StoreBatchDetailPage /></Protected> },

--- a/frontend/src/features/catalog/CatalogDetailPage.jsx
+++ b/frontend/src/features/catalog/CatalogDetailPage.jsx
@@ -1,0 +1,110 @@
+﻿import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import AppShell from '../../app/AppShell'
+import ScreenCard from '../../ui/ScreenCard'
+import Table from '../../ui/Table'
+import Button from '../../ui/Button'
+import { fetchJsonWithAuth } from '../../lib/authSession'
+import './catalog.css'
+
+function text(value, fallback = '-') {
+  const normalized = String(value ?? '').trim()
+  return normalized || fallback
+}
+
+export default function CatalogDetailPage() {
+  const { globalProductId } = useParams()
+  const navigate = useNavigate()
+  const [detail, setDetail] = useState(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    async function loadDetail() {
+      setIsLoading(true)
+      setError('')
+      try {
+        const response = await fetchJsonWithAuth(`/api/catalog/${encodeURIComponent(globalProductId)}`, { method: 'GET' })
+        const data = await response.json().catch(() => ({}))
+        if (!response.ok) throw new Error(data?.detail || 'Catalogusartikel kon niet worden geladen')
+        if (!cancelled) setDetail(data)
+      } catch (err) {
+        if (!cancelled) setError(err?.message || 'Catalogusartikel kon niet worden geladen')
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+    loadDetail()
+    return () => { cancelled = true }
+  }, [globalProductId])
+
+  const product = detail?.product || {}
+  const identities = Array.isArray(detail?.identities) ? detail.identities : []
+  const householdArticles = Array.isArray(detail?.household_articles) ? detail.household_articles : []
+
+  return (
+    <AppShell title="Catalogusdetail" showExit={false}>
+      <div className="rz-catalog-page" data-testid="catalog-detail-page">
+        <ScreenCard fullWidth>
+          <div className="rz-catalog-detail-actions">
+            <Button type="button" variant="secondary" onClick={() => navigate('/catalogus')}>Terug naar Catalogus</Button>
+          </div>
+
+          {isLoading ? <div>Catalogusartikel laden...</div> : null}
+          {error ? <div className="rz-inline-feedback rz-inline-feedback--error">{error}</div> : null}
+
+          {!isLoading && !error ? (
+            <div className="rz-catalog-detail-grid">
+              <section>
+                <h2>{text(product.name, 'Universeel artikel')}</h2>
+                <dl className="rz-catalog-definition-list">
+                  <div><dt>ID</dt><dd>{text(product.id)}</dd></div>
+                  <div><dt>Merk</dt><dd>{text(product.brand)}</dd></div>
+                  <div><dt>Primaire GTIN</dt><dd>{text(product.primary_gtin)}</dd></div>
+                  <div><dt>Producttype</dt><dd>{text(product.product_type)}</dd></div>
+                  <div><dt>Bron</dt><dd>{text(product.source)}</dd></div>
+                  <div><dt>Kwaliteitsstatus</dt><dd>{text(product.quality_status)}</dd></div>
+                </dl>
+              </section>
+
+              <section>
+                <h3>Identiteiten</h3>
+                <Table dataTestId="catalog-identities-table">
+                  <thead><tr className="rz-table-header"><th>Type</th><th>Waarde</th><th>Primair</th><th>Bron</th></tr></thead>
+                  <tbody>
+                    {identities.length ? identities.map((identity, index) => (
+                      <tr key={identity.id || `${identity.identity_type}-${identity.identity_value}-${index}`}>
+                        <td>{text(identity.identity_type)}</td>
+                        <td>{text(identity.identity_value)}</td>
+                        <td>{identity.is_primary ? 'Ja' : 'Nee'}</td>
+                        <td>{text(identity.source)}</td>
+                      </tr>
+                    )) : <tr><td colSpan="4">Geen aanvullende identiteiten gevonden.</td></tr>}
+                  </tbody>
+                </Table>
+              </section>
+
+              <section>
+                <h3>Gekoppelde huishoudartikelen</h3>
+                <Table dataTestId="catalog-household-articles-table">
+                  <thead><tr className="rz-table-header"><th>Huishouden</th><th>Huishoudartikel</th><th>Minimum</th><th>Ideaal</th></tr></thead>
+                  <tbody>
+                    {householdArticles.length ? householdArticles.map((article, index) => (
+                      <tr key={article.id || index}>
+                        <td>{text(article.household_id)}</td>
+                        <td>{text(article.name || article.article_name)}</td>
+                        <td>{text(article.minimum_stock)}</td>
+                        <td>{text(article.ideal_stock)}</td>
+                      </tr>
+                    )) : <tr><td colSpan="4">Geen gekoppelde huishoudartikelen gevonden.</td></tr>}
+                  </tbody>
+                </Table>
+              </section>
+            </div>
+          ) : null}
+        </ScreenCard>
+      </div>
+    </AppShell>
+  )
+}

--- a/frontend/src/features/catalog/CatalogPage.jsx
+++ b/frontend/src/features/catalog/CatalogPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import AppShell from '../../app/AppShell'
 import ScreenCard from '../../ui/ScreenCard'
 import Table from '../../ui/Table'
+import Button from '../../ui/Button'
 import { fetchJsonWithAuth } from '../../lib/authSession'
 import './catalog.css'
 
@@ -97,16 +98,16 @@ export default function CatalogPage() {
 
           <div className="rz-catalog-table-frame">
             <Table dataTestId="catalog-table" tableClassName="rz-catalog-table" resizableColumns>
+              <colgroup>
+                <col className="rz-catalog-col-name" />
+                <col className="rz-catalog-col-brand" />
+                <col className="rz-catalog-col-gtin" />
+                <col className="rz-catalog-col-product-type" />
+                <col className="rz-catalog-col-source" />
+                <col className="rz-catalog-col-household-count" />
+                <col className="rz-catalog-col-status" />
+              </colgroup>
               <thead>
-                <tr className="rz-table-header">
-                  <th onClick={() => updateSort('name')}>Universeel artikel</th>
-                  <th onClick={() => updateSort('brand')}>Merk</th>
-                  <th onClick={() => updateSort('primary_gtin')}>Primaire GTIN</th>
-                  <th onClick={() => updateSort('product_type')}>Producttype</th>
-                  <th onClick={() => updateSort('source')}>Bron</th>
-                  <th className="rz-num" onClick={() => updateSort('household_article_count')}>Huishoudartikelen</th>
-                  <th onClick={() => updateSort('quality_status')}>Status</th>
-                </tr>
                 <tr className="rz-table-filters">
                   <th><input className="rz-input rz-inline-input" placeholder="Zoek" value={filters.search} onChange={(event) => updateFilter('search', event.target.value)} /></th>
                   <th />
@@ -122,6 +123,15 @@ export default function CatalogPage() {
                       <option value="conflict">Conflict</option>
                     </select>
                   </th>
+                </tr>
+                <tr className="rz-table-header">
+                  <th onClick={() => updateSort('name')}>Universeel artikel</th>
+                  <th onClick={() => updateSort('brand')}>Merk</th>
+                  <th onClick={() => updateSort('primary_gtin')}>Primaire GTIN</th>
+                  <th onClick={() => updateSort('product_type')}>Producttype</th>
+                  <th onClick={() => updateSort('source')}>Bron</th>
+                  <th className="rz-num" onClick={() => updateSort('household_article_count')}>Huishoudartikelen</th>
+                  <th onClick={() => updateSort('quality_status')}>Status</th>
                 </tr>
               </thead>
               <tbody>
@@ -145,9 +155,9 @@ export default function CatalogPage() {
           </div>
 
           <div className="rz-catalog-pagination">
-            <button type="button" className="rz-button" disabled={currentPage <= 1} onClick={() => setPage(currentPage - 1)}>Vorige</button>
-            <span>Pagina {currentPage} van {pageCount} Â· {filteredItems.length} artikelen</span>
-            <button type="button" className="rz-button" disabled={currentPage >= pageCount} onClick={() => setPage(currentPage + 1)}>Volgende</button>
+            <Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => setPage(currentPage - 1)}>Vorige</Button>
+            <span>Pagina {currentPage} van {pageCount} - {filteredItems.length} artikelen</span>
+            <Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => setPage(currentPage + 1)}>Volgende</Button>
           </div>
         </ScreenCard>
       </div>

--- a/frontend/src/features/catalog/CatalogPage.jsx
+++ b/frontend/src/features/catalog/CatalogPage.jsx
@@ -1,10 +1,11 @@
-﻿import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import AppShell from '../../app/AppShell'
 import ScreenCard from '../../ui/ScreenCard'
 import Table from '../../ui/Table'
 import Button from '../../ui/Button'
 import { fetchJsonWithAuth } from '../../lib/authSession'
+import '../externalDatabases/externalDatabases.css'
 import './catalog.css'
 
 const PAGE_SIZE = 10
@@ -20,17 +21,32 @@ function qualityClass(status) {
   return 'rz-catalog-status rz-catalog-status--review'
 }
 
+function csvValue(value) {
+  return `"${String(value ?? '').replaceAll('"', '""')}"`
+}
+
 export default function CatalogPage() {
   const navigate = useNavigate()
   const [items, setItems] = useState([])
-  const [filters, setFilters] = useState({ search: '', productType: '', quality: '' })
+  const [selectedIds, setSelectedIds] = useState([])
+  const [filters, setFilters] = useState({
+    name: '',
+    brand: '',
+    primaryGtin: '',
+    productType: '',
+    source: '',
+    householdArticleCount: '',
+    qualityStatus: '',
+  })
   const [sort, setSort] = useState({ key: 'name', direction: 'asc' })
   const [page, setPage] = useState(1)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState('')
+  const [message, setMessage] = useState('')
 
   useEffect(() => {
     let cancelled = false
+
     async function loadCatalog() {
       setIsLoading(true)
       setError('')
@@ -45,32 +61,45 @@ export default function CatalogPage() {
         if (!cancelled) setIsLoading(false)
       }
     }
+
     loadCatalog()
     return () => { cancelled = true }
   }, [])
 
   const filteredItems = useMemo(() => {
-    const search = filters.search.trim().toLowerCase()
-    const productType = filters.productType.trim().toLowerCase()
-    const quality = filters.quality.trim().toLowerCase()
+    const normalizedFilters = Object.fromEntries(
+      Object.entries(filters).map(([key, value]) => [key, String(value || '').trim().toLowerCase()])
+    )
+
     const rows = items.filter((item) => {
-      const searchable = [item.name, item.brand, item.primary_gtin, item.product_type].join(' ').toLowerCase()
-      return (!search || searchable.includes(search))
-        && (!productType || String(item.product_type || '').toLowerCase().includes(productType))
-        && (!quality || String(item.quality_status || '').toLowerCase() === quality)
+      return (!normalizedFilters.name || String(item.name || '').toLowerCase().includes(normalizedFilters.name))
+        && (!normalizedFilters.brand || String(item.brand || '').toLowerCase().includes(normalizedFilters.brand))
+        && (!normalizedFilters.primaryGtin || String(item.primary_gtin || '').toLowerCase().includes(normalizedFilters.primaryGtin))
+        && (!normalizedFilters.productType || String(item.product_type || '').toLowerCase().includes(normalizedFilters.productType))
+        && (!normalizedFilters.source || String(item.source || '').toLowerCase().includes(normalizedFilters.source))
+        && (!normalizedFilters.householdArticleCount || String(item.household_article_count ?? '').toLowerCase().includes(normalizedFilters.householdArticleCount))
+        && (!normalizedFilters.qualityStatus || String(item.quality_status || '').toLowerCase() === normalizedFilters.qualityStatus)
     })
+
     rows.sort((left, right) => {
       const a = String(left?.[sort.key] ?? '').toLowerCase()
       const b = String(right?.[sort.key] ?? '').toLowerCase()
       const result = a.localeCompare(b, 'nl')
       return sort.direction === 'desc' ? -result : result
     })
+
     return rows
   }, [items, filters, sort])
+
+  useEffect(() => {
+    setSelectedIds((current) => current.filter((id) => items.some((item) => item.id === id)))
+  }, [items])
 
   const pageCount = Math.max(1, Math.ceil(filteredItems.length / PAGE_SIZE))
   const currentPage = Math.min(page, pageCount)
   const visibleItems = filteredItems.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
+  const visibleIds = visibleItems.map((item) => item.id)
+  const allVisibleSelected = visibleIds.length > 0 && visibleIds.every((id) => selectedIds.includes(id))
 
   function updateFilter(key, value) {
     setFilters((current) => ({ ...current, [key]: value }))
@@ -81,83 +110,175 @@ export default function CatalogPage() {
     setSort((current) => current.key === key
       ? { key, direction: current.direction === 'asc' ? 'desc' : 'asc' }
       : { key, direction: 'asc' })
+    setPage(1)
+  }
+
+  function sortMark(key) {
+    return sort.key === key && sort.direction === 'asc' ? '^' : 'v'
+  }
+
+  function goToPage(targetPage) {
+    setPage(Math.max(1, Math.min(pageCount, targetPage)))
+  }
+
+  function toggleSelected(id) {
+    setSelectedIds((current) => current.includes(id)
+      ? current.filter((selectedId) => selectedId !== id)
+      : [...current, id])
+  }
+
+  function toggleVisible() {
+    setSelectedIds((current) => {
+      if (allVisibleSelected) return current.filter((id) => !visibleIds.includes(id))
+      return Array.from(new Set([...current, ...visibleIds]))
+    })
+  }
+
+  function clearSelection() {
+    setSelectedIds([])
+    setMessage('Selectie gewist.')
+  }
+
+  function exportSelected() {
+    const selectedItems = items.filter((item) => selectedIds.includes(item.id))
+    if (!selectedItems.length) {
+      setMessage('Selecteer eerst een of meer catalogusartikelen.')
+      return
+    }
+
+    const rows = [
+      ['Universeel artikel', 'Merk', 'Primaire GTIN', 'Producttype', 'Bron', 'Huishoudartikelen', 'Status'],
+      ...selectedItems.map((item) => [
+        item.name,
+        item.brand,
+        item.primary_gtin,
+        item.product_type,
+        item.source,
+        item.household_article_count,
+        item.quality_status,
+      ]),
+    ]
+
+    const csv = rows.map((row) => row.map(csvValue).join(';')).join('\r\n')
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = 'rezzerv-catalogus-selectie.csv'
+    link.click()
+    URL.revokeObjectURL(url)
+    setMessage(`Export gemaakt voor ${selectedItems.length} catalogusartikel(en).`)
   }
 
   return (
     <AppShell title="Catalogus" showExit={false}>
-      <div className="rz-catalog-page" data-testid="catalog-page">
+      <div className="rz-catalog-page rz-external-databases" data-testid="catalog-page">
         <ScreenCard fullWidth>
-          <div className="rz-catalog-header">
-            <div>
-              <h2>Catalogus</h2>
-              <p>Read-only overzicht van universele artikelen, Producttypen en centrale productidentiteiten.</p>
+          <div className="rz-catalog-card">
+            <div className="rz-catalog-header">
+              <div>
+                <h2>Catalogus</h2>
+                <p>Read-only overzicht van universele artikelen, Producttypen en centrale productidentiteiten.</p>
+              </div>
             </div>
-          </div>
 
-          {error ? <div className="rz-inline-feedback rz-inline-feedback--error">{error}</div> : null}
+            {error ? <div className="rz-inline-feedback rz-inline-feedback--error">{error}</div> : null}
+            {message ? <div className="rz-inline-feedback">{message}</div> : null}
 
-          <div className="rz-catalog-table-frame">
-            <Table dataTestId="catalog-table" tableClassName="rz-catalog-table" resizableColumns>
-              <colgroup>
-                <col className="rz-catalog-col-name" />
-                <col className="rz-catalog-col-brand" />
-                <col className="rz-catalog-col-gtin" />
-                <col className="rz-catalog-col-product-type" />
-                <col className="rz-catalog-col-source" />
-                <col className="rz-catalog-col-household-count" />
-                <col className="rz-catalog-col-status" />
-              </colgroup>
-              <thead>
-                <tr className="rz-table-filters">
-                  <th><input className="rz-input rz-inline-input" placeholder="Zoek" value={filters.search} onChange={(event) => updateFilter('search', event.target.value)} /></th>
-                  <th />
-                  <th />
-                  <th><input className="rz-input rz-inline-input" placeholder="Filter" value={filters.productType} onChange={(event) => updateFilter('productType', event.target.value)} /></th>
-                  <th />
-                  <th />
-                  <th>
-                    <select className="rz-input rz-inline-input" value={filters.quality} onChange={(event) => updateFilter('quality', event.target.value)}>
-                      <option value="">Filter</option>
-                      <option value="compleet">Compleet</option>
-                      <option value="controle nodig">Controle nodig</option>
-                      <option value="conflict">Conflict</option>
-                    </select>
-                  </th>
-                </tr>
-                <tr className="rz-table-header">
-                  <th onClick={() => updateSort('name')}>Universeel artikel</th>
-                  <th onClick={() => updateSort('brand')}>Merk</th>
-                  <th onClick={() => updateSort('primary_gtin')}>Primaire GTIN</th>
-                  <th onClick={() => updateSort('product_type')}>Producttype</th>
-                  <th onClick={() => updateSort('source')}>Bron</th>
-                  <th className="rz-num" onClick={() => updateSort('household_article_count')}>Huishoudartikelen</th>
-                  <th onClick={() => updateSort('quality_status')}>Status</th>
-                </tr>
-              </thead>
-              <tbody>
-                {isLoading ? (
-                  <tr><td colSpan="7">Catalogus laden...</td></tr>
-                ) : visibleItems.length ? visibleItems.map((item) => (
-                  <tr key={item.id} onDoubleClick={() => navigate(`/catalogus/${encodeURIComponent(item.id)}`)} data-testid={`catalog-row-${item.id}`}>
-                    <td>{text(item.name)}</td>
-                    <td>{text(item.brand)}</td>
-                    <td>{text(item.primary_gtin)}</td>
-                    <td>{text(item.product_type)}</td>
-                    <td>{text(item.source)}</td>
-                    <td className="rz-num">{Number(item.household_article_count || 0)}</td>
-                    <td><span className={qualityClass(item.quality_status)}>{text(item.quality_status)}</span></td>
+            <div className="rz-external-databases-actions" aria-label="Bulkacties Catalogus">
+              <Button type="button" variant="secondary" disabled={!selectedIds.length} onClick={exportSelected}>
+                Exporteren
+              </Button>
+              <Button type="button" variant="secondary" disabled={!selectedIds.length} onClick={clearSelection}>
+                Selectie wissen
+              </Button>
+              <span className="rz-external-databases-muted">Geselecteerd: {selectedIds.length}</span>
+            </div>
+
+            <div className="rz-table-scroll rz-table-scroll--wide">
+              <Table dataTestId="catalog-table" tableClassName="rz-catalog-table" resizableColumns>
+                <colgroup>
+                  <col className="rz-catalog-col-select" />
+                  <col className="rz-catalog-col-name" />
+                  <col className="rz-catalog-col-brand" />
+                  <col className="rz-catalog-col-gtin" />
+                  <col className="rz-catalog-col-product-type" />
+                  <col className="rz-catalog-col-source" />
+                  <col className="rz-catalog-col-household-count" />
+                  <col className="rz-catalog-col-status" />
+                </colgroup>
+                <thead>
+                  <tr className="rz-table-header">
+                    <th className="rz-check">
+                      <input
+                        type="checkbox"
+                        checked={allVisibleSelected}
+                        onChange={toggleVisible}
+                        aria-label="Selecteer alle zichtbare catalogusartikelen"
+                      />
+                    </th>
+                    <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('name')}>Universeel artikel <span>{sortMark('name')}</span></button></th>
+                    <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('brand')}>Merk <span>{sortMark('brand')}</span></button></th>
+                    <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('primary_gtin')}>Primaire GTIN <span>{sortMark('primary_gtin')}</span></button></th>
+                    <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('product_type')}>Producttype <span>{sortMark('product_type')}</span></button></th>
+                    <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('source')}>Bron <span>{sortMark('source')}</span></button></th>
+                    <th className="rz-num"><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('household_article_count')}>Huishoudartikelen <span>{sortMark('household_article_count')}</span></button></th>
+                    <th><button type="button" className="rz-external-databases-sort" onClick={() => updateSort('quality_status')}>Status <span>{sortMark('quality_status')}</span></button></th>
                   </tr>
-                )) : (
-                  <tr><td colSpan="7">Geen universele artikelen gevonden.</td></tr>
-                )}
-              </tbody>
-            </Table>
-          </div>
+                  <tr className="rz-external-databases-filter-row">
+                    <th />
+                    <th><input className="rz-table-filter" placeholder="Zoek" value={filters.name} onChange={(event) => updateFilter('name', event.target.value)} /></th>
+                    <th><input className="rz-table-filter" placeholder="Filter" value={filters.brand} onChange={(event) => updateFilter('brand', event.target.value)} /></th>
+                    <th><input className="rz-table-filter" placeholder="Filter" value={filters.primaryGtin} onChange={(event) => updateFilter('primaryGtin', event.target.value)} /></th>
+                    <th><input className="rz-table-filter" placeholder="Filter" value={filters.productType} onChange={(event) => updateFilter('productType', event.target.value)} /></th>
+                    <th><input className="rz-table-filter" placeholder="Filter" value={filters.source} onChange={(event) => updateFilter('source', event.target.value)} /></th>
+                    <th><input className="rz-table-filter" placeholder="Filter" value={filters.householdArticleCount} onChange={(event) => updateFilter('householdArticleCount', event.target.value)} /></th>
+                    <th>
+                      <select className="rz-table-filter" value={filters.qualityStatus} onChange={(event) => updateFilter('qualityStatus', event.target.value)} aria-label="Kwaliteitsstatus filter">
+                        <option value="">Alle</option>
+                        <option value="compleet">Compleet</option>
+                        <option value="controle nodig">Controle nodig</option>
+                        <option value="conflict">Conflict</option>
+                      </select>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {isLoading ? (
+                    <tr><td colSpan="8">Catalogus laden...</td></tr>
+                  ) : visibleItems.length ? visibleItems.map((item) => (
+                    <tr key={item.id} onDoubleClick={() => navigate(`/catalogus/${encodeURIComponent(item.id)}`)} data-testid={`catalog-row-${item.id}`}>
+                      <td className="rz-check">
+                        <input
+                          type="checkbox"
+                          checked={selectedIds.includes(item.id)}
+                          onChange={() => toggleSelected(item.id)}
+                          aria-label={`Selecteer ${text(item.name, 'catalogusartikel')}`}
+                        />
+                      </td>
+                      <td>{text(item.name)}</td>
+                      <td>{text(item.brand)}</td>
+                      <td>{text(item.primary_gtin)}</td>
+                      <td>{text(item.product_type)}</td>
+                      <td>{text(item.source)}</td>
+                      <td className="rz-num">{Number(item.household_article_count || 0)}</td>
+                      <td><span className={qualityClass(item.quality_status)}>{text(item.quality_status)}</span></td>
+                    </tr>
+                  )) : (
+                    <tr><td colSpan="8">Geen universele artikelen gevonden.</td></tr>
+                  )}
+                </tbody>
+              </Table>
+            </div>
 
-          <div className="rz-catalog-pagination">
-            <Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => setPage(currentPage - 1)}>Vorige</Button>
-            <span>Pagina {currentPage} van {pageCount} - {filteredItems.length} artikelen</span>
-            <Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => setPage(currentPage + 1)}>Volgende</Button>
+            <div className="rz-external-databases-pagination" aria-label="Paginering Catalogus">
+              <Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => goToPage(1)}>Eerste</Button>
+              <Button type="button" variant="secondary" disabled={currentPage <= 1} onClick={() => goToPage(currentPage - 1)}>Vorige</Button>
+              <span className="rz-external-databases-page-indicator">Pagina {currentPage} van {pageCount}</span>
+              <Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => goToPage(currentPage + 1)}>Volgende</Button>
+              <Button type="button" variant="secondary" disabled={currentPage >= pageCount} onClick={() => goToPage(pageCount)}>Laatste</Button>
+              <span className="rz-external-databases-muted">{filteredItems.length} artikelen</span>
+            </div>
           </div>
         </ScreenCard>
       </div>

--- a/frontend/src/features/catalog/CatalogPage.jsx
+++ b/frontend/src/features/catalog/CatalogPage.jsx
@@ -1,0 +1,156 @@
+﻿import { useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import AppShell from '../../app/AppShell'
+import ScreenCard from '../../ui/ScreenCard'
+import Table from '../../ui/Table'
+import { fetchJsonWithAuth } from '../../lib/authSession'
+import './catalog.css'
+
+const PAGE_SIZE = 10
+
+function text(value, fallback = '-') {
+  const normalized = String(value ?? '').trim()
+  return normalized || fallback
+}
+
+function qualityClass(status) {
+  if (status === 'Compleet') return 'rz-catalog-status rz-catalog-status--complete'
+  if (status === 'Conflict') return 'rz-catalog-status rz-catalog-status--conflict'
+  return 'rz-catalog-status rz-catalog-status--review'
+}
+
+export default function CatalogPage() {
+  const navigate = useNavigate()
+  const [items, setItems] = useState([])
+  const [filters, setFilters] = useState({ search: '', productType: '', quality: '' })
+  const [sort, setSort] = useState({ key: 'name', direction: 'asc' })
+  const [page, setPage] = useState(1)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    async function loadCatalog() {
+      setIsLoading(true)
+      setError('')
+      try {
+        const response = await fetchJsonWithAuth('/api/catalog?limit=2000', { method: 'GET' })
+        const data = await response.json().catch(() => ({}))
+        if (!response.ok) throw new Error(data?.detail || 'Catalogus kon niet worden geladen')
+        if (!cancelled) setItems(Array.isArray(data?.items) ? data.items : [])
+      } catch (err) {
+        if (!cancelled) setError(err?.message || 'Catalogus kon niet worden geladen')
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+    loadCatalog()
+    return () => { cancelled = true }
+  }, [])
+
+  const filteredItems = useMemo(() => {
+    const search = filters.search.trim().toLowerCase()
+    const productType = filters.productType.trim().toLowerCase()
+    const quality = filters.quality.trim().toLowerCase()
+    const rows = items.filter((item) => {
+      const searchable = [item.name, item.brand, item.primary_gtin, item.product_type].join(' ').toLowerCase()
+      return (!search || searchable.includes(search))
+        && (!productType || String(item.product_type || '').toLowerCase().includes(productType))
+        && (!quality || String(item.quality_status || '').toLowerCase() === quality)
+    })
+    rows.sort((left, right) => {
+      const a = String(left?.[sort.key] ?? '').toLowerCase()
+      const b = String(right?.[sort.key] ?? '').toLowerCase()
+      const result = a.localeCompare(b, 'nl')
+      return sort.direction === 'desc' ? -result : result
+    })
+    return rows
+  }, [items, filters, sort])
+
+  const pageCount = Math.max(1, Math.ceil(filteredItems.length / PAGE_SIZE))
+  const currentPage = Math.min(page, pageCount)
+  const visibleItems = filteredItems.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
+
+  function updateFilter(key, value) {
+    setFilters((current) => ({ ...current, [key]: value }))
+    setPage(1)
+  }
+
+  function updateSort(key) {
+    setSort((current) => current.key === key
+      ? { key, direction: current.direction === 'asc' ? 'desc' : 'asc' }
+      : { key, direction: 'asc' })
+  }
+
+  return (
+    <AppShell title="Catalogus" showExit={false}>
+      <div className="rz-catalog-page" data-testid="catalog-page">
+        <ScreenCard fullWidth>
+          <div className="rz-catalog-header">
+            <div>
+              <h2>Catalogus</h2>
+              <p>Read-only overzicht van universele artikelen, Producttypen en centrale productidentiteiten.</p>
+            </div>
+          </div>
+
+          {error ? <div className="rz-inline-feedback rz-inline-feedback--error">{error}</div> : null}
+
+          <div className="rz-catalog-table-frame">
+            <Table dataTestId="catalog-table" tableClassName="rz-catalog-table" resizableColumns>
+              <thead>
+                <tr className="rz-table-header">
+                  <th onClick={() => updateSort('name')}>Universeel artikel</th>
+                  <th onClick={() => updateSort('brand')}>Merk</th>
+                  <th onClick={() => updateSort('primary_gtin')}>Primaire GTIN</th>
+                  <th onClick={() => updateSort('product_type')}>Producttype</th>
+                  <th onClick={() => updateSort('source')}>Bron</th>
+                  <th className="rz-num" onClick={() => updateSort('household_article_count')}>Huishoudartikelen</th>
+                  <th onClick={() => updateSort('quality_status')}>Status</th>
+                </tr>
+                <tr className="rz-table-filters">
+                  <th><input className="rz-input rz-inline-input" placeholder="Zoek" value={filters.search} onChange={(event) => updateFilter('search', event.target.value)} /></th>
+                  <th />
+                  <th />
+                  <th><input className="rz-input rz-inline-input" placeholder="Filter" value={filters.productType} onChange={(event) => updateFilter('productType', event.target.value)} /></th>
+                  <th />
+                  <th />
+                  <th>
+                    <select className="rz-input rz-inline-input" value={filters.quality} onChange={(event) => updateFilter('quality', event.target.value)}>
+                      <option value="">Filter</option>
+                      <option value="compleet">Compleet</option>
+                      <option value="controle nodig">Controle nodig</option>
+                      <option value="conflict">Conflict</option>
+                    </select>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {isLoading ? (
+                  <tr><td colSpan="7">Catalogus laden...</td></tr>
+                ) : visibleItems.length ? visibleItems.map((item) => (
+                  <tr key={item.id} onDoubleClick={() => navigate(`/catalogus/${encodeURIComponent(item.id)}`)} data-testid={`catalog-row-${item.id}`}>
+                    <td>{text(item.name)}</td>
+                    <td>{text(item.brand)}</td>
+                    <td>{text(item.primary_gtin)}</td>
+                    <td>{text(item.product_type)}</td>
+                    <td>{text(item.source)}</td>
+                    <td className="rz-num">{Number(item.household_article_count || 0)}</td>
+                    <td><span className={qualityClass(item.quality_status)}>{text(item.quality_status)}</span></td>
+                  </tr>
+                )) : (
+                  <tr><td colSpan="7">Geen universele artikelen gevonden.</td></tr>
+                )}
+              </tbody>
+            </Table>
+          </div>
+
+          <div className="rz-catalog-pagination">
+            <button type="button" className="rz-button" disabled={currentPage <= 1} onClick={() => setPage(currentPage - 1)}>Vorige</button>
+            <span>Pagina {currentPage} van {pageCount} Â· {filteredItems.length} artikelen</span>
+            <button type="button" className="rz-button" disabled={currentPage >= pageCount} onClick={() => setPage(currentPage + 1)}>Volgende</button>
+          </div>
+        </ScreenCard>
+      </div>
+    </AppShell>
+  )
+}

--- a/frontend/src/features/catalog/catalog.css
+++ b/frontend/src/features/catalog/catalog.css
@@ -1,0 +1,87 @@
+﻿.rz-catalog-page {
+  display: grid;
+  gap: 16px;
+}
+
+.rz-catalog-header h2,
+.rz-catalog-detail-grid h2,
+.rz-catalog-detail-grid h3 {
+  margin: 0;
+}
+
+.rz-catalog-header p {
+  margin: 6px 0 0;
+  color: #667085;
+}
+
+.rz-catalog-table-frame {
+  margin-top: 16px;
+  overflow-x: auto;
+}
+
+.rz-catalog-table {
+  min-width: 1080px;
+}
+
+.rz-catalog-table tbody tr {
+  cursor: pointer;
+}
+
+.rz-catalog-pagination,
+.rz-catalog-detail-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.rz-catalog-status {
+  display: inline-flex;
+  border-radius: 999px;
+  padding: 3px 9px;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.rz-catalog-status--complete {
+  background: #ecfdf3;
+  color: #027a48;
+}
+
+.rz-catalog-status--review {
+  background: #fffaeb;
+  color: #b54708;
+}
+
+.rz-catalog-status--conflict {
+  background: #fef3f2;
+  color: #b42318;
+}
+
+.rz-catalog-detail-grid {
+  display: grid;
+  gap: 22px;
+}
+
+.rz-catalog-definition-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.rz-catalog-definition-list div {
+  border: 1px solid #d0d5dd;
+  border-radius: 10px;
+  padding: 12px;
+  background: #f8fafc;
+}
+
+.rz-catalog-definition-list dt {
+  color: #667085;
+  font-size: 13px;
+}
+
+.rz-catalog-definition-list dd {
+  margin: 4px 0 0;
+}

--- a/frontend/src/features/catalog/catalog.css
+++ b/frontend/src/features/catalog/catalog.css
@@ -1,6 +1,6 @@
-﻿.rz-catalog-page {
+.rz-catalog-page {
   display: grid;
-  gap: 16px;
+  gap: var(--space-md);
   width: 100%;
   min-width: 0;
   box-sizing: border-box;
@@ -13,40 +13,43 @@
   box-sizing: border-box;
 }
 
+.rz-catalog-card {
+  display: grid;
+  gap: 18px;
+}
+
 .rz-catalog-header h2,
 .rz-catalog-detail-grid h2,
 .rz-catalog-detail-grid h3 {
   margin: 0;
+  color: var(--color-brand-primary);
 }
 
 .rz-catalog-header p {
   margin: 6px 0 0;
-  color: #667085;
-}
-
-.rz-catalog-table-frame {
-  width: 100%;
-  max-width: 100%;
-  min-width: 0;
-  margin-top: 16px;
-  overflow-x: auto;
+  color: #5f7a68;
 }
 
 .rz-catalog-table {
-  min-width: 1080px;
+  table-layout: fixed;
+  width: 100%;
+  min-width: 1100px;
 }
 
-.rz-catalog-table tbody tr {
-  cursor: pointer;
-}
+.rz-catalog-col-select { width: 44px; }
+.rz-catalog-col-name { width: 220px; }
+.rz-catalog-col-brand { width: 130px; }
+.rz-catalog-col-gtin { width: 145px; }
+.rz-catalog-col-product-type { width: 170px; }
+.rz-catalog-col-source { width: 145px; }
+.rz-catalog-col-household-count { width: 135px; }
+.rz-catalog-col-status { width: 110px; }
 
-.rz-catalog-pagination,
-.rz-catalog-detail-actions {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 12px;
-  margin-top: 14px;
+.rz-catalog-table th,
+.rz-catalog-table td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .rz-catalog-status {
@@ -70,6 +73,14 @@
 .rz-catalog-status--conflict {
   background: #fef3f2;
   color: #b42318;
+}
+
+.rz-catalog-detail-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 12px;
+  margin-top: 14px;
 }
 
 .rz-catalog-detail-grid {
@@ -97,33 +108,4 @@
 
 .rz-catalog-definition-list dd {
   margin: 4px 0 0;
-}
-
-.rz-catalog-table {
-  table-layout: fixed;
-  width: 1160px;
-  min-width: 1160px;
-}
-
-.rz-catalog-col-name { width: 230px; }
-.rz-catalog-col-brand { width: 150px; }
-.rz-catalog-col-gtin { width: 170px; }
-.rz-catalog-col-product-type { width: 190px; }
-.rz-catalog-col-source { width: 170px; }
-.rz-catalog-col-household-count { width: 130px; }
-.rz-catalog-col-status { width: 120px; }
-
-.rz-catalog-table th,
-.rz-catalog-table td {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.rz-catalog-table .rz-table-filters th {
-  background: #ffffff;
-}
-
-.rz-catalog-pagination .rz-button {
-  min-width: 88px;
 }

--- a/frontend/src/features/catalog/catalog.css
+++ b/frontend/src/features/catalog/catalog.css
@@ -1,6 +1,16 @@
 ﻿.rz-catalog-page {
   display: grid;
   gap: 16px;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+.rz-catalog-page > [data-testid="screen-card"] {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .rz-catalog-header h2,
@@ -15,6 +25,9 @@
 }
 
 .rz-catalog-table-frame {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   margin-top: 16px;
   overflow-x: auto;
 }
@@ -84,4 +97,33 @@
 
 .rz-catalog-definition-list dd {
   margin: 4px 0 0;
+}
+
+.rz-catalog-table {
+  table-layout: fixed;
+  width: 1160px;
+  min-width: 1160px;
+}
+
+.rz-catalog-col-name { width: 230px; }
+.rz-catalog-col-brand { width: 150px; }
+.rz-catalog-col-gtin { width: 170px; }
+.rz-catalog-col-product-type { width: 190px; }
+.rz-catalog-col-source { width: 170px; }
+.rz-catalog-col-household-count { width: 130px; }
+.rz-catalog-col-status { width: 120px; }
+
+.rz-catalog-table th,
+.rz-catalog-table td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rz-catalog-table .rz-table-filters th {
+  background: #ffffff;
+}
+
+.rz-catalog-pagination .rz-button {
+  min-width: 88px;
 }

--- a/frontend/src/features/home/HomePage.jsx
+++ b/frontend/src/features/home/HomePage.jsx
@@ -15,6 +15,7 @@ const tiles = [
   { key: 'kassa', label: 'Kassa', icon: '🧾' },
   { key: 'spaartegoeden', label: 'Spaartegoeden', icon: '🪙' },
   { key: 'externe-databases', label: 'Externe databases', icon: '🗄️' },
+  { key: 'catalogus', label: 'Catalogus', icon: 'CAT' },
   { key: 'klantkaarten', label: 'Klantkaarten', icon: '💳' },
   { key: 'recepten', label: 'Recepten', icon: '🍳' },
   { key: 'bestellen', label: 'Bestellen', icon: '📋' },
@@ -56,6 +57,7 @@ export default function HomePage() {
     if (key === 'kassa') navigate('/kassa')
     if (key === 'spaartegoeden') navigate('/spaartegoeden')
     if (key === 'externe-databases') navigate('/externe-databases')
+    if (key === 'catalogus') navigate('/catalogus')
     if (key === 'instellingen') navigate('/instellingen')
     if (key === 'admin') navigate('/admin')
   }
@@ -67,8 +69,8 @@ export default function HomePage() {
         <div className="rz-content-inner">
           <Card className="rz-card-home">
             <div className="rz-tile-grid" role="navigation" aria-label="Acties">
-              {tiles.filter((tile) => tile.key !== 'admin' || isHouseholdAdmin).map((t) => {
-                const clickable = ['bijna-op', 'voorraad', 'productgroepen', 'kassabonnen', 'kassa', 'spaartegoeden', 'externe-databases', 'instellingen', 'admin'].includes(t.key)
+              {tiles.filter((tile) => !['admin', 'catalogus'].includes(tile.key) || isHouseholdAdmin).map((t) => {
+                const clickable = ['bijna-op', 'voorraad', 'productgroepen', 'kassabonnen', 'kassa', 'spaartegoeden', 'externe-databases', 'instellingen', 'admin', 'catalogus'].includes(t.key)
                 return (
                   <div key={t.key} className="rz-tile" onClick={() => clickable && openTile(t.key)} style={{ cursor: clickable ? 'pointer' : 'default' }}>
                     <div className="rz-tile-icon" aria-hidden="true">{t.icon}</div>


### PR DESCRIPTION
## Doel

Voegt fase 1 van Catalogus toe als read-only centrale beheerroute voor universele artikelen en voorkomt structureel dat nieuwe inhoudelijke catalogusdoublures ontstaan.

## Scope

- actiebutton `Catalogus` op de Startpagina, alleen voor admin;
- route `/catalogus`;
- detailroute `/catalogus/:globalProductId`;
- read-only API `GET /api/catalog`;
- read-only API `GET /api/catalog/{global_product_id}`;
- overzicht van universeel artikel, merk, primaire GTIN, Producttype, bron, gekoppelde huishoudartikelen en kwaliteitsstatus;
- detailweergave met algemene productgegevens, identiteiten en gekoppelde huishoudartikelen;
- centrale `get_or_create_global_product`-service;
- genormaliseerde productfingerprint voor producten zonder GTIN;
- unieke database-index voor actieve producten met dezelfde fingerprint;
- gecentraliseerde externe kandidaatroute en Open Food Facts-route;
- regressietest voor generieke producten, varianten, GTIN-hergebruik en database-uniciteit.

## Datamodel

- `global_products` blijft de catalogus-SSOT;
- Producttype via `product_group_memberships` en `product_inventory_groups`;
- identiteiten via `product_identities`;
- huishoudartikelen uitsluitend read-only geteld en getoond;
- geen tweede catalogustabel;
- `product_fingerprint` bewaakt inhoudelijke uniciteit voor actieve producten zonder GTIN.

## Oorzaak van de doublures

Harde identiteiten zoals GTIN en externe artikelcodes waren al uniek, maar generieke producten zonder barcode konden via directe inserts opnieuw worden aangemaakt. Daardoor konden identieke combinaties van naam, merk, variant en inhoud meerdere keren in `global_products` terechtkomen.

## Oplossing

Producten zonder GTIN krijgen nu een deterministische fingerprint op basis van genormaliseerde productkenmerken. Alle relevante productie-aanmaakroutes gebruiken dezelfde centrale get-or-create-logica. De unieke database-index voorkomt ook bij gelijktijdige inserts dat dezelfde fingerprint tweemaal actief wordt opgeslagen.

## Validatie Catalogus fase 1

- backend en frontend Docker-build groen;
- `/api/health` geeft 200 OK;
- beide Catalogusroutes geregistreerd in OpenAPI;
- actieve frontendbundel bevat Catalogus fase 1;
- centrale frontendregressie: 23/23 groen;
- `git diff --check` groen, alleen bekende LF/CRLF-waarschuwingen.

## Validatie doublurepreventie

- Python-compilatie: geslaagd;
- backend rebuild: geslaagd;
- backend health: HTTP 200;
- generieke catalogusproducten worden centraal hergebruikt: PASS;
- relevante varianten blijven afzonderlijke producten: PASS;
- gelijke GTIN wordt hergebruikt: PASS;
- unieke fingerprint-index blokkeert inhoudelijke doublures: PASS;
- actieve producten zonder GTIN met fingerprint: 8;
- dubbele fingerprints: 0;
- inhoudelijke doubluregroepen: 0;
- `foreign_key_check`: 0;
- `integrity_check`: ok;
- `git diff --check`: geslaagd;
- laatste commit: `566088da`.

## Functionele PO-controle vóór merge

1. Log in als admin en controleer dat de actiebutton `Catalogus` zichtbaar is.
2. Controleer dat een niet-admin de actiebutton niet ziet en de route niet kan openen.
3. Open Catalogus en controleer dat de tabel zonder fout laadt.
4. Controleer zoeken, Producttypefilter, kwaliteitsfilter, sorteren en pagineren.
5. Dubbelklik een artikel en controleer de detailroute.
6. Controleer dat Producttype, GTIN, identiteiten en gekoppelde huishoudartikelen logisch worden weergegeven.
7. Controleer dat nergens mutatieacties beschikbaar zijn.
8. Controleer dat bestaande Startacties en schermen ongewijzigd werken.
9. Controleer functioneel dat eenzelfde generiek product niet opnieuw als apart catalogusproduct verschijnt.
10. Controleer dat producten met werkelijk verschillende merken, varianten of inhoud wel afzonderlijk blijven.

Merge uitsluitend na functionele PO-acceptatie en expliciete GO.