### PR TITLE
Add controlled GPC import package

### DIFF
--- a/.github/workflows/gpc-controlled-import-validation.yml
+++ b/.github/workflows/gpc-controlled-import-validation.yml
@@ -1,0 +1,36 @@
+name: GPC controlled import validation
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/cli/import_gpc_catalog_controlled.py"
+      - "backend/tests/test_gpc_controlled_import.py"
+      - "docs/gpc/GPC-SOURCE-MANIFEST.example.json"
+      - ".github/workflows/gpc-controlled-import-validation.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-controlled-import:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    env:
+      PYTHONPATH: .
+      DATABASE_URL: sqlite:////tmp/rezzerv-gpc-package-tests.db
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install minimal dependencies
+        run: pip install sqlalchemy==2.0.36 pytest
+      - name: Compile controlled import package
+        run: |
+          python -m py_compile app/cli/import_gpc_catalog_controlled.py
+          python -m py_compile tests/test_gpc_controlled_import.py
+      - name: Validate dry-run, apply, backup and restore
+        run: python -m pytest -q tests/test_gpc_controlled_import.py tests/test_gpc_catalog_service.py

--- a/backend/app/cli/import_gpc_catalog_controlled.py
+++ b/backend/app/cli/import_gpc_catalog_controlled.py
@@ -1,0 +1,147 @@
+"""Controlled GS1 GPC import with staging, evidence and rollback backup.
+
+The command is intentionally SQLite-only because that is the active Rezzerv
+runtime. It never downloads GS1 data and requires a caller-supplied XML file
+plus a source manifest.
+"""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import sqlite3
+import sys
+import tempfile
+
+from sqlalchemy import create_engine
+
+from app.services.gpc_catalog_service import import_gpc_xml
+
+TABLES = (
+    "gpc_segments", "gpc_families", "gpc_classes", "gpc_bricks",
+    "gpc_attribute_types", "gpc_attribute_values",
+    "gpc_brick_attribute_types", "gpc_attribute_type_values", "gpc_import_runs",
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _counts(path: Path) -> dict[str, int]:
+    result: dict[str, int] = {}
+    with sqlite3.connect(path) as conn:
+        existing = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        for table in TABLES:
+            result[table] = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0] if table in existing else 0
+    return result
+
+
+def _load_manifest(path: Path, xml_path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    required = {"source_name", "source_version", "language_code", "license_reference", "xml_sha256"}
+    missing = sorted(required - set(data))
+    if missing:
+        raise ValueError(f"Bronmanifest mist velden: {', '.join(missing)}")
+    actual_hash = _sha256(xml_path)
+    if data["xml_sha256"].lower() != actual_hash:
+        raise ValueError("SHA-256 van XML komt niet overeen met het bronmanifest")
+    return data
+
+
+def run_controlled_import(xml_file: Path, manifest_file: Path, database: Path, evidence_dir: Path, apply: bool) -> dict:
+    if not xml_file.is_file() or not manifest_file.is_file() or not database.is_file():
+        raise FileNotFoundError("XML, bronmanifest of SQLite-database ontbreekt")
+    manifest = _load_manifest(manifest_file, xml_file)
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    with tempfile.TemporaryDirectory(prefix="rezzerv-gpc-") as temp_dir:
+        staged_db = Path(temp_dir) / "rezzerv-staging.db"
+        shutil.copy2(database, staged_db)
+        before = _counts(staged_db)
+        staged_engine = create_engine(f"sqlite:///{staged_db}")
+        imported = import_gpc_xml(
+            xml_file,
+            language_code=str(manifest["language_code"]),
+            source_version=str(manifest["source_version"]),
+            db_engine=staged_engine,
+        )
+        staged_engine.dispose()
+        after = _counts(staged_db)
+
+        report = {
+            "status": "validated",
+            "mode": "apply" if apply else "dry-run",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "database": str(database),
+            "manifest": manifest,
+            "import": imported,
+            "counts_before": before,
+            "counts_after": after,
+            "count_delta": {key: after[key] - before[key] for key in TABLES},
+            "backup": None,
+        }
+
+        if apply:
+            backup = evidence_dir / f"rezzerv-pre-gpc-{timestamp}.db"
+            shutil.copy2(database, backup)
+            shutil.copy2(staged_db, database)
+            report["status"] = "applied"
+            report["backup"] = str(backup)
+            report["database_sha256_after"] = _sha256(database)
+
+    report_path = evidence_dir / f"gpc-import-report-{timestamp}.json"
+    report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    report["report_path"] = str(report_path)
+    return report
+
+
+def restore_backup(backup: Path, database: Path) -> dict:
+    if not backup.is_file():
+        raise FileNotFoundError(f"Back-up ontbreekt: {backup}")
+    shutil.copy2(backup, database)
+    return {"status": "restored", "backup": str(backup), "database": str(database), "database_sha256": _sha256(database)}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Controleer en importeer een GS1 GPC XML-bestand veilig.")
+    sub = parser.add_subparsers(dest="command", required=True)
+    validate = sub.add_parser("import")
+    validate.add_argument("xml_file")
+    validate.add_argument("manifest_file")
+    validate.add_argument("--database", required=True)
+    validate.add_argument("--evidence-dir", required=True)
+    validate.add_argument("--apply", action="store_true")
+    restore = sub.add_parser("restore")
+    restore.add_argument("backup")
+    restore.add_argument("--database", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "restore":
+            result = restore_backup(Path(args.backup), Path(args.database))
+        else:
+            result = run_controlled_import(
+                Path(args.xml_file), Path(args.manifest_file), Path(args.database),
+                Path(args.evidence_dir), bool(args.apply),
+            )
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+        print(json.dumps({"status": "failed", "detail": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/cli/import_gpc_catalog_controlled.py
+++ b/backend/app/cli/import_gpc_catalog_controlled.py
@@ -11,7 +11,6 @@ from datetime import datetime, timezone
 import hashlib
 import json
 from pathlib import Path
-import shutil
 import sqlite3
 import sys
 import tempfile
@@ -35,6 +34,13 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _sqlite_backup(source: Path, target: Path) -> None:
+    """Create a transactionally consistent SQLite backup."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(source) as source_conn, sqlite3.connect(target) as target_conn:
+        source_conn.backup(target_conn)
+
+
 def _counts(path: Path) -> dict[str, int]:
     result: dict[str, int] = {}
     with sqlite3.connect(path) as conn:
@@ -51,7 +57,7 @@ def _load_manifest(path: Path, xml_path: Path) -> dict:
     if missing:
         raise ValueError(f"Bronmanifest mist velden: {', '.join(missing)}")
     actual_hash = _sha256(xml_path)
-    if data["xml_sha256"].lower() != actual_hash:
+    if str(data["xml_sha256"]).lower() != actual_hash:
         raise ValueError("SHA-256 van XML komt niet overeen met het bronmanifest")
     return data
 
@@ -65,7 +71,7 @@ def run_controlled_import(xml_file: Path, manifest_file: Path, database: Path, e
 
     with tempfile.TemporaryDirectory(prefix="rezzerv-gpc-") as temp_dir:
         staged_db = Path(temp_dir) / "rezzerv-staging.db"
-        shutil.copy2(database, staged_db)
+        _sqlite_backup(database, staged_db)
         before = _counts(staged_db)
         staged_engine = create_engine(f"sqlite:///{staged_db}")
         imported = import_gpc_xml(
@@ -92,8 +98,8 @@ def run_controlled_import(xml_file: Path, manifest_file: Path, database: Path, e
 
         if apply:
             backup = evidence_dir / f"rezzerv-pre-gpc-{timestamp}.db"
-            shutil.copy2(database, backup)
-            shutil.copy2(staged_db, database)
+            _sqlite_backup(database, backup)
+            _sqlite_backup(staged_db, database)
             report["status"] = "applied"
             report["backup"] = str(backup)
             report["database_sha256_after"] = _sha256(database)
@@ -107,7 +113,7 @@ def run_controlled_import(xml_file: Path, manifest_file: Path, database: Path, e
 def restore_backup(backup: Path, database: Path) -> dict:
     if not backup.is_file():
         raise FileNotFoundError(f"Back-up ontbreekt: {backup}")
-    shutil.copy2(backup, database)
+    _sqlite_backup(backup, database)
     return {"status": "restored", "backup": str(backup), "database": str(database), "database_sha256": _sha256(database)}
 
 

--- a/backend/tests/test_gpc_controlled_import.py
+++ b/backend/tests/test_gpc_controlled_import.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import sqlite3
+
+from app.cli.import_gpc_catalog_controlled import restore_backup, run_controlled_import
+
+XML = """<?xml version='1.0' encoding='UTF-8'?>
+<schema><segment code='50000000' text='Voeding'><family code='50100000' text='Groenten'><class code='50101700' text='Onbewerkt'><brick code='10006144' text='Mosterdblad'/></class></family></segment></schema>
+"""
+
+
+def _database(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute("CREATE TABLE sentinel (value TEXT NOT NULL)")
+        conn.execute("INSERT INTO sentinel VALUES ('original')")
+
+
+def _source(tmp_path: Path) -> tuple[Path, Path]:
+    xml = tmp_path / "nl.xml"
+    xml.write_text(XML, encoding="utf-8")
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({
+        "source_name": "GS1 GPC NL test",
+        "source_version": "ci",
+        "language_code": "nl",
+        "license_reference": "test-only",
+        "xml_sha256": hashlib.sha256(xml.read_bytes()).hexdigest(),
+    }), encoding="utf-8")
+    return xml, manifest
+
+
+def test_dry_run_does_not_change_runtime_database(tmp_path: Path) -> None:
+    database = tmp_path / "rezzerv.db"
+    _database(database)
+    xml, manifest = _source(tmp_path)
+    before = database.read_bytes()
+    result = run_controlled_import(xml, manifest, database, tmp_path / "evidence", False)
+    assert result["status"] == "validated"
+    assert result["counts_after"]["gpc_bricks"] == 1
+    assert database.read_bytes() == before
+
+
+def test_apply_creates_backup_and_restore_recovers_database(tmp_path: Path) -> None:
+    database = tmp_path / "rezzerv.db"
+    _database(database)
+    xml, manifest = _source(tmp_path)
+    original = database.read_bytes()
+    result = run_controlled_import(xml, manifest, database, tmp_path / "evidence", True)
+    assert result["status"] == "applied"
+    backup = Path(result["backup"])
+    assert backup.is_file()
+    with sqlite3.connect(database) as conn:
+        assert conn.execute("SELECT description FROM gpc_bricks WHERE brick_code='10006144'").fetchone() == ("Mosterdblad",)
+    restore_backup(backup, database)
+    assert database.read_bytes() == original
+
+
+def test_manifest_hash_mismatch_blocks_import(tmp_path: Path) -> None:
+    database = tmp_path / "rezzerv.db"
+    _database(database)
+    xml, manifest = _source(tmp_path)
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    data["xml_sha256"] = "0" * 64
+    manifest.write_text(json.dumps(data), encoding="utf-8")
+    try:
+        run_controlled_import(xml, manifest, database, tmp_path / "evidence", False)
+    except ValueError as exc:
+        assert "SHA-256" in str(exc)
+    else:
+        raise AssertionError("Hash mismatch moet import blokkeren")

--- a/backend/tests/test_gpc_controlled_import.py
+++ b/backend/tests/test_gpc_controlled_import.py
@@ -47,7 +47,6 @@ def test_apply_creates_backup_and_restore_recovers_database(tmp_path: Path) -> N
     database = tmp_path / "rezzerv.db"
     _database(database)
     xml, manifest = _source(tmp_path)
-    original = database.read_bytes()
     result = run_controlled_import(xml, manifest, database, tmp_path / "evidence", True)
     assert result["status"] == "applied"
     backup = Path(result["backup"])
@@ -55,7 +54,10 @@ def test_apply_creates_backup_and_restore_recovers_database(tmp_path: Path) -> N
     with sqlite3.connect(database) as conn:
         assert conn.execute("SELECT description FROM gpc_bricks WHERE brick_code='10006144'").fetchone() == ("Mosterdblad",)
     restore_backup(backup, database)
-    assert database.read_bytes() == original
+    with sqlite3.connect(database) as conn:
+        assert conn.execute("SELECT value FROM sentinel").fetchone() == ("original",)
+        assert conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='gpc_bricks'").fetchone() is None
+        assert conn.execute("PRAGMA integrity_check").fetchone() == ("ok",)
 
 
 def test_manifest_hash_mismatch_blocks_import(tmp_path: Path) -> None:

--- a/docs/gpc/GPC-SOURCE-MANIFEST.example.json
+++ b/docs/gpc/GPC-SOURCE-MANIFEST.example.json
@@ -1,0 +1,7 @@
+{
+  "source_name": "GS1 GPC Nederlandse publicatie",
+  "source_version": "VUL_OFFICIELE_VERSIE_IN",
+  "language_code": "nl",
+  "license_reference": "VUL_CONTRACT_OF_DOWNLOADREFERENTIE_IN",
+  "xml_sha256": "VUL_SHA256_VAN_HET_ORIGINELE_XML_BESTAND_IN"
+}


### PR DESCRIPTION
## Doel
Voegt een gecontroleerd operationeel importpakket toe voor een echte Nederlandse GS1 GPC XML-publicatie.

## Functionaliteit
- verplicht bronmanifest met versie, taal, licentiereferentie en SHA-256
- standaard dry-run op een tijdelijke, transactioneel consistente kopie van de actieve SQLite-database
- aantallenrapport vóór en na import
- expliciete `--apply` voor wijziging van de actieve database
- automatische pre-import databaseback-up via SQLite backup API
- restore-opdracht voor rollback
- tests voor dry-run, apply, back-up, restore, integriteitscontrole en hashblokkade
- gerichte GitHub Actions-validatie

## Niet opgenomen
- geen GS1 XML-bronbestand
- geen automatische download
- geen Catalogus-API of frontend
- geen PostgreSQL-claim

## Gebruik
`python -m app.cli.import_gpc_catalog_controlled import <xml> <manifest> --database <rezzerv.db> --evidence-dir <map>`

Pas na beoordeling van het dry-runrapport:
`python -m app.cli.import_gpc_catalog_controlled import <xml> <manifest> --database <rezzerv.db> --evidence-dir <map> --apply`

Rollback:
`python -m app.cli.import_gpc_catalog_controlled restore <backup.db> --database <rezzerv.db>`

## Validatie
Alle gates op commit `c0daad8602842077682cbde36bedc03446d6ddd5` zijn groen:
- GPC controlled import validation run 3
- dry-run zonder wijziging actieve database
- apply met automatische back-up
- restore met inhoudelijke en `PRAGMA integrity_check`-controle
- blokkering bij onjuiste XML SHA-256
- bestaande GPC-importtests
- M2C2n final closure en routecatalogus
- kassabonketen en mergegate
- product-, artikel-, inventory- en householdguards
- forecast-, purchase- en notification-audits

## Risico
Laag tot middel. De actieve database wordt alleen gewijzigd na expliciete `--apply`; vóór wijziging wordt een herstelbare consistente back-up gemaakt. Het echte gelicentieerde GS1 XML-bestand blijft buiten GitHub.