### PR TITLE
Add Dutch GPC translation overlay

### DIFF
--- a/.github/workflows/gpc-translation-validation.yml
+++ b/.github/workflows/gpc-translation-validation.yml
@@ -1,0 +1,37 @@
+name: GPC translation validation
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/services/gpc_translation_service.py"
+      - "backend/app/cli/import_gpc_translations.py"
+      - "backend/tests/test_gpc_translation_service.py"
+      - ".github/workflows/gpc-translation-validation.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-gpc-translations:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    env:
+      PYTHONPATH: .
+      DATABASE_URL: sqlite:////tmp/rezzerv-gpc-translation-runtime.db
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install minimal dependencies
+        run: pip install sqlalchemy==2.0.36 pytest
+      - name: Compile translation modules
+        run: |
+          python -m py_compile app/services/gpc_translation_service.py
+          python -m py_compile app/cli/import_gpc_translations.py
+          python -m py_compile tests/test_gpc_translation_service.py
+      - name: Validate multilingual overlay and completeness gate
+        run: python -m pytest -q tests/test_gpc_translation_service.py tests/test_gpc_catalog_service.py

--- a/.github/workflows/gpc-translation-validation.yml
+++ b/.github/workflows/gpc-translation-validation.yml
@@ -4,8 +4,11 @@ on:
   pull_request:
     paths:
       - "backend/app/services/gpc_translation_service.py"
+      - "backend/app/services/gpc_official_translation_source.py"
       - "backend/app/cli/import_gpc_translations.py"
+      - "backend/app/cli/download_gpc_translation.py"
       - "backend/tests/test_gpc_translation_service.py"
+      - "backend/tests/test_gpc_official_translation_source.py"
       - ".github/workflows/gpc-translation-validation.yml"
   workflow_dispatch:
 
@@ -27,11 +30,14 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install minimal dependencies
-        run: pip install sqlalchemy==2.0.36 pytest
+        run: pip install sqlalchemy==2.0.36 pytest pytest-asyncio
       - name: Compile translation modules
         run: |
           python -m py_compile app/services/gpc_translation_service.py
+          python -m py_compile app/services/gpc_official_translation_source.py
           python -m py_compile app/cli/import_gpc_translations.py
+          python -m py_compile app/cli/download_gpc_translation.py
           python -m py_compile tests/test_gpc_translation_service.py
-      - name: Validate multilingual overlay and completeness gate
-        run: python -m pytest -q tests/test_gpc_translation_service.py tests/test_gpc_catalog_service.py
+          python -m py_compile tests/test_gpc_official_translation_source.py
+      - name: Validate multilingual overlay and official source adapter
+        run: python -m pytest -q tests/test_gpc_translation_service.py tests/test_gpc_official_translation_source.py tests/test_gpc_catalog_service.py

