### PR TITLE
Add GS1 GPC catalog import foundation

### DIFF
--- a/.github/workflows/gpc-catalog-validation.yml
+++ b/.github/workflows/gpc-catalog-validation.yml
@@ -1,0 +1,104 @@
+name: GPC catalog validation
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/services/gpc_catalog_service.py"
+      - "backend/app/cli/import_gpc_catalog.py"
+      - "backend/tests/test_gpc_catalog_service.py"
+      - ".github/workflows/gpc-catalog-validation.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-gpc-catalog:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install minimal dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install sqlalchemy==2.0.36 pytest
+
+      - name: Compile GPC modules
+        run: |
+          python -m py_compile app/services/gpc_catalog_service.py
+          python -m py_compile app/cli/import_gpc_catalog.py
+          python -m py_compile tests/test_gpc_catalog_service.py
+
+      - name: Run focused GPC tests
+        run: pytest -q tests/test_gpc_catalog_service.py
+
+      - name: Run isolated CLI import
+        env:
+          DATABASE_URL: sqlite:////tmp/rezzerv-gpc-validation.db
+        run: |
+          mkdir -p /tmp/gpc-validation
+          cat > /tmp/gpc-validation/nl-v-ci.xml <<'XML'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <schema>
+            <segment code="50000000" text="Voedingsmiddelen/Dranken/Tabak">
+              <family code="50100000" text="Groenten/Noten/Zaden">
+                <class code="50101700" text="Groenten - Onbewerkt">
+                  <brick code="10006144" text="Mosterdblad">
+                    <attType code="20000794" text="Teeltmethode">
+                      <attValue code="30002654" text="Conventioneel" />
+                    </attType>
+                  </brick>
+                </class>
+              </family>
+            </segment>
+          </schema>
+          XML
+          python -m app.cli.import_gpc_catalog /tmp/gpc-validation/nl-v-ci.xml --language nl --source-version ci > /tmp/gpc-validation/import-result.json
+
+      - name: Verify isolated database and audit record
+        run: |
+          python - <<'PY'
+          import json
+          import sqlite3
+          from pathlib import Path
+
+          db_path = Path('/tmp/rezzerv-gpc-validation.db')
+          result_path = Path('/tmp/gpc-validation/import-result.json')
+          assert db_path.is_file(), 'Geïsoleerde Rezzerv-testdatabase ontbreekt'
+          result = json.loads(result_path.read_text(encoding='utf-8'))
+          assert result['status'] == 'success'
+          assert result['datastore']['datastore'] == 'sqlite'
+          assert result['import']['language_code'] == 'nl'
+          assert result['import']['counts']['bricks'] == 1
+
+          with sqlite3.connect(db_path) as conn:
+              brick = conn.execute(
+                  "SELECT description, class_code FROM gpc_bricks WHERE brick_code = ?",
+                  ('10006144',),
+              ).fetchone()
+              audit = conn.execute(
+                  "SELECT language_code, source_version, status FROM gpc_import_runs ORDER BY id DESC LIMIT 1"
+              ).fetchone()
+
+          assert brick == ('Mosterdblad', '50101700')
+          assert audit == ('nl', 'ci', 'success')
+          PY
+
+      - name: Upload validation evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: gpc-catalog-validation-evidence
+          path: |
+            /tmp/gpc-validation/import-result.json
+            /tmp/rezzerv-gpc-validation.db
+          if-no-files-found: error

--- a/.github/workflows/gpc-catalog-validation.yml
+++ b/.github/workflows/gpc-catalog-validation.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
 
+# Keep this validation isolated from the runtime database.
 jobs:
   validate-gpc-catalog:
     runs-on: ubuntu-latest

--- a/.github/workflows/gpc-catalog-validation.yml
+++ b/.github/workflows/gpc-catalog-validation.yml
@@ -20,6 +20,7 @@ jobs:
         working-directory: backend
     env:
       PYTHONPATH: .
