### PR TITLE
Koppel geldige barcodes expliciet aan Mijn artikel en toon Catalogusstatus direct

### DIFF
--- a/backend/app/api/barcode_routes.py
+++ b/backend/app/api/barcode_routes.py
@@ -9,6 +9,7 @@ from app.services.barcode_identity_service import (
     BarcodeHouseholdArticleLinkError,
     link_household_article_to_matched_product,
     lookup_gtin,
+    save_gtin_catalog_and_household_link,
     validate_barcode,
 )
 from app.services.household_context_adapter import (
@@ -102,4 +103,52 @@ def barcode_household_article_link(
         raise HTTPException(
             status_code=500,
             detail="Barcodekoppeling kon niet worden opgeslagen",
+        ) from exc
+
+
+
+@router.post("/{gtin}/save-household-article")
+def save_barcode_for_household_article(
+    gtin: str,
+    payload: dict[str, Any] = Body(default_factory=dict),
+    authorization: Optional[str] = Header(None),
+):
+    runtime_context = _require_auth(authorization)
+    household_context = household_context_from_runtime_context(
+        runtime_context
+    )
+
+    if household_context.role == "viewer":
+        raise HTTPException(
+            status_code=403,
+            detail="Alleen een lid of beheerder mag barcodes opslaan.",
+        )
+
+    try:
+        with engine.begin() as conn:
+            return save_gtin_catalog_and_household_link(
+                conn,
+                household_id=household_context.active_household_id,
+                purchase_import_line_id=str(
+                    payload.get("purchase_import_line_id") or ""
+                ),
+                household_article_id=str(
+                    payload.get("household_article_id") or ""
+                ),
+                gtin=gtin,
+                article_name=str(
+                    payload.get("article_name") or ""
+                ),
+            )
+    except BarcodeHouseholdArticleLinkError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail=exc.detail,
+        ) from exc
+    except Exception as exc:
+        if isinstance(exc, HTTPException):
+            raise
+        raise HTTPException(
+            status_code=500,
+            detail="De barcode kon niet worden opgeslagen.",
         ) from exc

--- a/backend/app/api/barcode_routes.py
+++ b/backend/app/api/barcode_routes.py
@@ -5,7 +5,15 @@ from typing import Any, Callable, Optional
 from fastapi import APIRouter, Body, Header, HTTPException
 
 from app.db import engine
-from app.services.barcode_identity_service import lookup_gtin, validate_barcode
+from app.services.barcode_identity_service import (
+    BarcodeHouseholdArticleLinkError,
+    link_household_article_to_matched_product,
+    lookup_gtin,
+    validate_barcode,
+)
+from app.services.household_context_adapter import (
+    household_context_from_runtime_context,
+)
 
 router = APIRouter(prefix="/api/barcodes", tags=["barcodes"])
 _require_authenticated_context: Callable[..., dict] | None = None
@@ -47,3 +55,51 @@ def barcode_lookup(
         if isinstance(exc, HTTPException):
             raise
         raise HTTPException(status_code=500, detail="Barcode kon niet worden opgezocht") from exc
+
+
+
+@router.post("/{gtin}/household-article-link")
+def barcode_household_article_link(
+    gtin: str,
+    payload: dict[str, Any] = Body(default_factory=dict),
+    authorization: Optional[str] = Header(None),
+):
+    runtime_context = _require_auth(authorization)
+    household_context = household_context_from_runtime_context(
+        runtime_context
+    )
+
+    if household_context.role == "viewer":
+        raise HTTPException(
+            status_code=403,
+            detail="Alleen een lid of beheerder mag artikelen koppelen.",
+        )
+
+    try:
+        with engine.begin() as conn:
+            return link_household_article_to_matched_product(
+                conn,
+                household_id=household_context.active_household_id,
+                purchase_import_line_id=str(
+                    payload.get("purchase_import_line_id") or ""
+                ),
+                household_article_id=str(
+                    payload.get("household_article_id") or ""
+                ),
+                gtin=gtin,
+                global_product_id=str(
+                    payload.get("global_product_id") or ""
+                ),
+            )
+    except BarcodeHouseholdArticleLinkError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail=exc.detail,
+        ) from exc
+    except Exception as exc:
+        if isinstance(exc, HTTPException):
+            raise
+        raise HTTPException(
+            status_code=500,
+            detail="Barcodekoppeling kon niet worden opgeslagen",
+        ) from exc

--- a/backend/app/api/catalog_routes.py
+++ b/backend/app/api/catalog_routes.py
@@ -22,14 +22,22 @@ def _columns(table_name: str) -> set[str]:
 
 def _quality_status(row: dict[str, Any]) -> str:
     source = str(row.get("source") or "").strip().lower()
+    has_gtin = bool(
+        str(row.get("primary_gtin") or "").strip()
+    )
+    has_product_type = bool(
+        str(row.get("product_type") or "").strip()
+    )
 
-    if source == "receipt_user_confirmed":
-        return "Door gebruiker bevestigd"
-
-    if not str(row.get("primary_gtin") or "").strip():
+    if not has_gtin:
         return "Controle nodig"
 
-    if not str(row.get("product_type") or "").strip():
+    if source == "receipt_user_confirmed":
+        if not has_product_type:
+            return "GTIN bevestigd — producttype ontbreekt"
+        return "Door gebruiker bevestigd"
+
+    if not has_product_type:
         return "Controle nodig"
 
     return "Compleet"

--- a/backend/app/api/catalog_routes.py
+++ b/backend/app/api/catalog_routes.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 from typing import Any
 
@@ -21,10 +21,17 @@ def _columns(table_name: str) -> set[str]:
 
 
 def _quality_status(row: dict[str, Any]) -> str:
+    source = str(row.get("source") or "").strip().lower()
+
+    if source == "receipt_user_confirmed":
+        return "Door gebruiker bevestigd"
+
     if not str(row.get("primary_gtin") or "").strip():
         return "Controle nodig"
+
     if not str(row.get("product_type") or "").strip():
         return "Controle nodig"
+
     return "Compleet"
 
 
@@ -215,18 +222,50 @@ def get_catalog_product(global_product_id: str):
     household_table = _household_table()
     if household_table:
         table_columns = _columns(household_table)
-        requested = [
+        select_parts = [
             "id",
             "household_id",
-            "name",
-            "article_name",
-            "minimum_stock",
-            "ideal_stock",
-            "article_group_id",
-        ]
-        select_parts = [
-            column if column in table_columns else f"NULL AS {column}"
-            for column in requested
+            (
+                "COALESCE(custom_name, naam) AS name"
+                if {"custom_name", "naam"}.issubset(table_columns)
+                else (
+                    "naam AS name"
+                    if "naam" in table_columns
+                    else (
+                        "name"
+                        if "name" in table_columns
+                        else "NULL AS name"
+                    )
+                )
+            ),
+            (
+                "naam AS article_name"
+                if "naam" in table_columns
+                else (
+                    "article_name"
+                    if "article_name" in table_columns
+                    else "NULL AS article_name"
+                )
+            ),
+            (
+                "min_stock AS minimum_stock"
+                if "min_stock" in table_columns
+                else (
+                    "minimum_stock"
+                    if "minimum_stock" in table_columns
+                    else "NULL AS minimum_stock"
+                )
+            ),
+            (
+                "ideal_stock"
+                if "ideal_stock" in table_columns
+                else "NULL AS ideal_stock"
+            ),
+            (
+                "article_group_id"
+                if "article_group_id" in table_columns
+                else "NULL AS article_group_id"
+            ),
         ]
         with engine.begin() as conn:
             household_articles = [
@@ -244,8 +283,62 @@ def get_catalog_product(global_product_id: str):
                 ).mappings().all()
             ]
 
+    receipt_lines: list[dict[str, Any]] = []
+
+    if {
+        "purchase_import_lines",
+        "purchase_import_batches",
+    }.issubset(tables):
+        with engine.begin() as conn:
+            receipt_lines = [
+                dict(row)
+                for row in conn.execute(
+                    text(
+                        """
+                        SELECT
+                            pil.id,
+                            pil.batch_id,
+                            pil.article_name_raw,
+                            pil.matched_household_article_id,
+                            COALESCE(
+                                pil.matched_global_product_id,
+                                ha.global_product_id
+                            ) AS matched_global_product_id,
+                            COALESCE(
+                                ha.custom_name,
+                                ha.naam
+                            ) AS household_article_name,
+                            COALESCE(
+                                ha.barcode,
+                                gp.primary_gtin
+                            ) AS gtin,
+                            pib.created_at
+                        FROM purchase_import_lines pil
+                        JOIN purchase_import_batches pib
+                          ON pib.id = pil.batch_id
+                        LEFT JOIN household_articles ha
+                          ON ha.id = pil.matched_household_article_id
+                        LEFT JOIN global_products gp
+                          ON gp.id = COALESCE(
+                              pil.matched_global_product_id,
+                              ha.global_product_id
+                          )
+                        WHERE COALESCE(
+                            pil.matched_global_product_id,
+                            ha.global_product_id
+                        ) = :global_product_id
+                        ORDER BY
+                            datetime(pib.created_at) DESC,
+                            pil.id DESC
+                        """
+                    ),
+                    {"global_product_id": global_product_id},
+                ).mappings().all()
+            ]
+
     return {
         "product": product,
         "identities": identities,
         "household_articles": household_articles,
+        "receipt_lines": receipt_lines,
     }

--- a/backend/app/api/catalog_routes.py
+++ b/backend/app/api/catalog_routes.py
@@ -32,12 +32,9 @@ def _quality_status(row: dict[str, Any]) -> str:
     if not has_gtin:
         return "Controle nodig"
 
-    if source == "receipt_user_confirmed":
-        if not has_product_type:
-            return "GTIN bevestigd — producttype ontbreekt"
-        return "Door gebruiker bevestigd"
-
     if not has_product_type:
+        if source == "receipt_user_confirmed":
+            return "GTIN bevestigd — producttype nog te bepalen"
         return "Controle nodig"
 
     return "Compleet"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16785,14 +16785,25 @@ def get_purchase_import_batch(batch_id: str):
                     pil.match_status,
                     pil.review_decision,
                     pil.matched_household_article_id,
-                    pil.matched_global_product_id,
-                    COALESCE(pil.selected_article_group_id, ha.article_group_id) AS selected_article_group_id,
+                    COALESCE(
+                        pil.matched_global_product_id,
+                        ha.global_product_id
+                    ) AS matched_global_product_id,
+                    COALESCE(
+                        pil.selected_article_group_id,
+                        ha.article_group_id
+                    ) AS selected_article_group_id,
                     ag.name AS selected_article_group_name,
                     gp.name AS matched_global_product_name,
                     gp.brand AS matched_global_product_brand,
                     gp.category AS matched_global_product_category,
                     gp.source AS matched_global_product_source,
                     gp.status AS matched_global_product_status,
+                    gp.primary_gtin AS matched_global_product_gtin,
+                    COALESCE(
+                        ha.barcode,
+                        gp.primary_gtin
+                    ) AS barcode,
                     pil.target_location_id,
                     pil.suggested_household_article_id,
                     pil.suggested_location_id,
@@ -16807,10 +16818,14 @@ def get_purchase_import_batch(batch_id: str):
                     pil.processing_error,
                     pil.final_location_id
                 FROM purchase_import_lines pil
-                LEFT JOIN global_products gp ON gp.id = pil.matched_global_product_id
                 LEFT JOIN household_articles ha
                   ON ha.id = pil.matched_household_article_id
                  AND ha.household_id = :household_id
+                LEFT JOIN global_products gp
+                  ON gp.id = COALESCE(
+                      pil.matched_global_product_id,
+                      ha.global_product_id
+                  )
                 LEFT JOIN article_groups ag
                   ON ag.id = COALESCE(pil.selected_article_group_id, ha.article_group_id)
                  AND ag.household_id = :household_id

--- a/backend/app/services/barcode_identity_service.py
+++ b/backend/app/services/barcode_identity_service.py
@@ -15,6 +15,12 @@ from typing import Any
 
 from sqlalchemy import inspect, text
 
+from app.services.gpc_local_catalog_service import classify_gpc_product
+from app.services.off_search_service import lookup_off_product_by_gtin
+from app.services.product_inventory_group_store import (
+    link_global_product_to_inventory_group_with_connection,
+)
+
 GTIN_LENGTH_TO_FORMAT = {
     8: "GTIN-8",
     12: "GTIN-12",
@@ -1079,6 +1085,84 @@ def _link_saved_product_to_household(
             )
 
 
+
+def classify_gtin_product_type(
+    *,
+    gtin: str,
+    fallback_product_name: str,
+) -> dict[str, Any]:
+    """Bepaal generiek een officieel GPC-producttype voor een GTIN."""
+    external_result = lookup_off_product_by_gtin(gtin)
+    external_product = external_result.get("product")
+
+    product_name = " ".join(
+        str(
+            (external_product or {}).get("product_name")
+            or fallback_product_name
+            or ""
+        ).strip().split()
+    )
+    category = " ".join(
+        str(
+            (external_product or {}).get("category")
+            or (external_product or {}).get("categories")
+            or ""
+        ).strip().split()
+    )
+    explicit_gpc_brick_code = str(
+        (external_product or {}).get("explicit_gpc_brick_code")
+        or ""
+    ).strip()
+
+    classification = classify_gpc_product(
+        product_name=product_name,
+        category=category,
+        explicit_gpc_brick_code=explicit_gpc_brick_code,
+    )
+
+    if classification.get("status") != "classified":
+        return {
+            "ok": True,
+            "status": "review_required",
+            "reason": classification.get("reason")
+            or external_result.get("status")
+            or "not_classified",
+            "gtin": gtin,
+            "external_source_status": external_result.get("status"),
+            "product_type": None,
+            "mutates_inventory": False,
+            "creates_inventory_event": False,
+        }
+
+    product_type_id = str(
+        classification.get("product_type_id") or ""
+    ).strip()
+
+    if not product_type_id.startswith("gpc:"):
+        return {
+            "ok": True,
+            "status": "review_required",
+            "reason": "classification_is_not_official_gpc",
+            "gtin": gtin,
+            "external_source_status": external_result.get("status"),
+            "product_type": None,
+            "mutates_inventory": False,
+            "creates_inventory_event": False,
+        }
+
+    return {
+        "ok": True,
+        "status": "classified",
+        "gtin": gtin,
+        "external_source_status": external_result.get("status"),
+        "product_name": product_name,
+        "category": category,
+        "product_type": classification,
+        "mutates_inventory": False,
+        "creates_inventory_event": False,
+    }
+
+
 def save_gtin_catalog_and_household_link(
     conn,
     *,
@@ -1127,6 +1211,11 @@ def save_gtin_catalog_and_household_link(
             "Bonregel en Mijn artikel zijn verplicht.",
         )
 
+    product_type_classification = classify_gtin_product_type(
+        gtin=normalized_gtin,
+        fallback_product_name=normalized_article_name,
+    )
+
     tables = _table_names(conn)
     inventory_event_count = None
 
@@ -1156,6 +1245,41 @@ def save_gtin_catalog_and_household_link(
         gtin=normalized_gtin,
     )
 
+    classified_product_type = (
+        product_type_classification.get("product_type") or {}
+    )
+    product_type_id = str(
+        classified_product_type.get("product_type_id") or ""
+    ).strip()
+
+    if (
+        product_type_classification.get("status") == "classified"
+        and product_type_id
+    ):
+        membership = link_global_product_to_inventory_group_with_connection(
+            conn,
+            global_product_id=product_id,
+            inventory_group_key=product_type_id,
+            comparison_group_key=product_type_id,
+            confidence=float(
+                classified_product_type.get("confidence") or 1.0
+            ),
+            source=str(
+                classified_product_type.get("classification_source")
+                or "automatic_gtin_gpc"
+            ),
+            confirmed_by_user=False,
+        )
+
+        if not membership.get("ok"):
+            raise BarcodeHouseholdArticleLinkError(
+                500,
+                str(
+                    membership.get("error")
+                    or "Het Producttype kon niet centraal worden gekoppeld."
+                ),
+            )
+
     if "inventory_events" in tables:
         inventory_event_count_after = conn.execute(
             text("SELECT COUNT(*) FROM inventory_events")
@@ -1176,5 +1300,6 @@ def save_gtin_catalog_and_household_link(
         "product": product,
         "purchase_import_line_id": normalized_line_id,
         "household_article_id": normalized_article_id,
+        "product_type_classification": product_type_classification,
         "inventory_mutated": False,
     }

--- a/backend/app/services/barcode_identity_service.py
+++ b/backend/app/services/barcode_identity_service.py
@@ -596,6 +596,7 @@ def _resolve_catalog_product_for_save(
     *,
     gtin: str,
     article_name: str,
+    household_article_id: str,
 ) -> dict[str, Any]:
     tables = _table_names(conn)
 
@@ -752,10 +753,12 @@ def _resolve_catalog_product_for_save(
         else:
             identity_values = {
                 "id": str(uuid.uuid4()),
+                "household_article_id": household_article_id,
                 "global_product_id": product_id,
                 "identity_type": "gtin",
                 "identity_value": gtin,
                 "source": "receipt_user_confirmed",
+                "confidence_score": 1.0,
                 "is_primary": 1,
             }
 
@@ -1082,6 +1085,7 @@ def save_gtin_catalog_and_household_link(
         conn,
         gtin=normalized_gtin,
         article_name=normalized_article_name,
+        household_article_id=normalized_article_id,
     )
 
     product = catalog_result["product"]

--- a/backend/app/services/barcode_identity_service.py
+++ b/backend/app/services/barcode_identity_service.py
@@ -10,6 +10,7 @@ Domain rules:
 from __future__ import annotations
 
 import re
+import uuid
 from typing import Any
 
 from sqlalchemy import inspect, text
@@ -553,4 +554,568 @@ def link_household_article_to_matched_product(
         "gtin": normalized_gtin,
         "inventory_mutated": False,
         "product": lookup.get("product"),
+    }
+
+
+
+def _insert_dynamic_row(
+    conn,
+    *,
+    table_name: str,
+    values: dict[str, Any],
+) -> None:
+    columns = _column_names(conn, table_name)
+    selected = {
+        key: value
+        for key, value in values.items()
+        if key in columns
+    }
+
+    if not selected:
+        raise BarcodeHouseholdArticleLinkError(
+            500,
+            f"Tabel {table_name} bevat geen bruikbare kolommen.",
+        )
+
+    column_sql = ", ".join(selected.keys())
+    value_sql = ", ".join(f":{key}" for key in selected)
+
+    conn.execute(
+        text(
+            f"""
+            INSERT INTO {table_name} ({column_sql})
+            VALUES ({value_sql})
+            """
+        ),
+        selected,
+    )
+
+
+def _resolve_catalog_product_for_save(
+    conn,
+    *,
+    gtin: str,
+    article_name: str,
+) -> dict[str, Any]:
+    tables = _table_names(conn)
+
+    if "global_products" not in tables:
+        raise BarcodeHouseholdArticleLinkError(
+            500,
+            "De centrale productcatalogus ontbreekt.",
+        )
+
+    product_columns = _column_names(conn, "global_products")
+    identity_available = "product_identities" in tables
+
+    product_ids: set[str] = set()
+
+    if "primary_gtin" in product_columns:
+        rows = conn.execute(
+            text(
+                """
+                SELECT id
+                FROM global_products
+                WHERE primary_gtin = :gtin
+                """
+            ),
+            {"gtin": gtin},
+        ).mappings().all()
+
+        product_ids.update(
+            str(row.get("id") or "").strip()
+            for row in rows
+            if str(row.get("id") or "").strip()
+        )
+
+    if identity_available:
+        rows = conn.execute(
+            text(
+                """
+                SELECT global_product_id
+                FROM product_identities
+                WHERE identity_type = 'gtin'
+                  AND identity_value = :gtin
+                """
+            ),
+            {"gtin": gtin},
+        ).mappings().all()
+
+        product_ids.update(
+            str(row.get("global_product_id") or "").strip()
+            for row in rows
+            if str(row.get("global_product_id") or "").strip()
+        )
+
+    if len(product_ids) > 1:
+        raise BarcodeHouseholdArticleLinkError(
+            409,
+            "Deze GTIN verwijst naar meerdere centrale producten.",
+        )
+
+    created = False
+
+    if product_ids:
+        product_id = next(iter(product_ids))
+    else:
+        product_id = str(uuid.uuid4())
+        created = True
+
+        product_values = {
+            "id": product_id,
+            "name": article_name or f"Product {gtin}",
+            "brand": None,
+            "primary_gtin": gtin,
+            "source": "receipt_user_confirmed",
+            "status": "active",
+            "created_at": None,
+            "updated_at": None,
+        }
+
+        # Datumvelden worden niet met NULL gevuld wanneer zij bestaan.
+        product_values.pop("created_at", None)
+        product_values.pop("updated_at", None)
+
+        _insert_dynamic_row(
+            conn,
+            table_name="global_products",
+            values=product_values,
+        )
+
+    if "primary_gtin" in product_columns:
+        conn.execute(
+            text(
+                """
+                UPDATE global_products
+                SET primary_gtin = CASE
+                        WHEN trim(COALESCE(primary_gtin, '')) = ''
+                        THEN :gtin
+                        ELSE primary_gtin
+                    END
+                WHERE id = :product_id
+                """
+            ),
+            {
+                "gtin": gtin,
+                "product_id": product_id,
+            },
+        )
+
+    if "name" in product_columns:
+        conn.execute(
+            text(
+                """
+                UPDATE global_products
+                SET name = CASE
+                        WHEN trim(COALESCE(name, '')) = ''
+                        THEN :article_name
+                        ELSE name
+                    END
+                WHERE id = :product_id
+                """
+            ),
+            {
+                "article_name": article_name or f"Product {gtin}",
+                "product_id": product_id,
+            },
+        )
+
+    if identity_available:
+        identity_columns = _column_names(
+            conn,
+            "product_identities",
+        )
+
+        existing_identity = conn.execute(
+            text(
+                """
+                SELECT id, global_product_id
+                FROM product_identities
+                WHERE identity_type = 'gtin'
+                  AND identity_value = :gtin
+                LIMIT 1
+                """
+            ),
+            {"gtin": gtin},
+        ).mappings().first()
+
+        if existing_identity:
+            existing_product_id = str(
+                existing_identity.get("global_product_id") or ""
+            ).strip()
+
+            if existing_product_id != product_id:
+                raise BarcodeHouseholdArticleLinkError(
+                    409,
+                    "De GTIN is al aan een ander centraal product gekoppeld.",
+                )
+        else:
+            identity_values = {
+                "id": str(uuid.uuid4()),
+                "global_product_id": product_id,
+                "identity_type": "gtin",
+                "identity_value": gtin,
+                "source": "receipt_user_confirmed",
+                "is_primary": 1,
+            }
+
+            _insert_dynamic_row(
+                conn,
+                table_name="product_identities",
+                values=identity_values,
+            )
+
+        if "is_primary" in identity_columns:
+            conn.execute(
+                text(
+                    """
+                    UPDATE product_identities
+                    SET is_primary = CASE
+                            WHEN identity_type = 'gtin'
+                             AND identity_value = :gtin
+                            THEN 1
+                            ELSE is_primary
+                        END
+                    WHERE global_product_id = :product_id
+                    """
+                ),
+                {
+                    "gtin": gtin,
+                    "product_id": product_id,
+                },
+            )
+
+    product = conn.execute(
+        text(
+            """
+            SELECT id, name, brand, status, primary_gtin
+            FROM global_products
+            WHERE id = :product_id
+            LIMIT 1
+            """
+        ),
+        {"product_id": product_id},
+    ).mappings().first()
+
+    return {
+        "created": created,
+        "product": {
+            "global_product_id": product_id,
+            "name": product.get("name") if product else article_name,
+            "brand": product.get("brand") if product else None,
+            "status": product.get("status") if product else "active",
+            "primary_gtin": (
+                product.get("primary_gtin")
+                if product
+                else gtin
+            ),
+        },
+    }
+
+
+def _link_saved_product_to_household(
+    conn,
+    *,
+    household_id: str,
+    purchase_import_line_id: str,
+    household_article_id: str,
+    global_product_id: str,
+) -> None:
+    tables = _table_names(conn)
+
+    required_tables = {
+        "purchase_import_lines",
+        "purchase_import_batches",
+        "household_articles",
+    }
+
+    missing_tables = sorted(required_tables - tables)
+
+    if missing_tables:
+        raise BarcodeHouseholdArticleLinkError(
+            500,
+            "Benodigde tabel ontbreekt: " + ", ".join(missing_tables),
+        )
+
+    line_columns = _column_names(
+        conn,
+        "purchase_import_lines",
+    )
+    batch_columns = _column_names(
+        conn,
+        "purchase_import_batches",
+    )
+    article_columns = _column_names(
+        conn,
+        "household_articles",
+    )
+
+    line_id_column = _first_existing_column(
+        line_columns,
+        "id",
+        "line_id",
+    )
+    line_batch_column = _first_existing_column(
+        line_columns,
+        "batch_id",
+        "purchase_import_batch_id",
+        "import_batch_id",
+    )
+    batch_id_column = _first_existing_column(
+        batch_columns,
+        "batch_id",
+        "id",
+    )
+
+    if (
+        not line_id_column
+        or not line_batch_column
+        or not batch_id_column
+        or "household_id" not in batch_columns
+    ):
+        raise BarcodeHouseholdArticleLinkError(
+            500,
+            "De bonimporttabellen hebben niet de verwachte sleutels.",
+        )
+
+    line = conn.execute(
+        text(
+            f"""
+            SELECT
+                {line_id_column} AS line_id,
+                {line_batch_column} AS batch_id
+            FROM purchase_import_lines
+            WHERE {line_id_column} = :line_id
+            LIMIT 1
+            """
+        ),
+        {"line_id": purchase_import_line_id},
+    ).mappings().first()
+
+    if not line:
+        raise BarcodeHouseholdArticleLinkError(
+            404,
+            "Bonregel niet gevonden.",
+        )
+
+    batch = conn.execute(
+        text(
+            f"""
+            SELECT {batch_id_column} AS batch_id
+            FROM purchase_import_batches
+            WHERE {batch_id_column} = :batch_id
+              AND household_id = :household_id
+            LIMIT 1
+            """
+        ),
+        {
+            "batch_id": str(line.get("batch_id") or ""),
+            "household_id": household_id,
+        },
+    ).mappings().first()
+
+    if not batch:
+        raise BarcodeHouseholdArticleLinkError(
+            404,
+            "Bonregel niet gevonden binnen het actieve huishouden.",
+        )
+
+    article = conn.execute(
+        text(
+            """
+            SELECT id, global_product_id
+            FROM household_articles
+            WHERE id = :article_id
+              AND household_id = :household_id
+            LIMIT 1
+            """
+        ),
+        {
+            "article_id": household_article_id,
+            "household_id": household_id,
+        },
+    ).mappings().first()
+
+    if not article:
+        raise BarcodeHouseholdArticleLinkError(
+            404,
+            "Mijn artikel niet gevonden binnen het actieve huishouden.",
+        )
+
+    existing_product_id = str(
+        article.get("global_product_id") or ""
+    ).strip()
+
+    if (
+        existing_product_id
+        and existing_product_id != global_product_id
+    ):
+        raise BarcodeHouseholdArticleLinkError(
+            409,
+            "Mijn artikel is al aan een ander centraal product gekoppeld.",
+        )
+
+    article_updated_fragment = (
+        ", updated_at = CURRENT_TIMESTAMP"
+        if "updated_at" in article_columns
+        else ""
+    )
+
+    conn.execute(
+        text(
+            f"""
+            UPDATE household_articles
+            SET global_product_id = :global_product_id
+                {article_updated_fragment}
+            WHERE id = :article_id
+              AND household_id = :household_id
+            """
+        ),
+        {
+            "global_product_id": global_product_id,
+            "article_id": household_article_id,
+            "household_id": household_id,
+        },
+    )
+
+    mapped_article_column = _first_existing_column(
+        line_columns,
+        "matched_household_article_id",
+        "household_article_id",
+        "selected_household_article_id",
+    )
+
+    mapped_product_column = _first_existing_column(
+        line_columns,
+        "matched_global_product_id",
+        "global_product_id",
+        "selected_global_product_id",
+    )
+
+    update_parts = []
+    parameters = {
+        "line_id": purchase_import_line_id,
+        "article_id": household_article_id,
+        "global_product_id": global_product_id,
+    }
+
+    if mapped_article_column:
+        update_parts.append(
+            f"{mapped_article_column} = :article_id"
+        )
+
+    if mapped_product_column:
+        update_parts.append(
+            f"{mapped_product_column} = :global_product_id"
+        )
+
+    if update_parts:
+        conn.execute(
+            text(
+                f"""
+                UPDATE purchase_import_lines
+                SET {", ".join(update_parts)}
+                WHERE {line_id_column} = :line_id
+                """
+            ),
+            parameters,
+        )
+
+
+def save_gtin_catalog_and_household_link(
+    conn,
+    *,
+    household_id: str,
+    purchase_import_line_id: str,
+    household_article_id: str,
+    gtin: str,
+    article_name: str,
+) -> dict[str, Any]:
+    """Sla een geldige GTIN centraal op en koppel die lokaal."""
+
+    validation = validate_barcode(gtin, "gtin")
+
+    if not validation.get("valid"):
+        raise BarcodeHouseholdArticleLinkError(
+            400,
+            "De barcode is niet geldig.",
+        )
+
+    normalized_gtin = str(
+        validation.get("normalized_value") or ""
+    ).strip()
+
+    normalized_household_id = str(
+        household_id or ""
+    ).strip()
+    normalized_line_id = str(
+        purchase_import_line_id or ""
+    ).strip()
+    normalized_article_id = str(
+        household_article_id or ""
+    ).strip()
+    normalized_article_name = " ".join(
+        str(article_name or "").strip().split()
+    )
+
+    if not normalized_household_id:
+        raise BarcodeHouseholdArticleLinkError(
+            400,
+            "Het actieve huishouden ontbreekt.",
+        )
+
+    if not normalized_line_id or not normalized_article_id:
+        raise BarcodeHouseholdArticleLinkError(
+            400,
+            "Bonregel en Mijn artikel zijn verplicht.",
+        )
+
+    tables = _table_names(conn)
+    inventory_event_count = None
+
+    if "inventory_events" in tables:
+        inventory_event_count = conn.execute(
+            text("SELECT COUNT(*) FROM inventory_events")
+        ).scalar_one()
+
+    catalog_result = _resolve_catalog_product_for_save(
+        conn,
+        gtin=normalized_gtin,
+        article_name=normalized_article_name,
+    )
+
+    product = catalog_result["product"]
+    product_id = str(
+        product.get("global_product_id") or ""
+    ).strip()
+
+    _link_saved_product_to_household(
+        conn,
+        household_id=normalized_household_id,
+        purchase_import_line_id=normalized_line_id,
+        household_article_id=normalized_article_id,
+        global_product_id=product_id,
+    )
+
+    if "inventory_events" in tables:
+        inventory_event_count_after = conn.execute(
+            text("SELECT COUNT(*) FROM inventory_events")
+        ).scalar_one()
+
+        if inventory_event_count_after != inventory_event_count:
+            raise BarcodeHouseholdArticleLinkError(
+                500,
+                "De barcodeopslag heeft onverwacht de voorraad gewijzigd.",
+            )
+
+    return {
+        "ok": True,
+        "gtin": normalized_gtin,
+        "catalog_product_created": bool(
+            catalog_result.get("created")
+        ),
+        "product": product,
+        "purchase_import_line_id": normalized_line_id,
+        "household_article_id": normalized_article_id,
+        "inventory_mutated": False,
     }

--- a/backend/app/services/barcode_identity_service.py
+++ b/backend/app/services/barcode_identity_service.py
@@ -823,6 +823,7 @@ def _link_saved_product_to_household(
     purchase_import_line_id: str,
     household_article_id: str,
     global_product_id: str,
+    gtin: str,
 ) -> None:
     tables = _table_names(conn)
 
@@ -964,21 +965,35 @@ def _link_saved_product_to_household(
         else ""
     )
 
+    article_assignments = [
+        "global_product_id = :global_product_id",
+    ]
+
+    article_parameters = {
+        "global_product_id": global_product_id,
+        "article_id": household_article_id,
+        "household_id": household_id,
+        "gtin": gtin,
+    }
+
+    if "barcode" in article_columns:
+        article_assignments.append("barcode = :gtin")
+
+    if "updated_at" in article_columns:
+        article_assignments.append(
+            "updated_at = CURRENT_TIMESTAMP"
+        )
+
     conn.execute(
         text(
             f"""
             UPDATE household_articles
-            SET global_product_id = :global_product_id
-                {article_updated_fragment}
+            SET {", ".join(article_assignments)}
             WHERE id = :article_id
               AND household_id = :household_id
             """
         ),
-        {
-            "global_product_id": global_product_id,
-            "article_id": household_article_id,
-            "household_id": household_id,
-        },
+        article_parameters,
     )
 
     mapped_article_column = _first_existing_column(
@@ -1099,6 +1114,7 @@ def save_gtin_catalog_and_household_link(
         purchase_import_line_id=normalized_line_id,
         household_article_id=normalized_article_id,
         global_product_id=product_id,
+        gtin=normalized_gtin,
     )
 
     if "inventory_events" in tables:

--- a/backend/app/services/barcode_identity_service.py
+++ b/backend/app/services/barcode_identity_service.py
@@ -262,3 +262,295 @@ def lookup_gtin(conn, value: Any) -> dict[str, Any]:
         },
         "mutated": False,
     }
+
+
+
+class BarcodeHouseholdArticleLinkError(ValueError):
+    def __init__(self, status_code: int, detail: str):
+        super().__init__(detail)
+        self.status_code = int(status_code)
+        self.detail = str(detail)
+
+
+def _column_names(conn, table_name: str) -> set[str]:
+    return {
+        str(column["name"])
+        for column in inspect(conn).get_columns(table_name)
+    }
+
+
+def _first_existing_column(
+    columns: set[str],
+    *candidates: str,
+) -> str | None:
+    for candidate in candidates:
+        if candidate in columns:
+            return candidate
+    return None
+
+
+def link_household_article_to_matched_product(
+    conn,
+    *,
+    household_id: str,
+    purchase_import_line_id: str,
+    household_article_id: str,
+    gtin: str,
+    global_product_id: str,
+) -> dict[str, Any]:
+    """Maak één expliciete productkoppeling zonder voorraadmutatie."""
+
+    household_id = str(household_id or "").strip()
+    line_id = str(purchase_import_line_id or "").strip()
+    article_id = str(household_article_id or "").strip()
+    requested_product_id = str(global_product_id or "").strip()
+
+    if not household_id:
+        raise BarcodeHouseholdArticleLinkError(
+            400,
+            "Het actieve huishouden ontbreekt.",
+        )
+
+    if not line_id or not article_id or not requested_product_id:
+        raise BarcodeHouseholdArticleLinkError(
+            400,
+            "Bonregel, Mijn artikel en universeel artikel zijn verplicht.",
+        )
+
+    lookup = lookup_gtin(conn, gtin)
+
+    if lookup.get("match_status") != "matched":
+        raise BarcodeHouseholdArticleLinkError(
+            409,
+            "Alleen een volledig en eenduidig herkende GTIN kan worden gekoppeld.",
+        )
+
+    matched_product_id = str(
+        (lookup.get("product") or {}).get("global_product_id") or ""
+    ).strip()
+
+    normalized_gtin = str(lookup.get("gtin") or "").strip()
+
+    if matched_product_id != requested_product_id:
+        raise BarcodeHouseholdArticleLinkError(
+            409,
+            "Het universele artikel hoort niet bij de gecontroleerde GTIN.",
+        )
+
+    tables = _table_names(conn)
+    required_tables = {
+        "purchase_import_lines",
+        "purchase_import_batches",
+        "household_articles",
+    }
+
+    missing_tables = sorted(required_tables - tables)
+    if missing_tables:
+        raise BarcodeHouseholdArticleLinkError(
+            500,
+            "Benodigde tabel ontbreekt: " + ", ".join(missing_tables),
+        )
+
+    line_columns = _column_names(conn, "purchase_import_lines")
+    batch_columns = _column_names(conn, "purchase_import_batches")
+    article_columns = _column_names(conn, "household_articles")
+
+    line_id_column = _first_existing_column(
+        line_columns,
+        "id",
+        "line_id",
+    )
+    line_batch_column = _first_existing_column(
+        line_columns,
+        "batch_id",
+        "purchase_import_batch_id",
+        "import_batch_id",
+    )
+    batch_id_column = _first_existing_column(
+        batch_columns,
+        "batch_id",
+        "id",
+    )
+
+    if (
+        not line_id_column
+        or not line_batch_column
+        or not batch_id_column
+        or "household_id" not in batch_columns
+    ):
+        raise BarcodeHouseholdArticleLinkError(
+            500,
+            "De bonimporttabellen hebben niet de verwachte sleutelkolommen.",
+        )
+
+    line = conn.execute(
+        text(
+            f"""
+            SELECT
+                {line_id_column} AS line_id,
+                {line_batch_column} AS batch_id
+            FROM purchase_import_lines
+            WHERE {line_id_column} = :line_id
+            LIMIT 1
+            """
+        ),
+        {"line_id": line_id},
+    ).mappings().first()
+
+    if not line:
+        raise BarcodeHouseholdArticleLinkError(
+            404,
+            "Bonregel niet gevonden.",
+        )
+
+    batch = conn.execute(
+        text(
+            f"""
+            SELECT
+                {batch_id_column} AS batch_id,
+                household_id
+            FROM purchase_import_batches
+            WHERE {batch_id_column} = :batch_id
+              AND household_id = :household_id
+            LIMIT 1
+            """
+        ),
+        {
+            "batch_id": str(line.get("batch_id") or ""),
+            "household_id": household_id,
+        },
+    ).mappings().first()
+
+    if not batch:
+        raise BarcodeHouseholdArticleLinkError(
+            404,
+            "Bonregel niet gevonden binnen het actieve huishouden.",
+        )
+
+    required_article_columns = {
+        "id",
+        "household_id",
+        "global_product_id",
+    }
+
+    if not required_article_columns.issubset(article_columns):
+        raise BarcodeHouseholdArticleLinkError(
+            500,
+            "Mijn-artikeltabel mist verplichte koppelkolommen.",
+        )
+
+    article = conn.execute(
+        text(
+            """
+            SELECT
+                id,
+                household_id,
+                global_product_id
+            FROM household_articles
+            WHERE id = :article_id
+              AND household_id = :household_id
+            LIMIT 1
+            """
+        ),
+        {
+            "article_id": article_id,
+            "household_id": household_id,
+        },
+    ).mappings().first()
+
+    if not article:
+        raise BarcodeHouseholdArticleLinkError(
+            404,
+            "Mijn artikel niet gevonden binnen het actieve huishouden.",
+        )
+
+    existing_product_id = str(
+        article.get("global_product_id") or ""
+    ).strip()
+
+    if (
+        existing_product_id
+        and existing_product_id != requested_product_id
+    ):
+        raise BarcodeHouseholdArticleLinkError(
+            409,
+            "Mijn artikel is al aan een ander universeel artikel gekoppeld.",
+        )
+
+    inventory_before = None
+
+    if "inventory_events" in tables:
+        inventory_before = conn.execute(
+            text("SELECT COUNT(*) FROM inventory_events")
+        ).scalar_one()
+
+    changed = existing_product_id != requested_product_id
+
+    if changed:
+        updated_at_fragment = (
+            ", updated_at = CURRENT_TIMESTAMP"
+            if "updated_at" in article_columns
+            else ""
+        )
+
+        conn.execute(
+            text(
+                f"""
+                UPDATE household_articles
+                SET global_product_id = :global_product_id
+                    {updated_at_fragment}
+                WHERE id = :article_id
+                  AND household_id = :household_id
+                """
+            ),
+            {
+                "global_product_id": requested_product_id,
+                "article_id": article_id,
+                "household_id": household_id,
+            },
+        )
+
+    mapped_article_column = _first_existing_column(
+        line_columns,
+        "matched_household_article_id",
+        "household_article_id",
+        "selected_household_article_id",
+    )
+
+    if mapped_article_column:
+        conn.execute(
+            text(
+                f"""
+                UPDATE purchase_import_lines
+                SET {mapped_article_column} = :article_id
+                WHERE {line_id_column} = :line_id
+                """
+            ),
+            {
+                "article_id": article_id,
+                "line_id": line_id,
+            },
+        )
+
+    if "inventory_events" in tables:
+        inventory_after = conn.execute(
+            text("SELECT COUNT(*) FROM inventory_events")
+        ).scalar_one()
+
+        if inventory_after != inventory_before:
+            raise BarcodeHouseholdArticleLinkError(
+                500,
+                "De barcodekoppeling heeft onverwacht de voorraad gewijzigd.",
+            )
+
+    return {
+        "ok": True,
+        "changed": changed,
+        "idempotent": not changed,
+        "purchase_import_line_id": line_id,
+        "household_article_id": article_id,
+        "global_product_id": requested_product_id,
+        "gtin": normalized_gtin,
+        "inventory_mutated": False,
+        "product": lookup.get("product"),
+    }

--- a/backend/app/services/barcode_identity_service.py
+++ b/backend/app/services/barcode_identity_service.py
@@ -1028,7 +1028,7 @@ def _link_saved_product_to_household(
         )
 
     if update_parts:
-        conn.execute(
+        update_result = conn.execute(
             text(
                 f"""
                 UPDATE purchase_import_lines
@@ -1038,6 +1038,45 @@ def _link_saved_product_to_household(
             ),
             parameters,
         )
+
+        if int(update_result.rowcount or 0) != 1:
+            raise BarcodeHouseholdArticleLinkError(
+                500,
+                "De kassabonregel kon niet worden gekoppeld.",
+            )
+
+        verification_columns = [
+            f"{mapped_article_column} AS household_article_id"
+            if mapped_article_column
+            else "NULL AS household_article_id",
+            f"{mapped_product_column} AS global_product_id"
+            if mapped_product_column
+            else "NULL AS global_product_id",
+        ]
+
+        verified = conn.execute(
+            text(
+                f"""
+                SELECT {", ".join(verification_columns)}
+                FROM purchase_import_lines
+                WHERE {line_id_column} = :line_id
+                LIMIT 1
+                """
+            ),
+            {"line_id": purchase_import_line_id},
+        ).mappings().first()
+
+        if (
+            not verified
+            or str(verified.get("household_article_id") or "")
+                != str(household_article_id)
+            or str(verified.get("global_product_id") or "")
+                != str(global_product_id)
+        ):
+            raise BarcodeHouseholdArticleLinkError(
+                500,
+                "De kassabon- en cataloguskoppeling is niet volledig opgeslagen.",
+            )
 
 
 def save_gtin_catalog_and_household_link(

--- a/backend/app/services/external_article_ui_projection.py
+++ b/backend/app/services/external_article_ui_projection.py
@@ -66,6 +66,43 @@ def _central_product_details(
     return dict(row) if row else {}
 
 
+def _catalog_product_by_gtin(
+    conn,
+    *values: Any,
+) -> dict[str, Any] | None:
+    gtin = ""
+
+    for value in values:
+        candidate = "".join(
+            character
+            for character in _text(value)
+            if character.isdigit()
+        )
+        if len(candidate) in {8, 12, 13, 14}:
+            gtin = candidate
+            break
+
+    if not gtin:
+        return None
+
+    row = conn.execute(
+        text(
+            """
+            SELECT
+                id AS global_product_id,
+                name AS global_product_name,
+                primary_gtin
+            FROM global_products
+            WHERE primary_gtin = :gtin
+            LIMIT 1
+            """
+        ),
+        {"gtin": gtin},
+    ).mappings().first()
+
+    return dict(row) if row else None
+
+
 def project_central_link_truth(conn, row: dict[str, Any]) -> dict[str, Any]:
     next_row = dict(row)
     retailer_code = _text(next_row.get("retailer_code"))
@@ -81,6 +118,29 @@ def project_central_link_truth(conn, row: dict[str, Any]) -> dict[str, Any]:
         receipt_text=receipt_text,
         external_article_code=external_article_code,
     ) if retailer_code and (receipt_text or external_article_code) else None
+
+    if not central_link:
+        catalog_product = _catalog_product_by_gtin(
+            conn,
+            next_row.get("gtin"),
+            next_row.get("primary_gtin"),
+            next_row.get("linked_gtin"),
+            next_row.get("barcode"),
+            external_article_code,
+        )
+
+        if catalog_product:
+            central_link = {
+                "global_product_id": catalog_product.get(
+                    "global_product_id"
+                ),
+                "global_product_name": catalog_product.get(
+                    "global_product_name"
+                ),
+                "primary_gtin": catalog_product.get("primary_gtin"),
+                "source": "catalog_gtin",
+                "link_status": "active",
+            }
 
     active = bool(central_link)
     central_product_id = _text((central_link or {}).get("global_product_id"))

--- a/backend/app/services/external_article_ui_projection.py
+++ b/backend/app/services/external_article_ui_projection.py
@@ -120,6 +120,24 @@ def project_central_link_truth(conn, row: dict[str, Any]) -> dict[str, Any]:
     ) if retailer_code and (receipt_text or external_article_code) else None
 
     if not central_link:
+        candidate_gtin_values = []
+
+        for candidate in next_row.get("candidates") or []:
+            if not isinstance(candidate, dict):
+                continue
+
+            candidate_gtin_values.extend(
+                [
+                    candidate.get("gtin"),
+                    candidate.get("ean"),
+                    candidate.get("barcode"),
+                    candidate.get("code"),
+                    candidate.get("external_source_product_code"),
+                    candidate.get("candidate_source_product_code"),
+                    candidate.get("source_product_code"),
+                ]
+            )
+
         catalog_product = _catalog_product_by_gtin(
             conn,
             next_row.get("gtin"),
@@ -127,6 +145,7 @@ def project_central_link_truth(conn, row: dict[str, Any]) -> dict[str, Any]:
             next_row.get("linked_gtin"),
             next_row.get("barcode"),
             external_article_code,
+            *candidate_gtin_values,
         )
 
         if catalog_product:

--- a/backend/app/services/external_product_candidate_store.py
+++ b/backend/app/services/external_product_candidate_store.py
@@ -831,6 +831,38 @@ def _m2c2h5_list_purchase_import_placeholders(conn, existing_context_keys: set[s
     unit_expr = _m2c2h5_col("pil", columns, ["unit_raw"])
     price_expr = _m2c2h5_col("pil", columns, ["line_price_raw"])
     global_product_expr = _m2c2h5_col("pil", columns, ["matched_global_product_id", "matched_global_article_id"])
+
+    household_article_join_sql = ""
+    household_article_column = next(
+        (
+            candidate
+            for candidate in (
+                "matched_household_article_id",
+                "household_article_id",
+                "selected_household_article_id",
+            )
+            if candidate in columns
+        ),
+        None,
+    )
+
+    if (
+        household_article_column
+        and _m2c2h5_table_exists(conn, "household_articles")
+    ):
+        household_columns = _m2c2h5_table_columns(
+            conn,
+            "household_articles",
+        )
+        if {"id", "global_product_id"}.issubset(household_columns):
+            household_article_join_sql = (
+                "LEFT JOIN household_articles ha "
+                f"ON ha.id = pil.{household_article_column}"
+            )
+            global_product_expr = (
+                f"COALESCE({global_product_expr}, ha.global_product_id)"
+            )
+
     created_expr = _m2c2h5_col("pil", columns, ["created_at"])
     updated_expr = _m2c2h5_col("pil", columns, ["updated_at"])
 
@@ -851,6 +883,7 @@ def _m2c2h5_list_purchase_import_placeholders(conn, existing_context_keys: set[s
                 {updated_expr} AS updated_at
             FROM purchase_import_lines pil
             {batch_join_sql}
+            {household_article_join_sql}
             ORDER BY pil.ui_sort_order ASC, pil.created_at DESC, pil.id DESC
             LIMIT :limit
             """

--- a/backend/app/services/external_product_candidate_store.py
+++ b/backend/app/services/external_product_candidate_store.py
@@ -884,7 +884,15 @@ def _m2c2h5_list_purchase_import_placeholders(conn, existing_context_keys: set[s
             FROM purchase_import_lines pil
             {batch_join_sql}
             {household_article_join_sql}
-            ORDER BY pil.ui_sort_order ASC, pil.created_at DESC, pil.id DESC
+            ORDER BY
+                CASE
+                    WHEN COALESCE({global_product_expr}, '') <> '' THEN 0
+                    ELSE 1
+                END ASC,
+                COALESCE({updated_expr}, {created_expr}, '') DESC,
+                COALESCE({created_expr}, '') DESC,
+                pil.ui_sort_order ASC,
+                pil.id DESC
             LIMIT :limit
             """
         ),

--- a/backend/app/services/external_product_candidate_store.py
+++ b/backend/app/services/external_product_candidate_store.py
@@ -1217,9 +1217,22 @@ def _m2c2i_fix7b_ensure_catalog_products_for_article_codes(conn, candidates: lis
 
     return enriched
 
-def _m2c2i_fix7b_dedupe_top_receipt_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Toon één bovenste tabelrij per winkelketen + genormaliseerde bonartikelnaam."""
-    best_by_key: dict[str, dict[str, Any]] = {}
+def _m2c2i_fix7b_dedupe_top_receipt_items(
+    items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Toon één bovenste tabelrij per winkelketen en bonartikelnaam.
+
+    Gegevens van een reeds gekoppelde duplicaatregel blijven leidend,
+    zodat de eerste schermlading de centrale Cataloguskoppeling toont.
+    """
+    grouped: dict[str, list[dict[str, Any]]] = {}
+
+    for item in items:
+        key = _m2c2i_fix7a3_normalized_receipt_key(
+            item.get("retailer_code"),
+            item.get("receipt_line_text"),
+        )
+        grouped.setdefault(key, []).append(dict(item))
 
     status_priority = {
         "linked_to_catalog": 5,
@@ -1229,37 +1242,120 @@ def _m2c2i_fix7b_dedupe_top_receipt_items(items: list[dict[str, Any]]) -> list[d
         "no_candidate": 1,
     }
 
-    for item in items:
-        key = _m2c2i_fix7a3_normalized_receipt_key(
-            item.get("retailer_code"),
-            item.get("receipt_line_text"),
-        )
+    def row_score(item: dict[str, Any]) -> tuple:
+        status = str(
+            item.get("status")
+            or item.get("candidate_status")
+            or ""
+        ).strip()
 
-        current = best_by_key.get(key)
-        item_status = str(item.get("status") or item.get("candidate_status") or "").strip()
-        item_score = (
-            status_priority.get(item_status, 0),
+        return (
+            status_priority.get(status, 0),
             1 if str(item.get("global_product_id") or "").strip() else 0,
-            1 if str(item.get("retailer_article_number") or "").strip() else 0,
+            1 if str(
+                item.get("matched_household_article_id") or ""
+            ).strip() else 0,
+            1 if str(
+                item.get("retailer_article_number") or ""
+            ).strip() else 0,
             str(item.get("updated_at") or item.get("created_at") or ""),
         )
 
-        if current is None:
-            best_by_key[key] = item
-            continue
+    linked_fields = (
+        "global_product_id",
+        "canonical_catalog_product_id",
+        "linked_candidate_name",
+        "linked_gtin",
+        "linked_product_type_id",
+        "linked_product_type",
+        "linked_score",
+        "is_linked_to_catalog",
+        "is_existing_link_for_receipt_item",
+        "status",
+        "candidate_status",
+    )
 
-        current_status = str(current.get("status") or current.get("candidate_status") or "").strip()
-        current_score = (
-            status_priority.get(current_status, 0),
-            1 if str(current.get("global_product_id") or "").strip() else 0,
-            1 if str(current.get("retailer_article_number") or "").strip() else 0,
-            str(current.get("updated_at") or current.get("created_at") or ""),
-        )
+    result: list[dict[str, Any]] = []
 
-        if item_score > current_score:
-            best_by_key[key] = item
+    for entries in grouped.values():
+        entries.sort(key=row_score, reverse=True)
+        representative = dict(entries[0])
 
-    return list(best_by_key.values())
+        linked_entries = [
+            entry
+            for entry in entries
+            if (
+                str(entry.get("global_product_id") or "").strip()
+                and str(
+                    entry.get("status")
+                    or entry.get("candidate_status")
+                    or ""
+                ).strip()
+                == "linked_to_catalog"
+            )
+        ]
+
+        if linked_entries:
+            linked_entries.sort(key=row_score, reverse=True)
+            linked = linked_entries[0]
+
+            for field in linked_fields:
+                value = linked.get(field)
+                if value not in (None, ""):
+                    representative[field] = value
+
+            representative["status"] = "linked_to_catalog"
+            representative["candidate_status"] = "linked_to_catalog"
+            representative["is_linked_to_catalog"] = True
+            representative["is_existing_link_for_receipt_item"] = True
+            representative["canonical_catalog_product_id"] = (
+                str(
+                    representative.get("canonical_catalog_product_id")
+                    or representative.get("global_product_id")
+                    or ""
+                ).strip()
+                or None
+            )
+
+        merged_candidates: list[dict[str, Any]] = []
+        seen_candidates: set[str] = set()
+
+        for entry in entries:
+            for candidate in entry.get("candidates") or []:
+                if not isinstance(candidate, dict):
+                    continue
+
+                identity = "|".join(
+                    [
+                        str(candidate.get("id") or ""),
+                        str(
+                            candidate.get("candidate_source_name")
+                            or candidate.get("source_name")
+                            or ""
+                        ),
+                        str(
+                            candidate.get("candidate_source_product_code")
+                            or candidate.get("source_product_code")
+                            or candidate.get("retailer_article_number")
+                            or ""
+                        ),
+                        str(candidate.get("candidate_name") or ""),
+                    ]
+                )
+
+                if identity in seen_candidates:
+                    continue
+
+                seen_candidates.add(identity)
+                merged_candidates.append(dict(candidate))
+
+        if merged_candidates:
+            representative["candidates"] = merged_candidates
+            representative["candidate_count"] = len(merged_candidates)
+
+        result.append(representative)
+
+    return result
 
 
 def _m2c2i_fix7c_same_retailer_for_projection(placeholder: dict[str, object], candidate: dict[str, object]) -> bool:

--- a/backend/app/services/off_search_service.py
+++ b/backend/app/services/off_search_service.py
@@ -31,6 +31,7 @@ OFF_FIELDS = [
     "quantity",
     "categories",
     "categories_tags",
+    "gpcCategoryCode",
     "countries",
     "countries_tags",
     "stores",
@@ -48,6 +49,110 @@ def _text(value: Any) -> str:
     if isinstance(value, list):
         return " ".join(_text(item) for item in value if _text(item))
     return str(value or "").strip()
+
+
+
+def lookup_off_product_by_gtin(gtin: Any) -> dict[str, Any]:
+    """Zoek één Open Food Facts-product exact op GTIN zonder lokale mutatie."""
+    normalized_gtin = "".join(
+        character
+        for character in _text(gtin)
+        if character.isdigit()
+    )
+
+    if len(normalized_gtin) not in {8, 12, 13, 14}:
+        return {
+            "ok": False,
+            "status": "invalid_gtin",
+            "gtin": normalized_gtin,
+            "product": None,
+            "mutated": False,
+        }
+
+    fields = ",".join(OFF_FIELDS)
+    url = (
+        "https://world.openfoodfacts.org/api/v2/product/"
+        f"{urllib.parse.quote(normalized_gtin)}.json"
+        f"?fields={urllib.parse.quote(fields)}"
+    )
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "Rezzerv/1.0 (product classification)",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(
+            request,
+            timeout=TIMEOUT_SECONDS,
+        ) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except Exception as exc:  # pragma: no cover - netwerkafhankelijk
+        return {
+            "ok": True,
+            "status": "external_source_unavailable",
+            "gtin": normalized_gtin,
+            "product": None,
+            "error": str(exc),
+            "mutated": False,
+        }
+
+    product = payload.get("product")
+    if (
+        int(payload.get("status") or 0) != 1
+        or not isinstance(product, dict)
+    ):
+        return {
+            "ok": True,
+            "status": "not_found",
+            "gtin": normalized_gtin,
+            "product": None,
+            "mutated": False,
+        }
+
+    returned_gtin = _text(
+        product.get("code")
+        or product.get("id")
+        or product.get("_id")
+        or normalized_gtin
+    )
+    returned_gtin = "".join(
+        character
+        for character in returned_gtin
+        if character.isdigit()
+    )
+
+    if returned_gtin != normalized_gtin:
+        return {
+            "ok": True,
+            "status": "not_found",
+            "gtin": normalized_gtin,
+            "product": None,
+            "mutated": False,
+        }
+
+    return {
+        "ok": True,
+        "status": "found",
+        "gtin": normalized_gtin,
+        "product": {
+            "gtin": normalized_gtin,
+            "product_name": _text(
+                product.get("product_name_nl")
+                or product.get("product_name")
+            ),
+            "brand": _text(product.get("brands")),
+            "category": _text(product.get("categories")),
+            "categories": _text(product.get("categories")),
+            "explicit_gpc_brick_code": _text(
+                product.get("gpcCategoryCode")
+            ),
+            "source": "open_food_facts",
+        },
+        "mutated": False,
+    }
 
 
 def _normalize(value: Any) -> str:

--- a/backend/app/testing/external_receipt_dedupe_contract.py
+++ b/backend/app/testing/external_receipt_dedupe_contract.py
@@ -1,0 +1,53 @@
+"""Regressiecontract voor initiële Catalogusprojectie bij dubbele bonregels."""
+
+from app.services.external_product_candidate_store import (
+    _m2c2i_fix7b_dedupe_top_receipt_items,
+)
+
+
+def run() -> None:
+    rows = [
+        {
+            "receipt_line_text": "SYNTHETISCH PRODUCT",
+            "retailer_code": "voorbeeldwinkel",
+            "status": "no_candidate",
+            "candidate_status": "no_candidate",
+            "global_product_id": None,
+            "updated_at": "2026-01-02T12:00:00",
+            "candidates": [],
+        },
+        {
+            "receipt_line_text": "SYNTHETISCH PRODUCT",
+            "retailer_code": "voorbeeldwinkel",
+            "status": "linked_to_catalog",
+            "candidate_status": "linked_to_catalog",
+            "global_product_id": "synthetic-global-product-id",
+            "canonical_catalog_product_id": "synthetic-global-product-id",
+            "linked_candidate_name": "Synthetisch product",
+            "linked_gtin": "12345670",
+            "linked_product_type": "Nog niet geclassificeerd",
+            "is_linked_to_catalog": True,
+            "is_existing_link_for_receipt_item": True,
+            "updated_at": "2026-01-01T12:00:00",
+            "candidates": [],
+        },
+    ]
+
+    result = _m2c2i_fix7b_dedupe_top_receipt_items(rows)
+
+    assert len(result) == 1
+    row = result[0]
+    assert row["global_product_id"] == "synthetic-global-product-id"
+    assert row["canonical_catalog_product_id"] == (
+        "synthetic-global-product-id"
+    )
+    assert row["linked_candidate_name"] == "Synthetisch product"
+    assert row["linked_gtin"] == "12345670"
+    assert row["status"] == "linked_to_catalog"
+    assert row["is_linked_to_catalog"] is True
+
+    print("EXTERNAL_RECEIPT_INITIAL_PROJECTION_CONTRACT_GREEN")
+
+
+if __name__ == "__main__":
+    run()

--- a/backend/tests/test_barcode_catalog_save_service.py
+++ b/backend/tests/test_barcode_catalog_save_service.py
@@ -56,7 +56,8 @@ def build_database():
         conn.execute(text(
             "CREATE TABLE household_articles ("
             "id TEXT PRIMARY KEY, household_id TEXT, "
-            "global_product_id TEXT, updated_at TEXT)"
+            "global_product_id TEXT, barcode TEXT, "
+            "updated_at TEXT)"
         ))
         conn.execute(text(
             "CREATE TABLE inventory_events (id TEXT PRIMARY KEY)"
@@ -72,7 +73,7 @@ def build_database():
         ))
         conn.execute(text(
             "INSERT INTO household_articles "
-            "VALUES ('article-1', 'household-1', NULL, NULL)"
+            "VALUES ('article-1', 'household-1', NULL, NULL, NULL)"
         ))
 
     return engine, gtin
@@ -108,11 +109,14 @@ def check_unknown_gtin_is_created_and_linked() -> None:
             "AND identity_value = :gtin"
         ), {"gtin": gtin}).scalar_one()
 
-        article_product = conn.execute(text(
-            "SELECT global_product_id "
+        article_row = conn.execute(text(
+            "SELECT global_product_id, barcode "
             "FROM household_articles "
             "WHERE id = 'article-1'"
-        )).scalar_one()
+        )).mappings().one()
+
+        article_product = article_row["global_product_id"]
+        article_barcode = article_row["barcode"]
 
         line_product = conn.execute(text(
             "SELECT matched_global_product_id "
@@ -137,6 +141,10 @@ def check_unknown_gtin_is_created_and_linked() -> None:
     assert_true(
         article_product == result["product"]["global_product_id"],
         "Huishoudartikel is niet gekoppeld",
+    )
+    assert_true(
+        article_barcode == gtin,
+        "Barcode is niet bij Mijn artikel opgeslagen",
     )
     assert_true(
         line_product == result["product"]["global_product_id"],

--- a/backend/tests/test_barcode_catalog_save_service.py
+++ b/backend/tests/test_barcode_catalog_save_service.py
@@ -35,8 +35,13 @@ def build_database():
         conn.execute(text(
             "CREATE TABLE product_identities ("
             "id TEXT PRIMARY KEY, "
-            "global_product_id TEXT, identity_type TEXT, "
-            "identity_value TEXT, source TEXT, is_primary INTEGER)"
+            "household_article_id TEXT NOT NULL, "
+            "global_product_id TEXT, "
+            "identity_type TEXT NOT NULL, "
+            "identity_value TEXT NOT NULL, "
+            "source TEXT NOT NULL, "
+            "confidence_score NUMERIC NOT NULL DEFAULT 1.0, "
+            "is_primary INTEGER NOT NULL DEFAULT 0)"
         ))
         conn.execute(text(
             "CREATE TABLE purchase_import_batches ("
@@ -96,6 +101,13 @@ def check_unknown_gtin_is_created_and_linked() -> None:
             "AND identity_value = :gtin"
         ), {"gtin": gtin}).scalar_one()
 
+        identity_household_article = conn.execute(text(
+            "SELECT household_article_id "
+            "FROM product_identities "
+            "WHERE identity_type = 'gtin' "
+            "AND identity_value = :gtin"
+        ), {"gtin": gtin}).scalar_one()
+
         article_product = conn.execute(text(
             "SELECT global_product_id "
             "FROM household_articles "
@@ -118,6 +130,10 @@ def check_unknown_gtin_is_created_and_linked() -> None:
     )
     assert_true(product_count == 1, "Onjuist aantal producten")
     assert_true(identity_count == 1, "GTIN-identiteit ontbreekt")
+    assert_true(
+        identity_household_article == "article-1",
+        "GTIN-identiteit mist het huishoudartikel",
+    )
     assert_true(
         article_product == result["product"]["global_product_id"],
         "Huishoudartikel is niet gekoppeld",

--- a/backend/tests/test_barcode_catalog_save_service.py
+++ b/backend/tests/test_barcode_catalog_save_service.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import sys
+import traceback
+from collections.abc import Callable
+
+from sqlalchemy import create_engine, text
+
+from app.services.barcode_identity_service import (
+    calculate_gtin_check_digit,
+    save_gtin_catalog_and_household_link,
+)
+
+
+def valid_gtin(body: str) -> str:
+    return body + str(calculate_gtin_check_digit(body))
+
+
+def assert_true(value: bool, message: str) -> None:
+    if not value:
+        raise AssertionError(message)
+
+
+def build_database():
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    gtin = valid_gtin("089394000222")
+
+    with engine.begin() as conn:
+        conn.execute(text(
+            "CREATE TABLE global_products ("
+            "id TEXT PRIMARY KEY, "
+            "name TEXT, brand TEXT, primary_gtin TEXT, "
+            "source TEXT, status TEXT)"
+        ))
+        conn.execute(text(
+            "CREATE TABLE product_identities ("
+            "id TEXT PRIMARY KEY, "
+            "global_product_id TEXT, identity_type TEXT, "
+            "identity_value TEXT, source TEXT, is_primary INTEGER)"
+        ))
+        conn.execute(text(
+            "CREATE TABLE purchase_import_batches ("
+            "batch_id TEXT PRIMARY KEY, household_id TEXT)"
+        ))
+        conn.execute(text(
+            "CREATE TABLE purchase_import_lines ("
+            "id TEXT PRIMARY KEY, batch_id TEXT, "
+            "matched_household_article_id TEXT, "
+            "matched_global_product_id TEXT)"
+        ))
+        conn.execute(text(
+            "CREATE TABLE household_articles ("
+            "id TEXT PRIMARY KEY, household_id TEXT, "
+            "global_product_id TEXT, updated_at TEXT)"
+        ))
+        conn.execute(text(
+            "CREATE TABLE inventory_events (id TEXT PRIMARY KEY)"
+        ))
+
+        conn.execute(text(
+            "INSERT INTO purchase_import_batches "
+            "VALUES ('batch-1', 'household-1')"
+        ))
+        conn.execute(text(
+            "INSERT INTO purchase_import_lines "
+            "VALUES ('line-1', 'batch-1', NULL, NULL)"
+        ))
+        conn.execute(text(
+            "INSERT INTO household_articles "
+            "VALUES ('article-1', 'household-1', NULL, NULL)"
+        ))
+
+    return engine, gtin
+
+
+def check_unknown_gtin_is_created_and_linked() -> None:
+    engine, gtin = build_database()
+
+    with engine.begin() as conn:
+        result = save_gtin_catalog_and_household_link(
+            conn,
+            household_id="household-1",
+            purchase_import_line_id="line-1",
+            household_article_id="article-1",
+            gtin=gtin,
+            article_name="Apple Quinoa",
+        )
+
+        product_count = conn.execute(text(
+            "SELECT COUNT(*) FROM global_products"
+        )).scalar_one()
+
+        identity_count = conn.execute(text(
+            "SELECT COUNT(*) FROM product_identities "
+            "WHERE identity_type = 'gtin' "
+            "AND identity_value = :gtin"
+        ), {"gtin": gtin}).scalar_one()
+
+        article_product = conn.execute(text(
+            "SELECT global_product_id "
+            "FROM household_articles "
+            "WHERE id = 'article-1'"
+        )).scalar_one()
+
+        line_product = conn.execute(text(
+            "SELECT matched_global_product_id "
+            "FROM purchase_import_lines "
+            "WHERE id = 'line-1'"
+        )).scalar_one()
+
+        event_count = conn.execute(text(
+            "SELECT COUNT(*) FROM inventory_events"
+        )).scalar_one()
+
+    assert_true(
+        result["catalog_product_created"] is True,
+        "Centraal product is niet aangemaakt",
+    )
+    assert_true(product_count == 1, "Onjuist aantal producten")
+    assert_true(identity_count == 1, "GTIN-identiteit ontbreekt")
+    assert_true(
+        article_product == result["product"]["global_product_id"],
+        "Huishoudartikel is niet gekoppeld",
+    )
+    assert_true(
+        line_product == result["product"]["global_product_id"],
+        "Uitpakken-regel is niet bijgewerkt",
+    )
+    assert_true(event_count == 0, "Voorraad is gewijzigd")
+
+
+def check_repeat_is_idempotent() -> None:
+    engine, gtin = build_database()
+
+    with engine.begin() as conn:
+        first = save_gtin_catalog_and_household_link(
+            conn,
+            household_id="household-1",
+            purchase_import_line_id="line-1",
+            household_article_id="article-1",
+            gtin=gtin,
+            article_name="Apple Quinoa",
+        )
+
+        second = save_gtin_catalog_and_household_link(
+            conn,
+            household_id="household-1",
+            purchase_import_line_id="line-1",
+            household_article_id="article-1",
+            gtin=gtin,
+            article_name="Apple Quinoa",
+        )
+
+        product_count = conn.execute(text(
+            "SELECT COUNT(*) FROM global_products"
+        )).scalar_one()
+
+        identity_count = conn.execute(text(
+            "SELECT COUNT(*) FROM product_identities"
+        )).scalar_one()
+
+    assert_true(
+        first["catalog_product_created"] is True,
+        "Eerste opslag moet een product maken",
+    )
+    assert_true(
+        second["catalog_product_created"] is False,
+        "Tweede opslag mag geen nieuw product maken",
+    )
+    assert_true(product_count == 1, "Dubbel product aangemaakt")
+    assert_true(identity_count == 1, "Dubbele identiteit aangemaakt")
+
+
+def main() -> int:
+    checks: list[tuple[str, Callable[[], None]]] = [
+        (
+            "Onbekende GTIN wordt centraal en lokaal opgeslagen",
+            check_unknown_gtin_is_created_and_linked,
+        ),
+        (
+            "Herhaalde opslag is idempotent",
+            check_repeat_is_idempotent,
+        ),
+    ]
+
+    failures = 0
+
+    print("Rezzerv Fase 3 - catalogusopslagcontracttests")
+    print("=" * 62)
+
+    for number, (name, check) in enumerate(checks, start=1):
+        try:
+            check()
+            print(f"PASS {number}/{len(checks)} - {name}")
+        except Exception as exc:
+            failures += 1
+            print(f"FAIL {number}/{len(checks)} - {name}: {exc}")
+            traceback.print_exc()
+
+    print("=" * 62)
+
+    if failures:
+        print(f"RESULTAAT: ROOD - {failures} controle(s) mislukt")
+        return 1
+
+    print(
+        f"RESULTAAT: GROEN - "
+        f"{len(checks)} van {len(checks)} controles geslaagd"
+    )
+    print("Voorraadmutaties: geen")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_barcode_household_article_link_service.py
+++ b/backend/tests/test_barcode_household_article_link_service.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import sys
+import traceback
+from collections.abc import Callable
+
+from sqlalchemy import create_engine, text
+
+from app.services.barcode_identity_service import (
+    BarcodeHouseholdArticleLinkError,
+    calculate_gtin_check_digit,
+    link_household_article_to_matched_product,
+)
+
+
+def _valid_gtin(body: str) -> str:
+    return body + str(calculate_gtin_check_digit(body))
+
+
+def _assert(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _database():
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    gtin = _valid_gtin("871234567890")
+
+    with engine.begin() as conn:
+        conn.execute(text(
+            "CREATE TABLE global_products "
+            "(id TEXT PRIMARY KEY, name TEXT, brand TEXT, "
+            "status TEXT, primary_gtin TEXT)"
+        ))
+        conn.execute(text(
+            "CREATE TABLE product_identities "
+            "(id TEXT PRIMARY KEY, global_product_id TEXT, "
+            "identity_type TEXT, identity_value TEXT, "
+            "source TEXT, is_primary INTEGER)"
+        ))
+        conn.execute(text(
+            "CREATE TABLE product_group_memberships "
+            "(global_product_id TEXT, inventory_group_key TEXT, "
+            "active INTEGER)"
+        ))
+        conn.execute(text(
+            "CREATE TABLE product_inventory_groups "
+            "(inventory_group_key TEXT, gpc_brick_code TEXT, "
+            "display_name TEXT, source TEXT, active INTEGER)"
+        ))
+        conn.execute(text(
+            "CREATE TABLE purchase_import_batches "
+            "(batch_id TEXT PRIMARY KEY, household_id TEXT)"
+        ))
+        conn.execute(text(
+            "CREATE TABLE purchase_import_lines "
+            "(id TEXT PRIMARY KEY, batch_id TEXT, "
+            "matched_household_article_id TEXT)"
+        ))
+        conn.execute(text(
+            "CREATE TABLE household_articles "
+            "(id TEXT PRIMARY KEY, household_id TEXT, "
+            "global_product_id TEXT, updated_at TEXT)"
+        ))
+        conn.execute(text(
+            "CREATE TABLE inventory_events "
+            "(id TEXT PRIMARY KEY)"
+        ))
+
+        conn.execute(
+            text(
+                "INSERT INTO global_products VALUES "
+                "('product-1', 'Product', 'Merk', "
+                "'active', :gtin)"
+            ),
+            {"gtin": gtin},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO product_identities VALUES "
+                "('identity-1', 'product-1', 'gtin', "
+                ":gtin, 'manual', 1)"
+            ),
+            {"gtin": gtin},
+        )
+        conn.execute(text(
+            "INSERT INTO product_group_memberships VALUES "
+            "('product-1', 'gpc:10000000', 1)"
+        ))
+        conn.execute(text(
+            "INSERT INTO product_inventory_groups VALUES "
+            "('gpc:10000000', '10000000', "
+            "'Producttype', 'gs1_gpc_nl', 1)"
+        ))
+        conn.execute(text(
+            "INSERT INTO purchase_import_batches VALUES "
+            "('batch-1', 'household-1')"
+        ))
+        conn.execute(text(
+            "INSERT INTO purchase_import_lines VALUES "
+            "('line-1', 'batch-1', NULL)"
+        ))
+        conn.execute(text(
+            "INSERT INTO household_articles VALUES "
+            "('article-1', 'household-1', NULL, NULL)"
+        ))
+        conn.execute(text(
+            "INSERT INTO household_articles VALUES "
+            "('article-other', 'household-2', NULL, NULL)"
+        ))
+
+    return engine, gtin
+
+
+def check_link_and_idempotency() -> None:
+    engine, gtin = _database()
+
+    with engine.begin() as conn:
+        first = link_household_article_to_matched_product(
+            conn,
+            household_id="household-1",
+            purchase_import_line_id="line-1",
+            household_article_id="article-1",
+            gtin=gtin,
+            global_product_id="product-1",
+        )
+
+        second = link_household_article_to_matched_product(
+            conn,
+            household_id="household-1",
+            purchase_import_line_id="line-1",
+            household_article_id="article-1",
+            gtin=gtin,
+            global_product_id="product-1",
+        )
+
+        article_product = conn.execute(text(
+            "SELECT global_product_id "
+            "FROM household_articles "
+            "WHERE id = 'article-1'"
+        )).scalar_one()
+
+        mapped_article = conn.execute(text(
+            "SELECT matched_household_article_id "
+            "FROM purchase_import_lines "
+            "WHERE id = 'line-1'"
+        )).scalar_one()
+
+        events = conn.execute(text(
+            "SELECT COUNT(*) FROM inventory_events"
+        )).scalar_one()
+
+    _assert(first["changed"] is True, "Eerste koppeling wijzigt niet")
+    _assert(second["idempotent"] is True, "Koppeling is niet idempotent")
+    _assert(article_product == "product-1", "Product-id niet opgeslagen")
+    _assert(mapped_article == "article-1", "Bonregel niet gekoppeld")
+    _assert(events == 0, "Er is een voorraad-event aangemaakt")
+
+
+def check_household_isolation() -> None:
+    engine, gtin = _database()
+
+    with engine.begin() as conn:
+        try:
+            link_household_article_to_matched_product(
+                conn,
+                household_id="household-1",
+                purchase_import_line_id="line-1",
+                household_article_id="article-other",
+                gtin=gtin,
+                global_product_id="product-1",
+            )
+        except BarcodeHouseholdArticleLinkError as exc:
+            _assert(
+                exc.status_code == 404,
+                "Ander huishouden moet als niet gevonden gelden",
+            )
+        else:
+            raise AssertionError(
+                "Artikel uit ander huishouden is gekoppeld"
+            )
+
+
+def check_product_mismatch_rejected() -> None:
+    engine, gtin = _database()
+
+    with engine.begin() as conn:
+        try:
+            link_household_article_to_matched_product(
+                conn,
+                household_id="household-1",
+                purchase_import_line_id="line-1",
+                household_article_id="article-1",
+                gtin=gtin,
+                global_product_id="product-other",
+            )
+        except BarcodeHouseholdArticleLinkError as exc:
+            _assert(
+                exc.status_code == 409,
+                "Productmismatch moet een conflict geven",
+            )
+        else:
+            raise AssertionError(
+                "Productmismatch is geaccepteerd"
+            )
+
+
+def main() -> int:
+    checks: list[tuple[str, Callable[[], None]]] = [
+        ("Koppeling en idempotentie", check_link_and_idempotency),
+        ("Huishoudisolatie", check_household_isolation),
+        ("Productmismatch geweigerd", check_product_mismatch_rejected),
+    ]
+
+    failures = 0
+
+    print("Rezzerv barcode Fase 3 - contracttests")
+    print("=" * 52)
+
+    for number, (name, check) in enumerate(checks, start=1):
+        try:
+            check()
+            print(f"PASS {number}/{len(checks)} - {name}")
+        except Exception as exc:
+            failures += 1
+            print(
+                f"FAIL {number}/{len(checks)} - {name}: {exc}"
+            )
+            traceback.print_exc()
+
+    print("=" * 52)
+
+    if failures:
+        print(
+            f"RESULTAAT: ROOD - {failures} controle(s) mislukt"
+        )
+        return 1
+
+    print(
+        f"RESULTAAT: GROEN - "
+        f"{len(checks)} van {len(checks)} controles geslaagd"
+    )
+    print("Voorraadmutaties: geen")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/frontend/src/features/barcodes/BarcodeIdentityField.jsx
+++ b/frontend/src/features/barcodes/BarcodeIdentityField.jsx
@@ -46,6 +46,16 @@ export default function BarcodeIdentityField({
           {busy ? 'Controleren…' : 'Controleren'}
         </Button>
       </div>
+      {state.message ? (
+        <div
+          className={`rz-barcode-field__status rz-barcode-field__status--${state.status || 'idle'}`}
+          role={state.status === 'error' ? 'alert' : 'status'}
+          aria-live="polite"
+          data-testid={`receipt-line-barcode-status-${lineId}`}
+        >
+          {state.message}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/frontend/src/features/barcodes/BarcodeIdentityField.jsx
+++ b/frontend/src/features/barcodes/BarcodeIdentityField.jsx
@@ -46,16 +46,6 @@ export default function BarcodeIdentityField({
           {busy ? 'Controleren…' : 'Controleren'}
         </Button>
       </div>
-      {state.message ? (
-        <div
-          className={`rz-barcode-field__status rz-barcode-field__status--${state.status || 'idle'}`}
-          role={state.status === 'error' ? 'alert' : 'status'}
-          aria-live="polite"
-          data-testid={`receipt-line-barcode-status-${lineId}`}
-        >
-          {state.message}
-        </div>
-      ) : null}
     </div>
   )
 }

--- a/frontend/src/features/catalog/CatalogDetailPage.jsx
+++ b/frontend/src/features/catalog/CatalogDetailPage.jsx
@@ -12,6 +12,41 @@ function text(value, fallback = '-') {
   return normalized || fallback
 }
 
+function sourceLabel(value) {
+  const normalized = String(value ?? '').trim().toLowerCase()
+
+  const labels = {
+    receipt_user_confirmed: 'Door gebruiker bevestigd',
+    receipt: 'Kassabon',
+    user: 'Gebruiker',
+    manual: 'Handmatig',
+    catalog_gtin: 'Bestaande Catalogus-GTIN',
+    openfoodfacts: 'Open Food Facts',
+    open_food_facts: 'Open Food Facts',
+    public_reference: 'Openbare referentie',
+    gs1: 'GS1',
+    ai: 'AI',
+  }
+
+  return labels[normalized] || text(value)
+}
+
+function identityTypeLabel(value) {
+  const normalized = String(value ?? '').trim().toLowerCase()
+
+  const labels = {
+    gtin: 'GTIN',
+    ean: 'EAN',
+    upc: 'UPC',
+    retailer_article_number: 'Winkelartikelnummer',
+    external_article_number: 'Extern artikelnummer',
+    store_sku: 'Winkelcode',
+    text_match: 'Tekstherkenning',
+  }
+
+  return labels[normalized] || text(value)
+}
+
 export default function CatalogDetailPage() {
   const { globalProductId } = useParams()
   const navigate = useNavigate()
@@ -21,83 +56,237 @@ export default function CatalogDetailPage() {
 
   useEffect(() => {
     let cancelled = false
+
     async function loadDetail() {
       setIsLoading(true)
       setError('')
+
       try {
-        const response = await fetchJsonWithAuth(`/api/catalog/${encodeURIComponent(globalProductId)}`, { method: 'GET' })
+        const response = await fetchJsonWithAuth(
+          `/api/catalog/${encodeURIComponent(globalProductId)}`,
+          { method: 'GET' },
+        )
+
         const data = await response.json().catch(() => ({}))
-        if (!response.ok) throw new Error(data?.detail || 'Catalogusartikel kon niet worden geladen')
+
+        if (!response.ok) {
+          throw new Error(
+            data?.detail || 'Catalogusartikel kon niet worden geladen',
+          )
+        }
+
         if (!cancelled) setDetail(data)
       } catch (err) {
-        if (!cancelled) setError(err?.message || 'Catalogusartikel kon niet worden geladen')
+        if (!cancelled) {
+          setError(
+            err?.message || 'Catalogusartikel kon niet worden geladen',
+          )
+        }
       } finally {
         if (!cancelled) setIsLoading(false)
       }
     }
+
     loadDetail()
-    return () => { cancelled = true }
+
+    return () => {
+      cancelled = true
+    }
   }, [globalProductId])
 
   const product = detail?.product || {}
-  const identities = Array.isArray(detail?.identities) ? detail.identities : []
-  const householdArticles = Array.isArray(detail?.household_articles) ? detail.household_articles : []
+  const identities = Array.isArray(detail?.identities)
+    ? detail.identities
+    : []
+  const householdArticles = Array.isArray(detail?.household_articles)
+    ? detail.household_articles
+    : []
+  const receiptLines = Array.isArray(detail?.receipt_lines)
+    ? detail.receipt_lines
+    : []
 
   return (
     <AppShell title="Catalogusdetail" showExit={false}>
-      <div className="rz-catalog-page" data-testid="catalog-detail-page">
+      <div
+        className="rz-catalog-page"
+        data-testid="catalog-detail-page"
+      >
         <ScreenCard fullWidth>
           <div className="rz-catalog-detail-actions">
-            <Button type="button" variant="secondary" onClick={() => navigate('/catalogus')}>Terug naar Catalogus</Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => navigate('/catalogus')}
+            >
+              Terug naar Catalogus
+            </Button>
           </div>
 
           {isLoading ? <div>Catalogusartikel laden...</div> : null}
-          {error ? <div className="rz-inline-feedback rz-inline-feedback--error">{error}</div> : null}
+
+          {error ? (
+            <div className="rz-inline-feedback rz-inline-feedback--error">
+              {error}
+            </div>
+          ) : null}
 
           {!isLoading && !error ? (
             <div className="rz-catalog-detail-grid">
               <section>
                 <h2>{text(product.name, 'Universeel artikel')}</h2>
+
                 <dl className="rz-catalog-definition-list">
-                  <div><dt>ID</dt><dd>{text(product.id)}</dd></div>
-                  <div><dt>Merk</dt><dd>{text(product.brand)}</dd></div>
-                  <div><dt>Primaire GTIN</dt><dd>{text(product.primary_gtin)}</dd></div>
-                  <div><dt>Producttype</dt><dd>{text(product.product_type)}</dd></div>
-                  <div><dt>Bron</dt><dd>{text(product.source)}</dd></div>
-                  <div><dt>Kwaliteitsstatus</dt><dd>{text(product.quality_status)}</dd></div>
+                  <div>
+                    <dt>ID</dt>
+                    <dd>{text(product.id)}</dd>
+                  </div>
+
+                  <div>
+                    <dt>Merk</dt>
+                    <dd>{text(product.brand)}</dd>
+                  </div>
+
+                  <div>
+                    <dt>Primaire GTIN</dt>
+                    <dd>{text(product.primary_gtin)}</dd>
+                  </div>
+
+                  <div>
+                    <dt>Producttype</dt>
+                    <dd>
+                      {text(
+                        product.product_type,
+                        'Nog niet geclassificeerd',
+                      )}
+                    </dd>
+                  </div>
+
+                  <div>
+                    <dt>Bron</dt>
+                    <dd>{sourceLabel(product.source)}</dd>
+                  </div>
+
+                  <div>
+                    <dt>Kwaliteitsstatus</dt>
+                    <dd>{text(product.quality_status)}</dd>
+                  </div>
                 </dl>
               </section>
 
               <section>
                 <h3>Identiteiten</h3>
+
                 <Table dataTestId="catalog-identities-table">
-                  <thead><tr className="rz-table-header"><th>Type</th><th>Waarde</th><th>Primair</th><th>Bron</th></tr></thead>
+                  <thead>
+                    <tr className="rz-table-header">
+                      <th>Type</th>
+                      <th>Waarde</th>
+                      <th>Primair</th>
+                      <th>Bron</th>
+                    </tr>
+                  </thead>
+
                   <tbody>
-                    {identities.length ? identities.map((identity, index) => (
-                      <tr key={identity.id || `${identity.identity_type}-${identity.identity_value}-${index}`}>
-                        <td>{text(identity.identity_type)}</td>
-                        <td>{text(identity.identity_value)}</td>
-                        <td>{identity.is_primary ? 'Ja' : 'Nee'}</td>
-                        <td>{text(identity.source)}</td>
+                    {identities.length ? (
+                      identities.map((identity, index) => (
+                        <tr
+                          key={
+                            identity.id
+                            || `${identity.identity_type}-${identity.identity_value}-${index}`
+                          }
+                        >
+                          <td>
+                            {identityTypeLabel(
+                              identity.identity_type,
+                            )}
+                          </td>
+                          <td>{text(identity.identity_value)}</td>
+                          <td>
+                            {identity.is_primary ? 'Ja' : 'Nee'}
+                          </td>
+                          <td>{sourceLabel(identity.source)}</td>
+                        </tr>
+                      ))
+                    ) : (
+                      <tr>
+                        <td colSpan="4">
+                          Geen aanvullende identiteiten gevonden.
+                        </td>
                       </tr>
-                    )) : <tr><td colSpan="4">Geen aanvullende identiteiten gevonden.</td></tr>}
+                    )}
                   </tbody>
                 </Table>
               </section>
 
               <section>
                 <h3>Gekoppelde huishoudartikelen</h3>
+
                 <Table dataTestId="catalog-household-articles-table">
-                  <thead><tr className="rz-table-header"><th>Huishouden</th><th>Huishoudartikel</th><th>Minimum</th><th>Ideaal</th></tr></thead>
+                  <thead>
+                    <tr className="rz-table-header">
+                      <th>Huishouden</th>
+                      <th>Huishoudartikel</th>
+                      <th>Minimum</th>
+                      <th>Ideaal</th>
+                    </tr>
+                  </thead>
+
                   <tbody>
-                    {householdArticles.length ? householdArticles.map((article, index) => (
-                      <tr key={article.id || index}>
-                        <td>{text(article.household_id)}</td>
-                        <td>{text(article.name || article.article_name)}</td>
-                        <td>{text(article.minimum_stock)}</td>
-                        <td>{text(article.ideal_stock)}</td>
+                    {householdArticles.length ? (
+                      householdArticles.map((article, index) => (
+                        <tr key={article.id || index}>
+                          <td>{text(article.household_id)}</td>
+                          <td>
+                            {text(
+                              article.name
+                              || article.article_name,
+                            )}
+                          </td>
+                          <td>{text(article.minimum_stock)}</td>
+                          <td>{text(article.ideal_stock)}</td>
+                        </tr>
+                      ))
+                    ) : (
+                      <tr>
+                        <td colSpan="4">
+                          Geen gekoppelde huishoudartikelen gevonden.
+                        </td>
                       </tr>
-                    )) : <tr><td colSpan="4">Geen gekoppelde huishoudartikelen gevonden.</td></tr>}
+                    )}
+                  </tbody>
+                </Table>
+              </section>
+
+              <section>
+                <h3>Gekoppelde kassabonregels</h3>
+
+                <Table dataTestId="catalog-receipt-lines-table">
+                  <thead>
+                    <tr className="rz-table-header">
+                      <th>Bonartikel</th>
+                      <th>Huishoudartikel</th>
+                      <th>GTIN</th>
+                    </tr>
+                  </thead>
+
+                  <tbody>
+                    {receiptLines.length ? (
+                      receiptLines.map((line, index) => (
+                        <tr key={line.id || index}>
+                          <td>{text(line.article_name_raw)}</td>
+                          <td>
+                            {text(line.household_article_name)}
+                          </td>
+                          <td>{text(line.gtin)}</td>
+                        </tr>
+                      ))
+                    ) : (
+                      <tr>
+                        <td colSpan="3">
+                          Geen gekoppelde kassabonregels gevonden.
+                        </td>
+                      </tr>
+                    )}
                   </tbody>
                 </Table>
               </section>

--- a/frontend/src/features/catalog/CatalogPage.jsx
+++ b/frontend/src/features/catalog/CatalogPage.jsx
@@ -253,6 +253,8 @@ export default function CatalogPage() {
                       <select className="rz-table-filter" value={filters.qualityStatus} onChange={(event) => updateFilter('qualityStatus', event.target.value)} aria-label="Kwaliteitsstatus filter">
                         <option value="">Alle</option>
                         <option value="compleet">Compleet</option>
+                        <option value="door gebruiker bevestigd">Door gebruiker bevestigd</option>
+                        <option value="gtin bevestigd — producttype ontbreekt">GTIN bevestigd — producttype ontbreekt</option>
                         <option value="controle nodig">Controle nodig</option>
                         <option value="conflict">Conflict</option>
                       </select>

--- a/frontend/src/features/catalog/CatalogPage.jsx
+++ b/frontend/src/features/catalog/CatalogPage.jsx
@@ -254,7 +254,7 @@ export default function CatalogPage() {
                         <option value="">Alle</option>
                         <option value="compleet">Compleet</option>
                         <option value="door gebruiker bevestigd">Door gebruiker bevestigd</option>
-                        <option value="gtin bevestigd — producttype ontbreekt">GTIN bevestigd — producttype ontbreekt</option>
+                        <option value="gtin bevestigd — producttype nog te bepalen">GTIN bevestigd — producttype nog te bepalen</option>
                         <option value="controle nodig">Controle nodig</option>
                         <option value="conflict">Conflict</option>
                       </select>

--- a/frontend/src/features/catalog/CatalogPage.jsx
+++ b/frontend/src/features/catalog/CatalogPage.jsx
@@ -15,6 +15,22 @@ function text(value, fallback = '-') {
   return normalized || fallback
 }
 
+function sourceLabel(value) {
+  const normalized = String(value ?? '').trim().toLowerCase()
+  const labels = {
+    receipt_user_confirmed: 'Door gebruiker bevestigd',
+    receipt: 'Kassabon',
+    user: 'Gebruiker',
+    manual: 'Handmatig',
+    openfoodfacts: 'Open Food Facts',
+    open_food_facts: 'Open Food Facts',
+    gs1: 'GS1',
+    ai: 'AI',
+    public_reference: 'Openbare referentie',
+  }
+  return labels[normalized] || text(value)
+}
+
 function qualityClass(status) {
   if (status === 'Compleet') return 'rz-catalog-status rz-catalog-status--complete'
   if (status === 'Conflict') return 'rz-catalog-status rz-catalog-status--conflict'
@@ -178,7 +194,7 @@ export default function CatalogPage() {
             <div className="rz-catalog-header">
               <div>
                 <h2>Catalogus</h2>
-                <p>Read-only overzicht van universele artikelen, Producttypen en centrale productidentiteiten.</p>
+                <p>Alleen-lezenoverzicht van universele artikelen, producttypen en centrale productidentiteiten.</p>
               </div>
             </div>
 
@@ -260,7 +276,7 @@ export default function CatalogPage() {
                       <td>{text(item.brand)}</td>
                       <td>{text(item.primary_gtin)}</td>
                       <td>{text(item.product_type)}</td>
-                      <td>{text(item.source)}</td>
+                      <td>{sourceLabel(item.source)}</td>
                       <td className="rz-num">{Number(item.household_article_count || 0)}</td>
                       <td><span className={qualityClass(item.quality_status)}>{text(item.quality_status)}</span></td>
                     </tr>

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -246,6 +246,67 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
     if (!response.ok) throw new Error(data?.detail || 'Bonartikelen konden niet worden geladen')
     return buildReceiptItems(Array.isArray(data?.items) ? data.items : [])
   }
+
+  async function findCatalogProductByGtin(gtin) {
+    const normalizedGtin = gtinText(gtin)
+
+    if (normalizedGtin === '-') return null
+
+    const response = await fetchJsonWithAuth(
+      `/api/catalog?query=${encodeURIComponent(normalizedGtin)}&limit=20`,
+      { method: 'GET' },
+    )
+
+    const data = await response.json().catch(() => ({}))
+
+    if (!response.ok) {
+      throw new Error(
+        data?.detail
+        || 'De Catalogus kon niet op GTIN worden gecontroleerd',
+      )
+    }
+
+    const items = Array.isArray(data?.items) ? data.items : []
+
+    return items.find(
+      (product) =>
+        gtinText(product?.primary_gtin) === normalizedGtin,
+    ) || null
+  }
+
+  async function enrichOffResultsWithCatalog(results) {
+    const sourceResults = Array.isArray(results) ? results : []
+    const catalogProducts = new Map()
+
+    await Promise.all(
+      sourceResults.map(async (result) => {
+        const gtin = gtinText(
+          result?.gtin
+          || result?.ean
+          || result?.code,
+        )
+
+        if (gtin === '-' || catalogProducts.has(gtin)) return
+
+        const product = await findCatalogProductByGtin(gtin)
+        catalogProducts.set(gtin, product)
+      }),
+    )
+
+    return sourceResults.map((result) => {
+      const gtin = gtinText(
+        result?.gtin
+        || result?.ean
+        || result?.code,
+      )
+      const product = catalogProducts.get(gtin) || null
+
+      return {
+        ...result,
+        existing_catalog_product: product,
+      }
+    })
+  }
   async function loadItems() {
     try {
       const nextItems = await fetchItems()
@@ -307,21 +368,41 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
       linked_product_type_id: selectedItem.linkedProductTypeId,
     },
   } : null
-  const selectedCandidates = linkedSelectedCandidate ? [linkedSelectedCandidate] : offSearchResults.map((result) => ({
-    id: `off:${result.gtin}`,
-    candidateName: text(result.product_name),
-    brand: text(result.brand),
-    source: 'Open Food Facts',
-    externalCode: text(result.gtin),
-    score: result.automatic_rank_score ?? result.score,
-    status: 'OFF-kandidaat',
-    hasUniversalCode: true,
-    isLinkedToCatalog: false,
-    isLinkableToCatalog: true,
-    automaticRankScore: result.automatic_rank_score ?? null,
-    automaticEvidence: result.automatic_evidence ?? null,
-    raw: result,
-  }))
+  const selectedCandidates = linkedSelectedCandidate ? [linkedSelectedCandidate] : offSearchResults.map((result) => {
+    const catalogProduct = result?.existing_catalog_product || null
+    const catalogLinked = Boolean(catalogProduct)
+    const gtin = gtinText(result?.gtin || result?.ean || result?.code)
+
+    return {
+      id: catalogLinked
+        ? `linked:${catalogProduct.id || gtin}`
+        : `off:${gtin}`,
+      candidateName: catalogLinked
+        ? text(catalogProduct.name)
+        : text(result.product_name),
+      brand: catalogLinked
+        ? text(catalogProduct.brand)
+        : text(result.brand),
+      source: catalogLinked
+        ? 'Artikelcatalogus'
+        : 'Open Food Facts',
+      externalCode: gtin,
+      score: result.automatic_rank_score ?? result.score,
+      status: catalogLinked ? 'Gekoppeld' : 'OFF-kandidaat',
+      hasUniversalCode: true,
+      isLinkedToCatalog: catalogLinked,
+      catalogLinked,
+      isLinkableToCatalog: !catalogLinked,
+      automaticRankScore: result.automatic_rank_score ?? null,
+      automaticEvidence: result.automatic_evidence ?? null,
+      raw: {
+        ...result,
+        global_product_id: catalogProduct?.id || '',
+        matched_global_product_id: catalogProduct?.id || '',
+        primary_gtin: catalogProduct?.primary_gtin || gtin,
+      },
+    }
+  })
   const selectedCandidate = selectedCandidates.find((candidate) => candidate.id === selectedCandidateId) || null
   const hasValidProductTypeDecision = /^gpc:\d{8}$/.test(String(selectedProductTypeId || ''))
   const selectedCandidateCanBeLinked = Boolean(selectedItem && selectedCandidate && hasValidProductTypeDecision && !isLinkingProductType && !isClassifyingProductType)
@@ -497,8 +578,67 @@ export default function ReceiptItemsOverview({ onError, onMessage }) {
         throw new Error(data?.detail || 'Open Food Facts kon niet worden geraadpleegd')
       }
 
-      setOffSearchResults(Array.isArray(data?.results) ? data.results : [])
+      const enrichedResults = await enrichOffResultsWithCatalog(
+        Array.isArray(data?.results) ? data.results : [],
+      )
+
+      setOffSearchResults(enrichedResults)
       setOffPreview({ ...data, search_mode: mode })
+
+      const linkedResult = enrichedResults.find(
+        (result) => result?.existing_catalog_product,
+      )
+
+      if (linkedResult) {
+        const catalogProduct = linkedResult.existing_catalog_product
+        const linkedGtin = gtinText(
+          catalogProduct?.primary_gtin
+          || linkedResult?.gtin
+          || linkedResult?.ean
+          || linkedResult?.code,
+        )
+
+        const linkedFields = {
+          catalogLinked: true,
+          status: 'Gekoppeld',
+          linkedCandidateName: text(catalogProduct?.name),
+          globalProductId: text(catalogProduct?.id, ''),
+          gtin: linkedGtin,
+          hasKnownGtin: linkedGtin !== '-',
+          linkedProductTypeId: text(
+            catalogProduct?.product_type_id,
+            '',
+          ),
+          linkedProductType: text(
+            catalogProduct?.product_type,
+            '',
+          ),
+          productType: text(
+            catalogProduct?.product_type,
+            'Nog niet geclassificeerd',
+          ),
+          bestCandidateName: text(catalogProduct?.name),
+          bestCandidateCode: linkedGtin,
+        }
+
+        setItems((current) =>
+          current.map((currentItem) =>
+            currentItem.id === item.id
+              ? { ...currentItem, ...linkedFields }
+              : currentItem
+          )
+        )
+
+        setSelectedItem((current) =>
+          current?.id === item.id
+            ? { ...current, ...linkedFields }
+            : current
+        )
+
+        setSelectedCandidateId(
+          `linked:${catalogProduct?.id || linkedGtin}`,
+        )
+      }
     } catch (err) {
       setOffSearchResults([])
       setOffError(err?.message || 'Open Food Facts kon niet worden geraadpleegd')

--- a/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
+++ b/frontend/src/features/externalDatabases/ReceiptItemsOverview.jsx
@@ -179,7 +179,11 @@ function buildReceiptItems(rawItems) {
     const displayBest = linked || selectableBest
     const hasSelectableCandidate = candidates.some((candidate) => candidate.hasUniversalCode && !candidate.isFallbackCandidate && candidateMeetsScoreThreshold(candidate))
     const hasFallback = candidates.some((candidate) => candidate.isFallbackCandidate)
-    return { ...item, candidates, status: item.catalogLinked ? 'Gekoppeld' : (item.hasKnownGtin ? 'GTIN / EAN bekend' : (hasSelectableCandidate ? 'Universele kandidaten gevonden' : (hasFallback ? 'Geen externe match' : 'Geen universele kandidaat'))), candidateCount: candidates.filter((candidate) => candidate.hasUniversalCode && !candidate.isFallbackCandidate && candidateMeetsScoreThreshold(candidate)).length, bestCandidateName: item.catalogLinked && item.linkedCandidateName ? item.linkedCandidateName : (item.hasKnownGtin ? '' : text(displayBest?.candidateName, '')), productType: item.linkedProductType || '', bestCandidateCode: item.catalogLinked && item.gtin !== '-' ? item.gtin : (item.hasKnownGtin ? item.gtin : text(selectableBest?.externalCode, '')), bestCandidateScore: item.catalogLinked && item.linkedScore !== null ? item.linkedScore : (item.hasKnownGtin ? null : displayBest?.score ?? null), gtin: item.gtin, bestSelectableCandidateName: item.hasKnownGtin ? '' : text(selectableBest?.candidateName, '') }
+    return { ...item, candidates, status: item.catalogLinked ? 'Gekoppeld' : (item.hasKnownGtin ? 'GTIN / EAN bekend' : (hasSelectableCandidate ? 'Universele kandidaten gevonden' : (hasFallback ? 'Geen externe match' : 'Geen universele kandidaat'))), candidateCount: candidates.filter((candidate) => candidate.hasUniversalCode && !candidate.isFallbackCandidate && candidateMeetsScoreThreshold(candidate)).length, bestCandidateName: item.catalogLinked && item.linkedCandidateName ? item.linkedCandidateName : (item.hasKnownGtin ? '' : text(displayBest?.candidateName, '')), productType: item.linkedProductType || (
+        item.catalogLinked
+          ? 'Nog niet geclassificeerd'
+          : ''
+      ), bestCandidateCode: item.catalogLinked && item.gtin !== '-' ? item.gtin : (item.hasKnownGtin ? item.gtin : text(selectableBest?.externalCode, '')), bestCandidateScore: item.catalogLinked && item.linkedScore !== null ? item.linkedScore : (item.hasKnownGtin ? null : displayBest?.score ?? null), gtin: item.gtin, bestSelectableCandidateName: item.hasKnownGtin ? '' : text(selectableBest?.candidateName, '') }
   })
 }
 function offStatusLabel(preview) {

--- a/frontend/src/features/stores/StoreBatchDetailPage.jsx
+++ b/frontend/src/features/stores/StoreBatchDetailPage.jsx
@@ -2077,11 +2077,7 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
                   Barcode opslaan
                 </h3>
                 <p className="rz-modal-text">
-                  De barcode is geldig.
-                </p>
-                <p className="rz-modal-text">
-                  Het product wordt bijgewerkt in Uitpakken en centraal
-                  opgenomen of bijgewerkt in de catalogus.
+                  Dit is een geldige barcode.
                 </p>
                 <div className="rz-modal-actions">
                   <Button

--- a/frontend/src/features/stores/StoreBatchDetailPage.jsx
+++ b/frontend/src/features/stores/StoreBatchDetailPage.jsx
@@ -239,6 +239,7 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
   const [lineSaveState, setLineSaveState] = useState({})
   const [barcodeDrafts, setBarcodeDrafts] = useState({})
   const [barcodeStates, setBarcodeStates] = useState({})
+  const [barcodeSaveConfirm, setBarcodeSaveConfirm] = useState(null)
   const [activeBarcodeLineId, setActiveBarcodeLineId] = useState('')
   const [activeDetailLineId, setActiveDetailLineId] = useState(receiptLineId)
   const [selectedLineIds, setSelectedLineIds] = useState([])
@@ -367,23 +368,63 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
             product: lookup?.product || null,
           },
         }))
-        showUitpakkenFeedback(
-          'success',
-          message,
-          { key: `barcode-matched-${lineId}-${Date.now()}` }
+        const line = (batch?.lines || []).find(
+          (item) => String(item.id) === String(lineId)
         )
+        setBarcodeSaveConfirm({
+          lineId: String(lineId),
+          gtin: normalizedGtin,
+          articleName: String(line?.article_name_raw || '').trim(),
+          globalProductId,
+          productName,
+          matchStatus,
+        })
       } else if (matchStatus === 'conflict') {
         const message = 'Conflict: deze GTIN verwijst naar meerdere universele artikelen. Er is niets gewijzigd.'
         setBarcodeStates((current) => ({ ...current, [lineId]: { status: 'error', message } }))
         showUitpakkenFeedback('error', message, { key: `barcode-conflict-${lineId}-${Date.now()}` })
-      } else if (matchStatus === 'incomplete') {
-        const message = 'GTIN gevonden, maar de productkoppeling is nog niet compleet. Er is niets gewijzigd.'
-        setBarcodeStates((current) => ({ ...current, [lineId]: { status: 'warning', message } }))
-        showUitpakkenFeedback('warning', message, { key: `barcode-incomplete-${lineId}-${Date.now()}` })
-      } else {
-        const message = 'Geldige GTIN, maar nog niet bekend in de catalogus. Er is niets gewijzigd.'
-        setBarcodeStates((current) => ({ ...current, [lineId]: { status: 'warning', message } }))
-        showUitpakkenFeedback('warning', message, { key: `barcode-unknown-${lineId}-${Date.now()}` })
+      } else if (
+        matchStatus === 'incomplete'
+        || matchStatus === 'not_found'
+      ) {
+        const line = (batch?.lines || []).find(
+          (item) => String(item.id) === String(lineId)
+        )
+        const articleName = String(
+          line?.article_name_raw || ''
+        ).trim()
+        const normalizedGtin = String(
+          lookup?.gtin || validation.normalized_value || value
+        ).trim()
+        const productName = firstTextValue(
+          lookup?.product?.name,
+          articleName,
+          'Nieuw catalogusproduct'
+        )
+        const globalProductId = String(
+          lookup?.product?.global_product_id || ''
+        ).trim()
+        const message = 'De barcode is geldig.'
+        setBarcodeStates((current) => ({
+          ...current,
+          [lineId]: {
+            status: 'success',
+            message,
+            productName,
+            gtin: normalizedGtin,
+            matchStatus,
+            globalProductId,
+            product: lookup?.product || null,
+          },
+        }))
+        setBarcodeSaveConfirm({
+          lineId: String(lineId),
+          gtin: normalizedGtin,
+          articleName,
+          globalProductId,
+          productName,
+          matchStatus,
+        })
       }
     } catch (lookupError) {
       const message = normalizeErrorMessage(lookupError?.message || lookupError)
@@ -482,6 +523,108 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
         message,
         {
           key: `barcode-link-error-${lineId}-${Date.now()}`,
+        }
+      )
+    } finally {
+      setBusyLineId('')
+    }
+  }
+
+  async function saveConfirmedReceiptLineBarcode() {
+    const confirmation = barcodeSaveConfirm
+    if (!confirmation) return
+
+    const line = (batch?.lines || []).find(
+      (item) => String(item.id) === String(confirmation.lineId)
+    )
+    if (!line) {
+      setBarcodeSaveConfirm(null)
+      showUitpakkenFeedback(
+        'error',
+        'De bonregel is niet meer beschikbaar.',
+        { key: 'barcode-save-line-missing' }
+      )
+      return
+    }
+
+    const draft = getDraftValues(line)
+    const householdArticleId = String(
+      draft.articleId || ''
+    ).trim()
+
+    if (!householdArticleId) {
+      showUitpakkenFeedback(
+        'warning',
+        'Kies eerst Mijn artikel.',
+        { key: `barcode-save-no-article-${confirmation.lineId}` }
+      )
+      return
+    }
+
+    setBusyLineId(String(confirmation.lineId))
+
+    try {
+      const result = await fetchJson(
+        `/api/barcodes/${encodeURIComponent(confirmation.gtin)}/save-household-article`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            purchase_import_line_id: String(confirmation.lineId),
+            household_article_id: householdArticleId,
+            article_name: confirmation.articleName,
+          }),
+        }
+      )
+
+      const product = result?.product || {}
+      const productName = firstTextValue(
+        product?.name,
+        confirmation.articleName,
+        'Catalogusproduct'
+      )
+      const globalProductId = String(
+        product?.global_product_id || ''
+      ).trim()
+
+      await refreshBatch(batch.batch_id)
+
+      setBarcodeStates((current) => ({
+        ...current,
+        [confirmation.lineId]: {
+          ...(current[confirmation.lineId] || {}),
+          status: 'success',
+          message: result?.catalog_product_created
+            ? 'De barcode is opgeslagen en het product is opgenomen in de catalogus.'
+            : 'De barcode en productkoppeling zijn opgeslagen.',
+          productName,
+          gtin: result?.gtin || confirmation.gtin,
+          matchStatus: 'matched',
+          globalProductId,
+          product,
+          linkedHouseholdArticleId: householdArticleId,
+        },
+      }))
+
+      setBarcodeSaveConfirm(null)
+
+      showUitpakkenFeedback(
+        'success',
+        result?.catalog_product_created
+          ? 'Product opgenomen in de catalogus en bijgewerkt in Uitpakken.'
+          : 'Product bijgewerkt in Uitpakken.',
+        {
+          key: `barcode-save-success-${confirmation.lineId}-${Date.now()}`,
+        }
+      )
+    } catch (saveError) {
+      const message = normalizeErrorMessage(
+        saveError?.message || saveError
+      )
+      showUitpakkenFeedback(
+        'error',
+        message,
+        {
+          key: `barcode-save-error-${confirmation.lineId}-${Date.now()}`,
         }
       )
     } finally {
@@ -1914,6 +2057,55 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
               </div>
             )
           })() : null}
+
+          {barcodeSaveConfirm ? (
+            <div
+              className="rz-modal-backdrop"
+              role="presentation"
+              data-testid="receipt-line-barcode-save-confirm"
+            >
+              <div
+                className="rz-modal-card"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="barcode-save-confirm-title"
+              >
+                <h3
+                  id="barcode-save-confirm-title"
+                  className="rz-modal-title"
+                >
+                  Barcode opslaan
+                </h3>
+                <p className="rz-modal-text">
+                  De barcode is geldig.
+                </p>
+                <p className="rz-modal-text">
+                  Het product wordt bijgewerkt in Uitpakken en centraal
+                  opgenomen of bijgewerkt in de catalogus.
+                </p>
+                <div className="rz-modal-actions">
+                  <Button
+                    variant="secondary"
+                    type="button"
+                    disabled={Boolean(busyLineId)}
+                    onClick={() => setBarcodeSaveConfirm(null)}
+                    data-testid="receipt-line-barcode-save-cancel"
+                  >
+                    Annuleren
+                  </Button>
+                  <Button
+                    variant="primary"
+                    type="button"
+                    disabled={Boolean(busyLineId)}
+                    onClick={saveConfirmedReceiptLineBarcode}
+                    data-testid="receipt-line-barcode-save-confirm-button"
+                  >
+                    {busyLineId ? 'Opslaan…' : 'Opslaan'}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ) : null}
 
           {processConfirm ? (
             <div className="rz-modal-backdrop" role="presentation">

--- a/frontend/src/features/stores/StoreBatchDetailPage.jsx
+++ b/frontend/src/features/stores/StoreBatchDetailPage.jsx
@@ -309,7 +309,17 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
 
   function updateBarcodeDraft(lineId, value) {
     setBarcodeDrafts((current) => ({ ...current, [lineId]: value }))
-    setBarcodeStates((current) => ({ ...current, [lineId]: { status: 'idle', message: '' } }))
+    setBarcodeStates((current) => ({
+      ...current,
+      [lineId]: {
+        status: 'idle',
+        message: '',
+        gtin: '',
+        matchStatus: '',
+        productName: '',
+        globalProductId: '',
+      },
+    }))
   }
 
   async function validateReceiptLineBarcode(lineId, overrideValue = null) {
@@ -334,10 +344,34 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
       const lookup = await fetchJson(`/api/barcodes/${encodeURIComponent(validation.normalized_value || value)}`)
       const matchStatus = String(lookup?.match_status || '')
       if (matchStatus === 'matched') {
-        const productName = firstTextValue(lookup?.product?.name, 'bekend universeel artikel')
+        const productName = firstTextValue(
+          lookup?.product?.name,
+          'bekend universeel artikel'
+        )
+        const globalProductId = String(
+          lookup?.product?.global_product_id || ''
+        ).trim()
+        const normalizedGtin = String(
+          lookup?.gtin || validation.normalized_value || value
+        ).trim()
         const message = `Geldige GTIN. Gevonden: ${productName}.`
-        setBarcodeStates((current) => ({ ...current, [lineId]: { status: 'success', message, productName } }))
-        showUitpakkenFeedback('success', message, { key: `barcode-matched-${lineId}-${Date.now()}` })
+        setBarcodeStates((current) => ({
+          ...current,
+          [lineId]: {
+            status: 'success',
+            message,
+            productName,
+            gtin: normalizedGtin,
+            matchStatus,
+            globalProductId,
+            product: lookup?.product || null,
+          },
+        }))
+        showUitpakkenFeedback(
+          'success',
+          message,
+          { key: `barcode-matched-${lineId}-${Date.now()}` }
+        )
       } else if (matchStatus === 'conflict') {
         const message = 'Conflict: deze GTIN verwijst naar meerdere universele artikelen. Er is niets gewijzigd.'
         setBarcodeStates((current) => ({ ...current, [lineId]: { status: 'error', message } }))
@@ -355,6 +389,103 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
       const message = normalizeErrorMessage(lookupError?.message || lookupError)
       setBarcodeStates((current) => ({ ...current, [lineId]: { status: 'error', message } }))
       showUitpakkenFeedback('error', message, { key: `barcode-error-${lineId}-${Date.now()}` })
+    }
+  }
+
+  async function linkReceiptLineBarcode(line, draft) {
+    const lineId = String(line?.id || '')
+    const state = barcodeStates[lineId] || {}
+    const householdArticleId = String(
+      draft?.articleId || ''
+    ).trim()
+    const gtin = String(state.gtin || '').trim()
+    const globalProductId = String(
+      state.globalProductId || ''
+    ).trim()
+
+    if (!householdArticleId) {
+      showUitpakkenFeedback(
+        'warning',
+        'Kies eerst Mijn artikel.',
+        { key: `barcode-link-no-article-${lineId}` }
+      )
+      return
+    }
+
+    if (
+      state.matchStatus !== 'matched'
+      || !gtin
+      || !globalProductId
+    ) {
+      showUitpakkenFeedback(
+        'warning',
+        'Controleer eerst een bekende, complete GTIN.',
+        { key: `barcode-link-no-match-${lineId}` }
+      )
+      return
+    }
+
+    setBusyLineId(lineId)
+
+    try {
+      const result = await fetchJson(
+        `/api/barcodes/${encodeURIComponent(gtin)}/household-article-link`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            purchase_import_line_id: lineId,
+            household_article_id: householdArticleId,
+            global_product_id: globalProductId,
+          }),
+        }
+      )
+
+      await refreshBatch(batch.batch_id)
+
+      const message = result?.idempotent
+        ? 'Mijn artikel was al aan dit universele artikel gekoppeld.'
+        : 'Mijn artikel is aan het universele artikel gekoppeld.'
+
+      setBarcodeStates((current) => ({
+        ...current,
+        [lineId]: {
+          ...(current[lineId] || {}),
+          status: 'success',
+          message,
+          linkedHouseholdArticleId: householdArticleId,
+        },
+      }))
+
+      showUitpakkenFeedback(
+        'success',
+        message,
+        {
+          key: `barcode-link-success-${lineId}-${Date.now()}`,
+        }
+      )
+    } catch (linkError) {
+      const message = normalizeErrorMessage(
+        linkError?.message || linkError
+      )
+
+      setBarcodeStates((current) => ({
+        ...current,
+        [lineId]: {
+          ...(current[lineId] || {}),
+          status: 'error',
+          message,
+        },
+      }))
+
+      showUitpakkenFeedback(
+        'error',
+        message,
+        {
+          key: `barcode-link-error-${lineId}-${Date.now()}`,
+        }
+      )
+    } finally {
+      setBusyLineId('')
     }
   }
 
@@ -1425,10 +1556,27 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
             const { line, draft } = activeDetailEntry
             const lineBusy = busyLineId === line.id || isProcessingBatch
             const selectedLocationLabel = locationLabelForDraft(draft)
+            const barcodeState = barcodeStates[line.id] || {}
             const universalProductValue = firstTextValue(
-              barcodeStates[line.id]?.productName,
+              barcodeState.productName,
               standardProductLabel(line)
             )
+            const selectedHouseholdArticleId = String(
+              draft.articleId || ''
+            ).trim()
+            const alreadyLinked = Boolean(
+              selectedHouseholdArticleId
+              && String(
+                barcodeState.linkedHouseholdArticleId || ''
+              ) === selectedHouseholdArticleId
+            )
+            const canLinkBarcode = !lineBusy
+              && !isViewer
+              && barcodeState.matchStatus === 'matched'
+              && Boolean(barcodeState.gtin)
+              && Boolean(barcodeState.globalProductId)
+              && Boolean(selectedHouseholdArticleId)
+              && !alreadyLinked
             return (
               <div className="rz-modal-backdrop rz-receipt-line-detail-backdrop" role="presentation" onMouseDown={closeReceiptLineDetail} data-testid="receipt-line-detail-overlay">
                 <div className="rz-modal-card rz-receipt-line-detail-modal" role="dialog" aria-modal="true" aria-labelledby="receipt-line-detail-title" onMouseDown={(event) => event.stopPropagation()}>
@@ -1448,7 +1596,7 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
                   <div className="rz-receipt-line-detail__wide"><dt>Barcode / GTIN</dt><dd><BarcodeIdentityField lineId={line.id} value={barcodeDrafts[line.id] || ''} disabled={lineBusy} state={barcodeStates[line.id] || { status: 'idle', message: '' }} onChange={(nextValue) => updateBarcodeDraft(line.id, nextValue)} onValidate={() => validateReceiptLineBarcode(line.id)} onScan={() => openReceiptLineBarcodeScanner(line.id)} /></dd></div>
                   <div className="rz-receipt-line-detail__wide">
                     <dt>Universeel artikel</dt>
-                    <dd>
+                    <dd style={{ display: 'grid', gap: '10px' }}>
                       <input
                         className="rz-input rz-inline-input rz-receipt-line-detail__readonly-value"
                         value={universalProductValue}
@@ -1457,6 +1605,33 @@ export function StoreBatchDetailContent({ batchIdOverride = '', embedded = false
                         aria-label={`Universeel artikel voor bonregel ${line.id}`}
                         data-testid={`receipt-line-standard-product-${line.id}`}
                       />
+                      {barcodeState.matchStatus === 'matched' ? (
+                        <div
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '10px',
+                            flexWrap: 'wrap',
+                          }}
+                        >
+                          <Button
+                            type="button"
+                            variant="primary"
+                            disabled={!canLinkBarcode}
+                            onClick={() => linkReceiptLineBarcode(line, draft)}
+                            data-testid={`receipt-line-barcode-link-${line.id}`}
+                          >
+                            {lineBusy
+                              ? 'Koppelen…'
+                              : alreadyLinked
+                                ? 'Al gekoppeld'
+                                : 'Koppelen aan Mijn artikel'}
+                          </Button>
+                          {!selectedHouseholdArticleId ? (
+                            <span>Kies eerst Mijn artikel.</span>
+                          ) : null}
+                        </div>
+                      ) : null}
                     </dd>
                   </div>
                     </dl>

--- a/frontend/tests/e2e/external-databases-off.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases-off.frontend-regression.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+﻿import { test, expect } from '@playwright/test';
 import {
   attachConsoleErrorCollector,
   expectNoConsoleErrors,
@@ -177,7 +177,7 @@ test.describe('Externe databases OFF candidate flow', () => {
     await expectNoConsoleErrors(consoleErrors);
   });
 
-  test('Bananen worden automatisch geclassificeerd als officiële GPC Brick', async ({ page }) => {
+  test('Bananen worden automatisch geclassificeerd als officiÃ«le GPC Brick', async ({ page }) => {
     await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(receiptItemsPayload()) });
     });
@@ -193,12 +193,12 @@ test.describe('Externe databases OFF candidate flow', () => {
     const candidateRow = page.getByTestId('external-receipt-item-candidates-table').locator('tbody tr', { hasText: '8718265184886' });
     await candidateRow.getByRole('radio').check();
     await expect(page.getByLabel('Producttype')).toHaveValue('gpc:10005897');
-    await expect(page.getByLabel('Producttype').locator('option:checked')).toContainText('Bananen (Cavendish) — GPC 10005897');
-    await expect(page.getByTestId('external-producttype-classification-status')).toContainText('1,000');
+    await expect(page.getByLabel('Producttype').locator('option:checked')).toContainText('Bananen (Cavendish) â€” GPC 10005897');
+    await expect(page.getByTestId('external-producttype-classification-status')).toContainText('Producttype bepaald via expliciete GPC Brickcode.');
     await expect(page.getByRole('button', { name: 'Koppel artikel en Producttype', exact: true })).toBeEnabled();
   });
 
-  test('Langdurige OFF-zoekactie toont na één seconde de blokkerende R en verwijdert die direct na een fout', async ({ page }) => {
+  test('Langdurige OFF-zoekactie toont na Ã©Ã©n seconde de blokkerende R en verwijdert die direct na een fout', async ({ page }) => {
     const consoleErrors = attachConsoleErrorCollector(page);
     let releaseSearch;
     const searchGate = new Promise((resolve) => {

--- a/frontend/tests/e2e/external-databases-off.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases-off.frontend-regression.spec.js
@@ -177,7 +177,7 @@ test.describe('Externe databases OFF candidate flow', () => {
     await expectNoConsoleErrors(consoleErrors);
   });
 
-  test('Bananen worden automatisch geclassificeerd als officiÃ«le GPC Brick', async ({ page }) => {
+  test('Bananen worden automatisch geclassificeerd als officiële GPC Brick', async ({ page }) => {
     await page.route('**/api/external-databases/receipt-items?limit=500', async (route) => {
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(receiptItemsPayload()) });
     });
@@ -193,7 +193,7 @@ test.describe('Externe databases OFF candidate flow', () => {
     const candidateRow = page.getByTestId('external-receipt-item-candidates-table').locator('tbody tr', { hasText: '8718265184886' });
     await candidateRow.getByRole('radio').check();
     await expect(page.getByLabel('Producttype')).toHaveValue('gpc:10005897');
-    await expect(page.getByLabel('Producttype').locator('option:checked')).toContainText('Bananen (Cavendish) â€” GPC 10005897');
+    await expect(page.getByLabel('Producttype').locator('option:checked')).toContainText('Bananen (Cavendish) — GPC 10005897');
     await expect(page.getByTestId('external-producttype-classification-status')).toContainText('Producttype bepaald via expliciete GPC Brickcode.');
     await expect(page.getByRole('button', { name: 'Koppel artikel en Producttype', exact: true })).toBeEnabled();
   });

--- a/frontend/tests/e2e/external-databases-off.frontend-regression.spec.js
+++ b/frontend/tests/e2e/external-databases-off.frontend-regression.spec.js
@@ -193,7 +193,7 @@ test.describe('Externe databases OFF candidate flow', () => {
     const candidateRow = page.getByTestId('external-receipt-item-candidates-table').locator('tbody tr', { hasText: '8718265184886' });
     await candidateRow.getByRole('radio').check();
     await expect(page.getByLabel('Producttype')).toHaveValue('gpc:10005897');
-    await expect(page.getByLabel('Producttype').locator('option:checked')).toContainText('Bananen — GPC 10005897');
+    await expect(page.getByLabel('Producttype').locator('option:checked')).toContainText('Bananen (Cavendish) — GPC 10005897');
     await expect(page.getByTestId('external-producttype-classification-status')).toContainText('1,000');
     await expect(page.getByRole('button', { name: 'Koppel artikel en Producttype', exact: true })).toBeEnabled();
   });

--- a/frontend/tests/e2e/uitpakken.frontend-regression.spec.js
+++ b/frontend/tests/e2e/uitpakken.frontend-regression.spec.js
@@ -428,6 +428,27 @@ test.describe('Uitpakken frontend-regressie', () => {
       page.getByTestId(`receipt-line-barcode-status-${lineId}`)
     ).toHaveCount(0);
 
+    const successOverlay = page.getByTestId(
+      'app-feedback-success-overlay'
+    );
+
+    if (await successOverlay.count()) {
+      const feedbackButton = successOverlay.getByRole(
+        'button',
+        { name: /ok|sluiten/i }
+      );
+
+      if (await feedbackButton.count()) {
+        await feedbackButton.click();
+      } else {
+        await successOverlay.click({
+          position: { x: 5, y: 5 },
+        });
+      }
+
+      await expect(successOverlay).toHaveCount(0);
+    }
+
     await page.getByRole(
       'button',
       { name: 'Sluit bonartikeldetails' }

--- a/frontend/tests/e2e/uitpakken.frontend-regression.spec.js
+++ b/frontend/tests/e2e/uitpakken.frontend-regression.spec.js
@@ -1,4 +1,4 @@
-﻿import { test, expect } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import {
   attachConsoleErrorCollector,
   expectAnyVisible,
@@ -435,4 +435,3 @@ test.describe('Uitpakken frontend-regressie', () => {
   });
 
 });
-

--- a/frontend/tests/e2e/uitpakken.frontend-regression.spec.js
+++ b/frontend/tests/e2e/uitpakken.frontend-regression.spec.js
@@ -399,7 +399,7 @@ test.describe('Uitpakken frontend-regressie', () => {
 
     const confirm = page.getByTestId('receipt-line-barcode-save-confirm');
     await expect(confirm).toBeVisible();
-    await expect(confirm).toContainText('De barcode is geldig.');
+    await expect(confirm).toContainText('Dit is een geldige barcode.');
 
     await page.getByTestId('receipt-line-barcode-save-cancel').click();
     await expect(confirm).toHaveCount(0);

--- a/frontend/tests/e2e/uitpakken.frontend-regression.spec.js
+++ b/frontend/tests/e2e/uitpakken.frontend-regression.spec.js
@@ -322,6 +322,8 @@ test.describe('Uitpakken frontend-regressie', () => {
           matched_household_article_id: householdArticleId,
           matched_global_product_id: saved ? 'gp-mosterd' : null,
           matched_global_product_name: saved ? 'Mosterd Dijon' : null,
+          matched_global_product_gtin: saved ? gtin : null,
+          barcode: saved ? gtin : null,
         }],
       }),
     }));
@@ -420,8 +422,29 @@ test.describe('Uitpakken frontend-regressie', () => {
       page.getByTestId(`receipt-line-standard-product-${lineId}`)
     ).toHaveValue('Mosterd Dijon');
     await expect(
+      page.getByTestId(`receipt-line-barcode-input-${lineId}`)
+    ).toHaveValue(gtin);
+    await expect(
       page.getByTestId(`receipt-line-barcode-status-${lineId}`)
     ).toHaveCount(0);
+
+    await page.getByRole(
+      'button',
+      { name: 'Sluit bonartikeldetails' }
+    ).click();
+
+    await expect(
+      page.getByTestId('receipt-line-detail-overlay')
+    ).toHaveCount(0);
+
+    await page.getByTestId(`receipt-line-${lineId}`)
+      .locator('td')
+      .nth(1)
+      .dblclick();
+
+    await expect(
+      page.getByTestId(`receipt-line-barcode-input-${lineId}`)
+    ).toHaveValue(gtin);
 
     expect(
       mutationRequests.some(

--- a/frontend/tests/e2e/uitpakken.frontend-regression.spec.js
+++ b/frontend/tests/e2e/uitpakken.frontend-regression.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+﻿import { test, expect } from '@playwright/test';
 import {
   attachConsoleErrorCollector,
   expectAnyVisible,
@@ -241,7 +241,7 @@ test.describe('Uitpakken frontend-regressie', () => {
     page.on('request', (request) => {
       const url = request.url();
       if (
-        /inventory|purchase|external-product-links|household-articles/.test(url)
+        /inventory|purchase|external-product-links|household-articles|save-household-article/.test(url)
         && request.method() !== 'GET'
       ) {
         mutationRequests.push(`${request.method()} ${url}`);
@@ -435,3 +435,4 @@ test.describe('Uitpakken frontend-regressie', () => {
   });
 
 });
+

--- a/frontend/tests/e2e/uitpakken.frontend-regression.spec.js
+++ b/frontend/tests/e2e/uitpakken.frontend-regression.spec.js
@@ -229,31 +229,80 @@ test.describe('Uitpakken frontend-regressie', () => {
     await expectNoConsoleErrors(consoleErrors);
   });
 
-  test('Barcodecontrole in Uitpakken is centraal en read-only', async ({ page }) => {
+  test('Geldige GTIN wordt na bevestiging centraal opgeslagen en lokaal gekoppeld', async ({ page }) => {
     const consoleErrors = attachConsoleErrorCollector(page);
-    const batchId = 'barcode-readonly-regression';
+    const batchId = 'barcode-save-regression';
     const lineId = 'line-barcode-mosterd';
     const gtin = '8712345678906';
+    const householdArticleId = 'household-article-mosterd';
     const mutationRequests = [];
+    let saved = false;
 
     page.on('request', (request) => {
       const url = request.url();
-      if (/inventory|purchase|external-product-links|household-articles/.test(url) && request.method() !== 'GET') {
+      if (
+        /inventory|purchase|external-product-links|household-articles/.test(url)
+        && request.method() !== 'GET'
+      ) {
         mutationRequests.push(`${request.method()} ${url}`);
       }
     });
 
-    await page.route('**/api/household', async (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ id: '1', is_viewer: false, permissions: { 'article.create': true }, store_import_simplification_level: 'gebalanceerd' }) }));
-    await page.route('**/api/store-providers', async (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{ code: 'lidl', name: 'Lidl' }]) }));
-    await page.route('**/api/store-review-articles', async (route) => route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }));
-    await page.route('**/api/spaces*', async (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ items: [] }) }));
-    await page.route('**/api/sublocations*', async (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ items: [] }) }));
+    await page.route('**/api/household', async (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: '1',
+        is_viewer: false,
+        permissions: { 'article.create': true },
+        store_import_simplification_level: 'gebalanceerd',
+      }),
+    }));
+
+    await page.route('**/api/store-providers', async (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{ code: 'lidl', name: 'Lidl' }]),
+    }));
+
+    await page.route('**/api/store-review-articles', async (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{
+        id: householdArticleId,
+        naam: 'Mosterd',
+        custom_name: 'Mosterd',
+      }]),
+    }));
+
+    await page.route('**/api/spaces*', async (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [] }),
+    }));
+
+    await page.route('**/api/sublocations*', async (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [] }),
+    }));
+
     await page.route('**/api/unpack-start-batches*', async (route) => route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ items: [{ batch_id: batchId, store_provider_code: 'lidl', store_label: 'Lidl', purchase_date: '2026-07-25', inbox_status: 'Gecontroleerd', summary: { total: 1 } }] }),
+      body: JSON.stringify({
+        items: [{
+          batch_id: batchId,
+          store_provider_code: 'lidl',
+          store_label: 'Lidl',
+          purchase_date: '2026-07-25',
+          inbox_status: 'Gecontroleerd',
+          summary: { total: 1 },
+        }],
+      }),
     }));
-    await page.route(`**/api/purchase-import-batches/${batchId}`, async (route) => route.fulfill({
+
+    await page.route(`**/api/purchase-import-batches/${batchId}*`, async (route) => route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({
@@ -262,32 +311,126 @@ test.describe('Uitpakken frontend-regressie', () => {
         store_label: 'Lidl',
         purchase_date: '2026-07-25',
         import_status: 'review',
-        lines: [{ id: lineId, article_name_raw: 'MOSTERD 250G', quantity_raw: 1, unit_raw: 'stuk', processing_status: 'pending', review_decision: 'pending', match_status: 'unmatched' }],
+        lines: [{
+          id: lineId,
+          article_name_raw: 'MOSTERD 250G',
+          quantity_raw: 1,
+          unit_raw: 'stuk',
+          processing_status: 'pending',
+          review_decision: 'pending',
+          match_status: saved ? 'matched' : 'unmatched',
+          matched_household_article_id: householdArticleId,
+          matched_global_product_id: saved ? 'gp-mosterd' : null,
+          matched_global_product_name: saved ? 'Mosterd Dijon' : null,
+        }],
       }),
     }));
+
     await page.route('**/api/barcodes/validate', async (route) => {
       expect(route.request().method()).toBe('POST');
-      expect(await route.request().postDataJSON()).toEqual({ value: gtin, declared_type: 'gtin' });
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ valid: true, normalized_value: gtin, declared_type: 'gtin', mutated: false }) });
+      expect(await route.request().postDataJSON()).toEqual({
+        value: gtin,
+        declared_type: 'gtin',
+      });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          valid: true,
+          normalized_value: gtin,
+          declared_type: 'gtin',
+          mutated: false,
+        }),
+      });
     });
+
     await page.route(`**/api/barcodes/${gtin}`, async (route) => route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ valid: true, gtin, match_status: 'matched', product: { global_product_id: 'gp-mosterd', name: 'Mosterd Dijon', primary_gtin: gtin }, identity: { identity_type: 'gtin', identity_value: gtin }, product_type: { official: true, active: true }, mutated: false }),
+      body: JSON.stringify({
+        valid: true,
+        gtin,
+        match_status: 'not_found',
+        product: null,
+        identity: null,
+        product_type: null,
+        mutated: false,
+      }),
     }));
+
+    await page.route(
+      `**/api/barcodes/${gtin}/save-household-article`,
+      async (route) => {
+        expect(route.request().method()).toBe('POST');
+        expect(await route.request().postDataJSON()).toEqual({
+          purchase_import_line_id: lineId,
+          household_article_id: householdArticleId,
+          article_name: 'MOSTERD 250G',
+        });
+
+        saved = true;
+
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            ok: true,
+            gtin,
+            catalog_product_created: true,
+            product: {
+              global_product_id: 'gp-mosterd',
+              name: 'Mosterd Dijon',
+              primary_gtin: gtin,
+              status: 'active',
+            },
+            purchase_import_line_id: lineId,
+            household_article_id: householdArticleId,
+            inventory_mutated: false,
+          }),
+        });
+      }
+    );
 
     await page.goto(`/kassabonnen?batch=${batchId}`);
     await page.getByTestId(`receipt-line-${lineId}`).locator('td').nth(1).dblclick();
-    await expect(page).toHaveURL(new RegExp(`/kassabonnen\\?batch=${batchId}$`));
-    await expect(page.getByTestId('receipt-line-detail-overlay')).toBeVisible();
-    await expect(page.getByTestId('receipt-line-detail-panel')).toContainText('Bonartikel details');
-    await expect(page.getByRole('button', { name: 'Terug naar Uitpakken' })).toHaveCount(0);
-    await expect(page.getByText('Barcodecontrole is alleen ter identificatie.')).toHaveCount(0);
+
     await page.getByTestId(`receipt-line-barcode-input-${lineId}`).fill(gtin);
     await page.getByTestId(`receipt-line-barcode-check-${lineId}`).click();
-    await expect(page.getByTestId('app-feedback-success')).toContainText('Geldige GTIN. Gevonden: Mosterd Dijon.');
-    await expect(page.getByTestId(`receipt-line-standard-product-${lineId}`)).toHaveValue('Mosterd Dijon');
+
+    const confirm = page.getByTestId('receipt-line-barcode-save-confirm');
+    await expect(confirm).toBeVisible();
+    await expect(confirm).toContainText('De barcode is geldig.');
+
+    await page.getByTestId('receipt-line-barcode-save-cancel').click();
+    await expect(confirm).toHaveCount(0);
     expect(mutationRequests).toEqual([]);
+
+    await page.getByTestId(`receipt-line-barcode-check-${lineId}`).click();
+    await expect(confirm).toBeVisible();
+    await page.getByTestId('receipt-line-barcode-save-confirm-button').click();
+
+    await expect(confirm).toHaveCount(0);
+    await expect(page.getByTestId('app-feedback-success')).toContainText(
+      'Product opgenomen in de catalogus en bijgewerkt in Uitpakken.'
+    );
+    await expect(
+      page.getByTestId(`receipt-line-standard-product-${lineId}`)
+    ).toHaveValue('Mosterd Dijon');
+
+    expect(
+      mutationRequests.some(
+        (request) => request.includes(
+          `/api/barcodes/${gtin}/save-household-article`
+        )
+      )
+    ).toBe(true);
+
+    expect(
+      mutationRequests.some(
+        (request) => /inventory/.test(request)
+      )
+    ).toBe(false);
+
     await expectNoConsoleErrors(consoleErrors);
   });
 

--- a/frontend/tests/e2e/uitpakken.frontend-regression.spec.js
+++ b/frontend/tests/e2e/uitpakken.frontend-regression.spec.js
@@ -400,6 +400,9 @@ test.describe('Uitpakken frontend-regressie', () => {
     const confirm = page.getByTestId('receipt-line-barcode-save-confirm');
     await expect(confirm).toBeVisible();
     await expect(confirm).toContainText('Dit is een geldige barcode.');
+    await expect(
+      page.getByTestId(`receipt-line-barcode-status-${lineId}`)
+    ).toHaveCount(0);
 
     await page.getByTestId('receipt-line-barcode-save-cancel').click();
     await expect(confirm).toHaveCount(0);
@@ -416,6 +419,9 @@ test.describe('Uitpakken frontend-regressie', () => {
     await expect(
       page.getByTestId(`receipt-line-standard-product-${lineId}`)
     ).toHaveValue('Mosterd Dijon');
+    await expect(
+      page.getByTestId(`receipt-line-barcode-status-${lineId}`)
+    ).toHaveCount(0);
 
     expect(
       mutationRequests.some(


### PR DESCRIPTION
## Doel

Voegt de expliciete barcode- en GTIN-koppeling toe vanuit Uitpakken en zorgt dat bestaande Cataloguskoppelingen direct zichtbaar zijn in Externe databases, zonder eerst een regel te hoeven openen.

## Functionaliteit

- geldige GTIN wordt expliciet bevestigd via de bestaande popup;
- opslaan koppelt het centrale product en de GTIN aan het gekozen Mijn artikel binnen het actieve huishouden;
- geen voorraadmutatie of inventory event;
- bestaande centrale koppelingen worden direct geprojecteerd in Externe databases;
- dubbele bonregels worden samengevoegd zonder verlies van de gekoppelde Catalogusgegevens;
- gekoppelde bonartikelen krijgen voorrang binnen de eerste zichtbare selectie;
- bevestigde GTIN zonder betrouwbaar officieel GS1-GPC-producttype blijft zichtbaar als nog te classificeren;
- geen artikelgroep naar Producttype gekopieerd;
- geen artikel- of GTIN-specifieke waarden in productiecode.

## Architectuur

- Artikelgroep blijft huishoudspecifiek;
- Producttype blijft uitsluitend officiële GS1-GPC-classificatie;
- onzekere classificaties worden niet ingevuld;
- GET-routes voeren geen verborgen herstelmutaties uit;
- geen voorraadmutatie door koppelen, projecteren of lezen.

## Belangrijkste commits

- `6af73b43` — volledige GTIN-keten en Nederlandse catalogusweergave;
- `690b771d` — generieke GTIN-naar-Producttype-keten;
- `296cfec1` — herstel UTF-8 regressieverwachting;
- `379a8998` — behoud Cataloguskoppeling bij dubbele bonregels;
- `04d272fb` — prioriteer gekoppelde bonartikelen in Externe databases.

## Validatie

- functionele PO-controle positief: bestaande Cataloguskoppeling, kandidaatartikel en GTIN zijn direct zichtbaar zonder dubbelklik;
- werkelijke initiële projectie: groen;
- backend vóór regressie: gezond;
- centrale frontendregressie: **26/26 groen**;
- backend na regressie: gezond;
- repository schoon;
- branch en origin gelijk op `04d272fb`.

## Nog niet uitvoeren

Deze pull request mag niet automatisch worden gemerged. Merge naar `main` volgt uitsluitend na aparte expliciete Product Owner-GO.