--- a/backend/app/cli/download_gpc_translation.py
+++ b/backend/app/cli/download_gpc_translation.py
@@ -1,0 +1,35 @@
+"""Operator CLI for explicit download of an official translated GPC publication."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from app.services.gpc_official_translation_source import download_official_gpc_translation_sync
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Download een officiële vertaalde GS1 GPC-publicatie.")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--language", default="nl")
+    parser.add_argument("--format", choices=("xml", "json", "xlsx"), default="xml")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        result = download_official_gpc_translation_sync(
+            args.output_dir,
+            language_code=args.language,
+            file_format=args.format,
+        )
+    except (RuntimeError, ValueError, OSError) as exc:
+        print(json.dumps({"status": "failed", "detail": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 2
+    print(json.dumps({"status": "downloaded", **result}, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/cli/import_gpc_translations.py
+++ b/backend/app/cli/import_gpc_translations.py
@@ -1,0 +1,59 @@
+"""Export and import a Dutch language overlay for the GS1 GPC catalog."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+from sqlalchemy import create_engine
+
+from app.services.gpc_translation_service import (
+    export_translation_template,
+    import_gpc_translations_csv,
+    translation_coverage,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Beheer Nederlandse GPC-vertalingen.")
+    parser.add_argument("--database", required=True, help="Pad naar de Rezzerv SQLite-database")
+    sub = parser.add_subparsers(dest="command", required=True)
+    export = sub.add_parser("export-template")
+    export.add_argument("output_csv")
+    import_command = sub.add_parser("import")
+    import_command.add_argument("translation_csv")
+    import_command.add_argument("--allow-incomplete", action="store_true")
+    sub.add_parser("coverage")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    database = Path(args.database)
+    if not database.is_file():
+        print(json.dumps({"status": "failed", "detail": f"Database ontbreekt: {database}"}), file=sys.stderr)
+        return 2
+    engine = create_engine(f"sqlite:///{database}")
+    try:
+        if args.command == "export-template":
+            result = export_translation_template(Path(args.output_csv), db_engine=engine)
+        elif args.command == "import":
+            result = import_gpc_translations_csv(
+                Path(args.translation_csv),
+                require_complete=not args.allow_incomplete,
+                db_engine=engine,
+            )
+        else:
+            result = translation_coverage(db_engine=engine)
+    except (FileNotFoundError, ValueError) as exc:
+        print(json.dumps({"status": "failed", "detail": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 2
+    finally:
+        engine.dispose()
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/services/gpc_official_translation_source.py
+++ b/backend/app/services/gpc_official_translation_source.py
@@ -1,0 +1,95 @@
+"""Fetch an official translated GPC publication through the public GS1 browser client.
+
+The optional ``gpcc`` dependency is imported lazily so normal Rezzerv runtime use
+has no network dependency. Downloads are explicit operator actions and produce a
+manifest with source metadata and SHA-256 evidence.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+
+@dataclass(frozen=True)
+class OfficialGpcDownload:
+    language_code: str
+    publication_version: str
+    format: str
+    downloaded_at: str
+    file_name: str
+    file_sha256: str
+    source: str = "GS1 GPC Browser"
+    client: str = "gpcc"
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+async def _default_client():
+    try:
+        from gpcc import fetch_file, get_language, get_publications
+    except ImportError as exc:
+        raise RuntimeError(
+            "De optionele dependency 'gpcc' ontbreekt. Installeer deze alleen in de beheerdersomgeving."
+        ) from exc
+    return get_language, get_publications, fetch_file
+
+
+async def download_official_gpc_translation(
+    output_dir: str | Path,
+    *,
+    language_code: str = "nl",
+    file_format: str = "xml",
+    client_factory: Callable[[], Awaitable[tuple[Any, Any, Any]]] = _default_client,
+) -> dict:
+    """Download the latest official publication for one language and write evidence."""
+    language_code = language_code.strip().lower()
+    file_format = file_format.strip().lower()
+    if not language_code:
+        raise ValueError("Taalcode ontbreekt")
+    if file_format not in {"xml", "json", "xlsx"}:
+        raise ValueError("Formaat moet xml, json of xlsx zijn")
+
+    get_language, get_publications, fetch_file = await client_factory()
+    language = await get_language(language_code)
+    if not language:
+        raise ValueError(f"GS1 GPC Browser bevat geen taalcode: {language_code}")
+    publications = await get_publications(language)
+    if not publications:
+        raise ValueError(f"Geen GS1 GPC-publicatie gevonden voor taal: {language_code}")
+
+    publication = publications[0]
+    version = str(publication.version)
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    target = output / f"gpc-{language_code}-{version}.{file_format}"
+    with target.open("wb") as stream:
+        await fetch_file(stream, publication, format=file_format)
+    if not target.is_file() or target.stat().st_size == 0:
+        raise RuntimeError("GS1-download leverde geen bruikbaar bestand op")
+
+    evidence = OfficialGpcDownload(
+        language_code=language_code,
+        publication_version=version,
+        format=file_format,
+        downloaded_at=datetime.now(timezone.utc).isoformat(),
+        file_name=target.name,
+        file_sha256=_sha256(target),
+    )
+    manifest = output / f"gpc-{language_code}-{version}.source.json"
+    manifest.write_text(json.dumps(asdict(evidence), ensure_ascii=False, indent=2), encoding="utf-8")
+    return {**asdict(evidence), "file_path": str(target), "manifest_path": str(manifest)}
+
+
+def download_official_gpc_translation_sync(*args, **kwargs) -> dict:
+    return asyncio.run(download_official_gpc_translation(*args, **kwargs))

--- a/backend/app/services/gpc_translation_service.py
+++ b/backend/app/services/gpc_translation_service.py
@@ -1,0 +1,270 @@
+"""Language overlay for GS1 GPC reference descriptions.
+
+The official GS1 source text remains untouched in the existing GPC tables.
+Translated labels are stored separately and linked by entity type and code.
+"""
+from __future__ import annotations
+
+import csv
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import hashlib
+from pathlib import Path
+
+from sqlalchemy import Engine, text
+
+from app.db import engine as runtime_engine
+
+ENTITY_TABLES = {
+    "segment": ("gpc_segments", "segment_code", "description"),
+    "family": ("gpc_families", "family_code", "description"),
+    "class": ("gpc_classes", "class_code", "description"),
+    "brick": ("gpc_bricks", "brick_code", "description"),
+    "attribute_type": ("gpc_attribute_types", "att_type_code", "att_type_text"),
+    "attribute_value": ("gpc_attribute_values", "att_value_code", "att_value_text"),
+}
+
+
+@dataclass
+class TranslationImportCounts:
+    rows: int = 0
+    inserted: int = 0
+    updated: int = 0
+
+
+def ensure_gpc_translation_schema(db_engine: Engine = runtime_engine) -> None:
+    with db_engine.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE IF NOT EXISTS gpc_translations (
+                entity_type VARCHAR(30) NOT NULL,
+                entity_code VARCHAR(8) NOT NULL,
+                language_code VARCHAR(12) NOT NULL,
+                translated_text TEXT NOT NULL,
+                translation_source TEXT NOT NULL,
+                reviewed INTEGER NOT NULL DEFAULT 0,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (entity_type, entity_code, language_code)
+            )
+        """))
+        conn.execute(text("""
+            CREATE TABLE IF NOT EXISTS gpc_translation_import_runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_name TEXT NOT NULL,
+                source_sha256 VARCHAR(64) NOT NULL,
+                language_code VARCHAR(12) NOT NULL,
+                imported_at TEXT NOT NULL,
+                status VARCHAR(20) NOT NULL,
+                row_count INTEGER NOT NULL,
+                message TEXT
+            )
+        """))
+        conn.execute(text(
+            "CREATE INDEX IF NOT EXISTS idx_gpc_translation_language "
+            "ON gpc_translations(language_code, entity_type)"
+        ))
+
+
+def export_translation_template(
+    output_path: str | Path,
+    *,
+    target_language: str = "nl",
+    db_engine: Engine = runtime_engine,
+) -> dict:
+    """Export every official GPC label once for translation."""
+    ensure_gpc_translation_schema(db_engine)
+    target = Path(output_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    count = 0
+    with target.open("w", newline="", encoding="utf-8-sig") as handle:
+        writer = csv.DictWriter(handle, fieldnames=(
+            "entity_type", "entity_code", "source_text", "language_code",
+            "translated_text", "translation_source", "reviewed",
+        ))
+        writer.writeheader()
+        with db_engine.connect() as conn:
+            for entity_type, (table, code_column, text_column) in ENTITY_TABLES.items():
+                rows = conn.execute(text(
+                    f"SELECT {code_column}, {text_column} FROM {table} ORDER BY {code_column}"
+                ))
+                for code, source_text in rows:
+                    writer.writerow({
+                        "entity_type": entity_type,
+                        "entity_code": code,
+                        "source_text": source_text,
+                        "language_code": target_language,
+                        "translated_text": "",
+                        "translation_source": "",
+                        "reviewed": "0",
+                    })
+                    count += 1
+    return {"status": "exported", "path": str(target), "rows": count}
+
+
+def import_gpc_translations_csv(
+    csv_path: str | Path,
+    *,
+    required_language: str = "nl",
+    require_complete: bool = True,
+    db_engine: Engine = runtime_engine,
+) -> dict:
+    """Import a reviewed translation overlay and optionally require 100% coverage."""
+    path = Path(csv_path)
+    if not path.is_file():
+        raise FileNotFoundError(f"Vertaalbestand niet gevonden: {path}")
+    ensure_gpc_translation_schema(db_engine)
+    raw = path.read_bytes()
+    source_sha256 = hashlib.sha256(raw).hexdigest()
+    imported_at = datetime.now(timezone.utc).isoformat()
+    counts = TranslationImportCounts()
+    seen: set[tuple[str, str, str]] = set()
+
+    with path.open("r", newline="", encoding="utf-8-sig") as handle:
+        reader = csv.DictReader(handle)
+        required = {
+            "entity_type", "entity_code", "language_code", "translated_text",
+            "translation_source", "reviewed",
+        }
+        missing = required - set(reader.fieldnames or ())
+        if missing:
+            raise ValueError(f"Vertaalbestand mist kolommen: {', '.join(sorted(missing))}")
+        rows = list(reader)
+
+    with db_engine.begin() as conn:
+        for row_number, row in enumerate(rows, start=2):
+            entity_type = row["entity_type"].strip()
+            entity_code = row["entity_code"].strip()
+            language_code = row["language_code"].strip().lower()
+            translated_text = row["translated_text"].strip()
+            translation_source = row["translation_source"].strip()
+            reviewed_raw = row["reviewed"].strip().lower()
+            if entity_type not in ENTITY_TABLES:
+                raise ValueError(f"Regel {row_number}: onbekend entity_type {entity_type}")
+            if language_code != required_language.lower():
+                raise ValueError(f"Regel {row_number}: taal moet {required_language} zijn")
+            if not entity_code or not translated_text or not translation_source:
+                raise ValueError(f"Regel {row_number}: code, vertaling en bron zijn verplicht")
+            if reviewed_raw not in {"0", "1", "false", "true", "nee", "ja"}:
+                raise ValueError(f"Regel {row_number}: reviewed moet 0/1 of false/true zijn")
+            reviewed = 1 if reviewed_raw in {"1", "true", "ja"} else 0
+            key = (entity_type, entity_code, language_code)
+            if key in seen:
+                raise ValueError(f"Regel {row_number}: dubbele vertaling voor {entity_type} {entity_code}")
+            seen.add(key)
+            table, code_column, _ = ENTITY_TABLES[entity_type]
+            exists = conn.execute(text(
+                f"SELECT 1 FROM {table} WHERE {code_column} = :code"
+            ), {"code": entity_code}).first()
+            if not exists:
+                raise ValueError(f"Regel {row_number}: onbekende GPC-code {entity_code}")
+            current = conn.execute(text("""
+                SELECT 1 FROM gpc_translations
+                WHERE entity_type=:entity_type AND entity_code=:entity_code
+                  AND language_code=:language_code
+            """), {
+                "entity_type": entity_type, "entity_code": entity_code,
+                "language_code": language_code,
+            }).first()
+            payload = {
+                "entity_type": entity_type, "entity_code": entity_code,
+                "language_code": language_code, "translated_text": translated_text,
+                "translation_source": translation_source, "reviewed": reviewed,
+                "updated_at": imported_at,
+            }
+            if current:
+                conn.execute(text("""
+                    UPDATE gpc_translations
+                    SET translated_text=:translated_text,
+                        translation_source=:translation_source,
+                        reviewed=:reviewed, updated_at=:updated_at
+                    WHERE entity_type=:entity_type AND entity_code=:entity_code
+                      AND language_code=:language_code
+                """), payload)
+                counts.updated += 1
+            else:
+                conn.execute(text("""
+                    INSERT INTO gpc_translations (
+                        entity_type, entity_code, language_code, translated_text,
+                        translation_source, reviewed, updated_at
+                    ) VALUES (
+                        :entity_type, :entity_code, :language_code, :translated_text,
+                        :translation_source, :reviewed, :updated_at
+                    )
+                """), payload)
+                counts.inserted += 1
+            counts.rows += 1
+
+        coverage = translation_coverage(required_language, db_engine=db_engine, connection=conn)
+        if require_complete and coverage["missing_total"]:
+            raise ValueError(
+                f"Nederlandse vertaling is niet compleet: {coverage['missing_total']} namen ontbreken"
+            )
+        conn.execute(text("""
+            INSERT INTO gpc_translation_import_runs (
+                source_name, source_sha256, language_code, imported_at,
+                status, row_count, message
+            ) VALUES (
+                :source_name, :source_sha256, :language_code, :imported_at,
+                'success', :row_count, NULL
+            )
+        """), {
+            "source_name": path.name, "source_sha256": source_sha256,
+            "language_code": required_language.lower(), "imported_at": imported_at,
+            "row_count": counts.rows,
+        })
+
+    return {
+        "status": "success", "source_name": path.name,
+        "source_sha256": source_sha256, "language_code": required_language.lower(),
+        "counts": asdict(counts), "coverage": coverage,
+    }
+
+
+def translation_coverage(
+    language_code: str = "nl",
+    *,
+    db_engine: Engine = runtime_engine,
+    connection=None,
+) -> dict:
+    ensure_gpc_translation_schema(db_engine)
+    own_connection = connection is None
+    conn = connection or db_engine.connect()
+    try:
+        entities = {}
+        total = translated = 0
+        for entity_type, (table, code_column, _) in ENTITY_TABLES.items():
+            source_count = conn.execute(text(f"SELECT COUNT(*) FROM {table}")).scalar_one()
+            translated_count = conn.execute(text(f"""
+                SELECT COUNT(*) FROM {table} source
+                JOIN gpc_translations translation
+                  ON translation.entity_type = :entity_type
+                 AND translation.entity_code = source.{code_column}
+                 AND translation.language_code = :language_code
+            """), {
+                "entity_type": entity_type,
+                "language_code": language_code.lower(),
+            }).scalar_one()
+            entities[entity_type] = {
+                "source": source_count,
+                "translated": translated_count,
+                "missing": source_count - translated_count,
+            }
+            total += source_count
+            translated += translated_count
+        return {
+            "language_code": language_code.lower(), "entities": entities,
+            "source_total": total, "translated_total": translated,
+            "missing_total": total - translated,
+            "complete": total == translated,
+        }
+    finally:
+        if own_connection:
+            conn.close()
+
+
+def localized_text_expression(alias: str, entity_type: str, code_column: str, source_column: str) -> str:
+    """Reusable SQL fragment: Dutch when present, otherwise official source text."""
+    return (
+        f"COALESCE((SELECT translated_text FROM gpc_translations t "
+        f"WHERE t.entity_type='{entity_type}' AND t.entity_code={alias}.{code_column} "
+        f"AND t.language_code='nl'), {alias}.{source_column})"
+    )

--- a/backend/tests/test_gpc_official_translation_source.py
+++ b/backend/tests/test_gpc_official_translation_source.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from app.services.gpc_official_translation_source import download_official_gpc_translation
+
+
+class Publication:
+    version = "2025-11-27"
+
+
+async def _client_factory():
+    async def get_language(code):
+        return {"code": code} if code == "nl" else None
+
+    async def get_publications(language):
+        return [Publication()]
+
+    async def fetch_file(stream, publication, format):
+        stream.write(b"<schema language='nl'/>")
+
+    return get_language, get_publications, fetch_file
+
+
+@pytest.mark.asyncio
+async def test_download_writes_file_and_source_manifest(tmp_path: Path) -> None:
+    result = await download_official_gpc_translation(
+        tmp_path, language_code="nl", file_format="xml", client_factory=_client_factory
+    )
+    downloaded = Path(result["file_path"])
+    manifest = Path(result["manifest_path"])
+    assert downloaded.read_bytes() == b"<schema language='nl'/>"
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    assert data["language_code"] == "nl"
+    assert data["publication_version"] == "2025-11-27"
+    assert data["file_sha256"] == hashlib.sha256(downloaded.read_bytes()).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_unknown_language_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="taalcode"):
+        await download_official_gpc_translation(
+            tmp_path, language_code="zz", client_factory=_client_factory
+        )

--- a/backend/tests/test_gpc_translation_service.py
+++ b/backend/tests/test_gpc_translation_service.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from sqlalchemy import create_engine, text
+
+from app.services.gpc_translation_service import (
+    export_translation_template,
+    import_gpc_translations_csv,
+    translation_coverage,
+)
+
+
+def _engine(tmp_path: Path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'gpc.db'}")
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE gpc_segments (segment_code TEXT PRIMARY KEY, description TEXT NOT NULL)"))
+        conn.execute(text("CREATE TABLE gpc_families (family_code TEXT PRIMARY KEY, description TEXT NOT NULL, segment_code TEXT NOT NULL)"))
+        conn.execute(text("CREATE TABLE gpc_classes (class_code TEXT PRIMARY KEY, description TEXT NOT NULL, family_code TEXT NOT NULL)"))
+        conn.execute(text("CREATE TABLE gpc_bricks (brick_code TEXT PRIMARY KEY, description TEXT NOT NULL, class_code TEXT NOT NULL)"))
+        conn.execute(text("CREATE TABLE gpc_attribute_types (att_type_code TEXT PRIMARY KEY, att_type_text TEXT NOT NULL)"))
+        conn.execute(text("CREATE TABLE gpc_attribute_values (att_value_code TEXT PRIMARY KEY, att_value_text TEXT NOT NULL)"))
+        conn.execute(text("INSERT INTO gpc_segments VALUES ('50000000', 'Food/Beverage/Tobacco')"))
+        conn.execute(text("INSERT INTO gpc_families VALUES ('50100000', 'Fruits/Vegetables/Nuts/Seeds', '50000000')"))
+        conn.execute(text("INSERT INTO gpc_classes VALUES ('50101700', 'Vegetables - Unprepared/Unprocessed', '50100000')"))
+        conn.execute(text("INSERT INTO gpc_bricks VALUES ('10006144', 'Mustard Greens', '50101700')"))
+        conn.execute(text("INSERT INTO gpc_attribute_types VALUES ('20000794', 'Growing Method')"))
+        conn.execute(text("INSERT INTO gpc_attribute_values VALUES ('30002654', 'Conventional')"))
+    return engine
+
+
+def test_export_template_contains_every_official_name(tmp_path: Path) -> None:
+    engine = _engine(tmp_path)
+    output = tmp_path / "translations.csv"
+    result = export_translation_template(output, db_engine=engine)
+    assert result["rows"] == 6
+    with output.open(encoding="utf-8-sig", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    assert {row["entity_type"] for row in rows} == {
+        "segment", "family", "class", "brick", "attribute_type", "attribute_value"
+    }
+    assert next(row for row in rows if row["entity_type"] == "brick")["source_text"] == "Mustard Greens"
+
+
+def test_complete_dutch_overlay_import(tmp_path: Path) -> None:
+    engine = _engine(tmp_path)
+    csv_path = tmp_path / "nl.csv"
+    rows = [
+        ("segment", "50000000", "Voedingsmiddelen/Dranken/Tabak"),
+        ("family", "50100000", "Fruit/Groenten/Noten/Zaden"),
+        ("class", "50101700", "Groenten - Onbereid/Onbewerkt"),
+        ("brick", "10006144", "Mosterdblad"),
+        ("attribute_type", "20000794", "Teeltmethode"),
+        ("attribute_value", "30002654", "Conventioneel"),
+    ]
+    with csv_path.open("w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=(
+            "entity_type", "entity_code", "language_code", "translated_text",
+            "translation_source", "reviewed",
+        ))
+        writer.writeheader()
+        for entity_type, code, translated in rows:
+            writer.writerow({
+                "entity_type": entity_type, "entity_code": code,
+                "language_code": "nl", "translated_text": translated,
+                "translation_source": "Rezzerv gecontroleerde vertaling", "reviewed": "1",
+            })
+    result = import_gpc_translations_csv(csv_path, db_engine=engine)
+    assert result["coverage"]["complete"] is True
+    assert result["coverage"]["translated_total"] == 6
+    with engine.connect() as conn:
+        assert conn.execute(text("""
+            SELECT translated_text FROM gpc_translations
+            WHERE entity_type='brick' AND entity_code='10006144' AND language_code='nl'
+        """)).scalar_one() == "Mosterdblad"
+        assert conn.execute(text("SELECT description FROM gpc_bricks WHERE brick_code='10006144'" )).scalar_one() == "Mustard Greens"
+
+
+def test_incomplete_overlay_is_rejected_atomically(tmp_path: Path) -> None:
+    engine = _engine(tmp_path)
+    csv_path = tmp_path / "partial.csv"
+    csv_path.write_text(
+        "entity_type,entity_code,language_code,translated_text,translation_source,reviewed\n"
+        "brick,10006144,nl,Mosterdblad,test,0\n",
+        encoding="utf-8",
+    )
+    try:
+        import_gpc_translations_csv(csv_path, db_engine=engine)
+    except ValueError as exc:
+        assert "niet compleet" in str(exc)
+    else:
+        raise AssertionError("Onvolledige vertaling moet worden geweigerd")
+    coverage = translation_coverage(db_engine=engine)
+    assert coverage["translated_total"] == 0


### PR DESCRIPTION
## Doel
Voegt een officiële Nederlandse GS1 GPC-vertaallaag toe bovenop de normatieve Engelstalige publicatie.

## Bronstrategie
- Oxford English blijft de officiële normatieve bron
- Nederlandse termen worden opgehaald uit de officiële GS1 GPC Browser-publicatie voor taalcode `nl`
- de download is een expliciete beheeractie, geen runtime-afhankelijkheid
- ieder gedownload bestand krijgt een bronmanifest met publicatieversie, taal, formaat, tijdstip en SHA-256
- geen scraping van browserpagina's en geen zelfverzonnen vertalingen als primaire bron

## Ontwerp
- Engelse GS1-bronteksten blijven ongewijzigd en controleerbaar
- Nederlandse tekst wordt als apart taalattribuut gekoppeld op entity type + GPC-code
- ondersteuning voor Segment, Family, Class, Brick, attribuuttype en attribuutwaarde
- Nederlandse tekst heeft in toekomstige API's voorrang; Engels blijft fallback

## Functionaliteit
- officiële GS1-downloadadapter via de openbare `gpcc`-client
- operator-CLI voor `nl` in XML, JSON of XLSX
- vertaaltabel en importregistratie
- gecontroleerde import van Nederlandse termen
- bronregistratie, reviewed-indicator en SHA-256
- 100%-compleetheidsgate: standaard wordt een gedeeltelijke vertaallaag atomair geweigerd
- dekkingsrapport per entiteitstype
- tests voor bronadapter, manifest, taalblokkade en vertaallaag

## Gebruik officiële bron
`python -m app.cli.download_gpc_translation --output-dir <map> --language nl --format xml`

## Buiten scope
- geen wijziging aan officiële GS1-codes of Engelse bronteksten
- geen Catalogus-API of frontend
- geen automatische online download tijdens normaal Rezzerv-gebruik
- geen onbeoordeelde machinevertaling als primaire bron

## Bronnen
GS1 publiceert GPC als schema-download en als browsergebaseerde publicatie met vertalingen. Vertalingen worden beheerd door GS1 Member Organisations; Oxford English blijft normatief.