+      DATABASE_URL: sqlite:////tmp/rezzerv-gpc-pytest.db
 
     steps:
       - name: Checkout

--- a/.github/workflows/gpc-catalog-validation.yml
+++ b/.github/workflows/gpc-catalog-validation.yml
@@ -18,6 +18,8 @@ jobs:
     defaults:
       run:
         working-directory: backend
+    env:
+      PYTHONPATH: .
 
     steps:
       - name: Checkout
@@ -40,7 +42,7 @@ jobs:
           python -m py_compile tests/test_gpc_catalog_service.py
 
       - name: Run focused GPC tests
-        run: pytest -q tests/test_gpc_catalog_service.py
+        run: python -m pytest -q tests/test_gpc_catalog_service.py
 
       - name: Run isolated CLI import
         env:

--- a/backend/app/cli/__init__.py
+++ b/backend/app/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Operational command-line tools shipped with the Rezzerv backend."""

--- a/backend/app/cli/import_gpc_catalog.py
+++ b/backend/app/cli/import_gpc_catalog.py
@@ -1,0 +1,64 @@
+"""Import a caller-supplied GS1 GPC XML file into the Rezzerv database.
+
+Example from the backend container or backend working directory:
+    python -m app.cli.import_gpc_catalog /app/data/gpc/nl-v20241202.xml \
+        --language nl --source-version 20241202
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from app.db import get_runtime_datastore_info
+from app.services.gpc_catalog_service import import_gpc_xml
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Importeer een GS1 GPC XML-bestand in de actieve Rezzerv-database."
+    )
+    parser.add_argument("xml_file", help="Pad naar het lokaal beschikbare GPC XML-bestand")
+    parser.add_argument("--language", default="nl", help="Taalcode van het bestand (standaard: nl)")
+    parser.add_argument("--source-version", default=None, help="GS1 GPC bronversie, bijvoorbeeld 20241202")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        result = import_gpc_xml(
+            args.xml_file,
+            language_code=args.language,
+            source_version=args.source_version,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        print(json.dumps({"status": "failed", "detail": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 2
+    except Exception as exc:  # pragma: no cover - operational safety net
+        print(
+            json.dumps(
+                {"status": "failed", "detail": f"Onverwachte importfout: {exc}"},
+                ensure_ascii=False,
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "status": "success",
+                "datastore": get_runtime_datastore_info(),
+                "import": result,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/services/gpc_catalog_service.py
+++ b/backend/app/services/gpc_catalog_service.py
@@ -1,0 +1,322 @@
+"""GS1 GPC reference catalog schema and XML importer.
+
+This module intentionally imports only from a caller-supplied XML file. Normal
+Rezzerv runtime use therefore has no dependency on GS1 availability and keeps
+using the single configured Rezzerv database.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import hashlib
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+from sqlalchemy import Engine, inspect, text
+
+from app.db import engine as runtime_engine
+
+
+_SCHEMA_STATEMENTS = (
+    """
+    CREATE TABLE IF NOT EXISTS gpc_segments (
+        segment_code VARCHAR(8) PRIMARY KEY,
+        description TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS gpc_families (
+        family_code VARCHAR(8) PRIMARY KEY,
+        description TEXT NOT NULL,
+        segment_code VARCHAR(8) NOT NULL,
+        FOREIGN KEY (segment_code) REFERENCES gpc_segments(segment_code)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS gpc_classes (
+        class_code VARCHAR(8) PRIMARY KEY,
+        description TEXT NOT NULL,
+        family_code VARCHAR(8) NOT NULL,
+        FOREIGN KEY (family_code) REFERENCES gpc_families(family_code)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS gpc_bricks (
+        brick_code VARCHAR(8) PRIMARY KEY,
+        description TEXT NOT NULL,
+        class_code VARCHAR(8) NOT NULL,
+        FOREIGN KEY (class_code) REFERENCES gpc_classes(class_code)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS gpc_attribute_types (
+        att_type_code VARCHAR(8) PRIMARY KEY,
+        att_type_text TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS gpc_attribute_values (
+        att_value_code VARCHAR(8) PRIMARY KEY,
+        att_value_text TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS gpc_brick_attribute_types (
+        brick_code VARCHAR(8) NOT NULL,
+        att_type_code VARCHAR(8) NOT NULL,
+        PRIMARY KEY (brick_code, att_type_code),
+        FOREIGN KEY (brick_code) REFERENCES gpc_bricks(brick_code),
+        FOREIGN KEY (att_type_code) REFERENCES gpc_attribute_types(att_type_code)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS gpc_attribute_type_values (
+        att_type_code VARCHAR(8) NOT NULL,
+        att_value_code VARCHAR(8) NOT NULL,
+        PRIMARY KEY (att_type_code, att_value_code),
+        FOREIGN KEY (att_type_code) REFERENCES gpc_attribute_types(att_type_code),
+        FOREIGN KEY (att_value_code) REFERENCES gpc_attribute_values(att_value_code)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS gpc_import_runs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        source_name TEXT NOT NULL,
+        source_version TEXT,
+        language_code VARCHAR(12) NOT NULL,
+        source_sha256 VARCHAR(64) NOT NULL,
+        imported_at TEXT NOT NULL,
+        status VARCHAR(20) NOT NULL,
+        counts_json TEXT NOT NULL,
+        message TEXT
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_gpc_families_segment ON gpc_families(segment_code)",
+    "CREATE INDEX IF NOT EXISTS idx_gpc_classes_family ON gpc_classes(family_code)",
+    "CREATE INDEX IF NOT EXISTS idx_gpc_bricks_class ON gpc_bricks(class_code)",
+)
+
+
+@dataclass
+class GpcImportCounts:
+    segments: int = 0
+    families: int = 0
+    classes: int = 0
+    bricks: int = 0
+    attribute_types: int = 0
+    attribute_values: int = 0
+    brick_attribute_types: int = 0
+    attribute_type_values: int = 0
+
+
+def ensure_gpc_catalog_schema(db_engine: Engine = runtime_engine) -> None:
+    """Create the GPC reference tables idempotently in the Rezzerv database."""
+    with db_engine.begin() as conn:
+        if db_engine.dialect.name == "sqlite":
+            conn.execute(text("PRAGMA foreign_keys = ON"))
+        for statement in _SCHEMA_STATEMENTS:
+            conn.execute(text(statement))
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _children(parent: ET.Element, name: str):
+    return (child for child in list(parent) if _local_name(child.tag) == name)
+
+
+def _upsert(conn, table: str, key_name: str, key_value: str, values: dict) -> None:
+    existing = conn.execute(
+        text(f"SELECT {key_name} FROM {table} WHERE {key_name} = :key_value"),
+        {"key_value": key_value},
+    ).first()
+    payload = {key_name: key_value, **values}
+    if existing:
+        assignments = ", ".join(f"{name} = :{name}" for name in values)
+        conn.execute(
+            text(f"UPDATE {table} SET {assignments} WHERE {key_name} = :{key_name}"),
+            payload,
+        )
+    else:
+        columns = ", ".join(payload)
+        parameters = ", ".join(f":{name}" for name in payload)
+        conn.execute(text(f"INSERT INTO {table} ({columns}) VALUES ({parameters})"), payload)
+
+
+def _link(conn, table: str, first_name: str, first_value: str, second_name: str, second_value: str) -> bool:
+    existing = conn.execute(
+        text(
+            f"SELECT 1 FROM {table} WHERE {first_name} = :first_value "
+            f"AND {second_name} = :second_value"
+        ),
+        {"first_value": first_value, "second_value": second_value},
+    ).first()
+    if existing:
+        return False
+    conn.execute(
+        text(
+            f"INSERT INTO {table} ({first_name}, {second_name}) "
+            f"VALUES (:first_value, :second_value)"
+        ),
+        {"first_value": first_value, "second_value": second_value},
+    )
+    return True
+
+
+def import_gpc_xml(
+    xml_path: str | Path,
+    *,
+    language_code: str = "nl",
+    source_version: str | None = None,
+    db_engine: Engine = runtime_engine,
+) -> dict:
+    """Atomically import one GS1 GPC XML file into the Rezzerv database."""
+    path = Path(xml_path)
+    if not path.is_file():
+        raise FileNotFoundError(f"GPC XML-bestand niet gevonden: {path}")
+
+    xml_bytes = path.read_bytes()
+    source_sha256 = hashlib.sha256(xml_bytes).hexdigest()
+    root = ET.fromstring(xml_bytes)
+    if _local_name(root.tag) != "schema":
+        raise ValueError("Ongeldig GPC XML-bestand: root-element moet <schema> zijn")
+
+    ensure_gpc_catalog_schema(db_engine)
+    counts = GpcImportCounts()
+    imported_at = datetime.now(timezone.utc).isoformat()
+
+    with db_engine.begin() as conn:
+        if db_engine.dialect.name == "sqlite":
+            conn.execute(text("PRAGMA foreign_keys = ON"))
+
+        for segment in _children(root, "segment"):
+            segment_code = (segment.get("code") or "").strip()
+            description = (segment.get("text") or "").strip()
+            if not segment_code or not description:
+                raise ValueError("GPC segment zonder code of omschrijving")
+            _upsert(conn, "gpc_segments", "segment_code", segment_code, {"description": description})
+            counts.segments += 1
+
+            for family in _children(segment, "family"):
+                family_code = (family.get("code") or "").strip()
+                family_text = (family.get("text") or "").strip()
+                if not family_code or not family_text:
+                    raise ValueError("GPC family zonder code of omschrijving")
+                _upsert(
+                    conn,
+                    "gpc_families",
+                    "family_code",
+                    family_code,
+                    {"description": family_text, "segment_code": segment_code},
+                )
+                counts.families += 1
+
+                for class_element in _children(family, "class"):
+                    class_code = (class_element.get("code") or "").strip()
+                    class_text = (class_element.get("text") or "").strip()
+                    if not class_code or not class_text:
+                        raise ValueError("GPC class zonder code of omschrijving")
+                    _upsert(
+                        conn,
+                        "gpc_classes",
+                        "class_code",
+                        class_code,
+                        {"description": class_text, "family_code": family_code},
+                    )
+                    counts.classes += 1
+
+                    for brick in _children(class_element, "brick"):
+                        brick_code = (brick.get("code") or "").strip()
+                        brick_text = (brick.get("text") or "").strip()
+                        if not brick_code or not brick_text:
+                            raise ValueError("GPC brick zonder code of omschrijving")
+                        _upsert(
+                            conn,
+                            "gpc_bricks",
+                            "brick_code",
+                            brick_code,
+                            {"description": brick_text, "class_code": class_code},
+                        )
+                        counts.bricks += 1
+
+                        for attribute_type in _children(brick, "attType"):
+                            type_code = (attribute_type.get("code") or "").strip()
+                            type_text = (attribute_type.get("text") or "").strip()
+                            if not type_code or not type_text:
+                                raise ValueError("GPC attribuuttype zonder code of omschrijving")
+                            _upsert(
+                                conn,
+                                "gpc_attribute_types",
+                                "att_type_code",
+                                type_code,
+                                {"att_type_text": type_text},
+                            )
+                            counts.attribute_types += 1
+                            if _link(
+                                conn,
+                                "gpc_brick_attribute_types",
+                                "brick_code",
+                                brick_code,
+                                "att_type_code",
+                                type_code,
+                            ):
+                                counts.brick_attribute_types += 1
+
+                            for attribute_value in _children(attribute_type, "attValue"):
+                                value_code = (attribute_value.get("code") or "").strip()
+                                value_text = (attribute_value.get("text") or "").strip()
+                                if not value_code or not value_text:
+                                    raise ValueError("GPC attribuutwaarde zonder code of omschrijving")
+                                _upsert(
+                                    conn,
+                                    "gpc_attribute_values",
+                                    "att_value_code",
+                                    value_code,
+                                    {"att_value_text": value_text},
+                                )
+                                counts.attribute_values += 1
+                                if _link(
+                                    conn,
+                                    "gpc_attribute_type_values",
+                                    "att_type_code",
+                                    type_code,
+                                    "att_value_code",
+                                    value_code,
+                                ):
+                                    counts.attribute_type_values += 1
+
+        import json
+
+        conn.execute(
+            text(
+                """
+                INSERT INTO gpc_import_runs (
+                    source_name, source_version, language_code, source_sha256,
+                    imported_at, status, counts_json, message
+                ) VALUES (
+                    :source_name, :source_version, :language_code, :source_sha256,
+                    :imported_at, 'success', :counts_json, NULL
+                )
+                """
+            ),
+            {
+                "source_name": path.name,
+                "source_version": source_version,
+                "language_code": language_code.strip().lower() or "nl",
+                "source_sha256": source_sha256,
+                "imported_at": imported_at,
+                "counts_json": json.dumps(asdict(counts), sort_keys=True),
+            },
+        )
+
+    return {
+        "source_name": path.name,
+        "source_version": source_version,
+        "language_code": language_code.strip().lower() or "nl",
+        "source_sha256": source_sha256,
+        "imported_at": imported_at,
+        "counts": asdict(counts),
+        "tables": sorted(name for name in inspect(db_engine).get_table_names() if name.startswith("gpc_")),
+    }

--- a/backend/tests/test_gpc_catalog_service.py
+++ b/backend/tests/test_gpc_catalog_service.py
@@ -1,0 +1,113 @@
+from pathlib import Path
+
+from sqlalchemy import create_engine, inspect, text
+
+from app.services.gpc_catalog_service import import_gpc_xml
+
+
+SAMPLE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<schema>
+  <segment code="50000000" text="Food/Beverage/Tobacco">
+    <family code="50100000" text="Fruits/Vegetables/Nuts/Seeds">
+      <class code="50101700" text="Vegetables - Unprepared/Unprocessed">
+        <brick code="10006144" text="Mustard Greens">
+          <attType code="20000794" text="Growing Method">
+            <attValue code="30002654" text="Conventional" />
+          </attType>
+        </brick>
+      </class>
+    </family>
+  </segment>
+</schema>
+"""
+
+
+def test_import_gpc_xml_creates_hierarchy_and_audit(tmp_path: Path):
+    database_path = tmp_path / "rezzerv.db"
+    xml_path = tmp_path / "nl-v-test.xml"
+    xml_path.write_text(SAMPLE_XML, encoding="utf-8")
+    engine = create_engine(f"sqlite:///{database_path}")
+
+    result = import_gpc_xml(
+        xml_path,
+        language_code="nl",
+        source_version="test",
+        db_engine=engine,
+    )
+
+    assert result["counts"] == {
+        "segments": 1,
+        "families": 1,
+        "classes": 1,
+        "bricks": 1,
+        "attribute_types": 1,
+        "attribute_values": 1,
+        "brick_attribute_types": 1,
+        "attribute_type_values": 1,
+    }
+    assert set(result["tables"]) >= {
+        "gpc_segments",
+        "gpc_families",
+        "gpc_classes",
+        "gpc_bricks",
+        "gpc_attribute_types",
+        "gpc_attribute_values",
+        "gpc_brick_attribute_types",
+        "gpc_attribute_type_values",
+        "gpc_import_runs",
+    }
+
+    with engine.begin() as conn:
+        brick = conn.execute(
+            text("SELECT brick_code, description, class_code FROM gpc_bricks")
+        ).mappings().one()
+        audit = conn.execute(
+            text("SELECT language_code, source_version, status FROM gpc_import_runs")
+        ).mappings().one()
+
+    assert dict(brick) == {
+        "brick_code": "10006144",
+        "description": "Mustard Greens",
+        "class_code": "50101700",
+    }
+    assert dict(audit) == {
+        "language_code": "nl",
+        "source_version": "test",
+        "status": "success",
+    }
+
+
+def test_reimport_updates_descriptions_without_duplicates(tmp_path: Path):
+    xml_path = tmp_path / "nl-v-test.xml"
+    xml_path.write_text(SAMPLE_XML, encoding="utf-8")
+    engine = create_engine("sqlite:///:memory:")
+
+    import_gpc_xml(xml_path, db_engine=engine)
+    xml_path.write_text(SAMPLE_XML.replace("Mustard Greens", "Mosterdblad"), encoding="utf-8")
+    import_gpc_xml(xml_path, db_engine=engine)
+
+    with engine.begin() as conn:
+        brick_count = conn.execute(text("SELECT COUNT(*) FROM gpc_bricks")).scalar_one()
+        description = conn.execute(
+            text("SELECT description FROM gpc_bricks WHERE brick_code = '10006144'")
+        ).scalar_one()
+        import_count = conn.execute(text("SELECT COUNT(*) FROM gpc_import_runs")).scalar_one()
+
+    assert brick_count == 1
+    assert description == "Mosterdblad"
+    assert import_count == 2
+
+
+def test_invalid_root_is_rejected_before_schema_creation(tmp_path: Path):
+    xml_path = tmp_path / "invalid.xml"
+    xml_path.write_text("<not-schema />", encoding="utf-8")
+    engine = create_engine("sqlite:///:memory:")
+
+    try:
+        import_gpc_xml(xml_path, db_engine=engine)
+    except ValueError as exc:
+        assert "root-element" in str(exc)
+    else:
+        raise AssertionError("ValueError expected")
+
+    assert not any(name.startswith("gpc_") for name in inspect(engine).get_table_names())


### PR DESCRIPTION
## Doel

Voegt uitsluitend de infrastructuurbasis toe voor het gecontroleerd importeren van GS1 GPC-referentiegegevens in de bestaande Rezzerv-runtime-database.

## Gewijzigd

- idempotent GPC-referentieschema voor Segment, Familie, Klasse, Brick, attributen en attribuutwaarden
- importregistratie met taal, bronversie, SHA-256, datum en aantallen
- transactionele XML-import vanuit een expliciet lokaal bestand
- operationele opdracht `python -m app.cli.import_gpc_catalog ...`
- regressietests voor hiërarchie, herimport/upsert en ongeldige XML
- gerichte GitHub Actions-gate voor compilatie, pytest, CLI-import, databasecontrole en bewijsartefact

## Niet gewijzigd

- actiebutton of scherm Catalogus
- frontend
- login
- kassabonverwerking
- voorraad en inventory events
- bestaande productcatalogus en productverrijking
- Dockerconfiguratie

## Architectuurgrenzen

De import gebruikt `app.db.engine` en maakt dus geen tweede runtime-database. Er vindt geen automatische GS1-download plaats tijdens normaal applicatiegebruik.

## Validatie

De hervalidatie tegen `main` na merge van PR #198 is volledig groen:
- GPC catalog validation run 4
- compilatie van importer, CLI en tests
- drie gerichte pytest-tests
- geïsoleerde Nederlandse CLI-proefimport
- controle van Brick `10006144 — Mosterdblad`
- controle van de importregistratie
- bewijsartefact met JSON-resultaat en SQLite-testdatabase
- routecatalogus en M2C2n final closure
- kassabonketen en mergegate
- product-, artikel-, inventory- en householdguards
- forecast-, purchase- en notification-audits

## Risico

Laag tot middel. Bestaande flows worden niet aangeraakt. De huidige actieve SQLite-runtime is aantoonbaar gevalideerd. PostgreSQL-portabiliteit van de importregistratie is nog geen claim van deze release.