### PR TITLE
Validate live English and Dutch GPC publications

### DIFF
--- a/.github/workflows/gpc-live-language-validation.yml
+++ b/.github/workflows/gpc-live-language-validation.yml
@@ -1,0 +1,42 @@
+name: GPC live language validation
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/cli/validate_live_gpc_languages.py"
+      - "backend/tests/test_live_gpc_language_validation.py"
+      - ".github/workflows/gpc-live-language-validation.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-live-gpc-languages:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    env:
+      PYTHONPATH: .
+      DATABASE_URL: sqlite:////tmp/rezzerv-gpc-live-validation.db
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install validation dependencies
+        run: pip install sqlalchemy==2.0.36 pytest gpcc
+      - name: Compile and test comparison logic
+        run: |
+          python -m py_compile app/cli/validate_live_gpc_languages.py
+          python -m pytest -q tests/test_live_gpc_language_validation.py
+      - name: Download and compare official English and Dutch publications
+        run: python -m app.cli.validate_live_gpc_languages --output-dir /tmp/gpc-live-evidence
+      - name: Upload validation evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gpc-live-language-evidence
+          path: /tmp/gpc-live-evidence
+          retention-days: 14

--- a/backend/app/cli/validate_live_gpc_languages.py
+++ b/backend/app/cli/validate_live_gpc_languages.py
@@ -1,0 +1,93 @@
+"""Download and compare official English and Dutch GPC publications."""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+from app.services.gpc_official_translation_source import download_official_gpc_translation_sync
+
+ENTITY_TAGS = {
+    "segment": "segment",
+    "family": "family",
+    "class": "class",
+    "brick": "brick",
+    "attribute_type": "attType",
+    "attribute_value": "attValue",
+}
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def extract_names(xml_path: str | Path) -> dict[str, dict[str, str]]:
+    root = ET.parse(xml_path).getroot()
+    result = {entity: {} for entity in ENTITY_TAGS}
+    reverse = {tag: entity for entity, tag in ENTITY_TAGS.items()}
+    for element in root.iter():
+        entity = reverse.get(_local_name(element.tag))
+        if not entity:
+            continue
+        code = (element.get("code") or "").strip()
+        text = (element.get("text") or "").strip()
+        if code and text:
+            result[entity][code] = text
+    return result
+
+
+def compare_publications(english_xml: str | Path, dutch_xml: str | Path) -> dict:
+    english = extract_names(english_xml)
+    dutch = extract_names(dutch_xml)
+    by_type = {}
+    missing_rows = []
+    for entity in ENTITY_TAGS:
+        en_codes = set(english[entity])
+        nl_codes = set(dutch[entity])
+        missing = sorted(en_codes - nl_codes)
+        extra = sorted(nl_codes - en_codes)
+        blank = sorted(code for code in en_codes & nl_codes if not dutch[entity][code].strip())
+        identical = sorted(code for code in en_codes & nl_codes if english[entity][code] == dutch[entity][code])
+        by_type[entity] = {
+            "english": len(en_codes),
+            "dutch": len(nl_codes),
+            "missing_in_dutch": len(missing),
+            "extra_in_dutch": len(extra),
+            "blank_dutch": len(blank),
+            "identical_text": len(identical),
+        }
+        for code in missing:
+            missing_rows.append({"entity_type": entity, "entity_code": code, "english_text": english[entity][code]})
+    return {
+        "status": "complete" if not missing_rows else "incomplete",
+        "by_entity_type": by_type,
+        "missing_total": len(missing_rows),
+        "missing": missing_rows,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Vergelijk live Engelse en Nederlandse GS1 GPC-publicaties.")
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args(argv)
+    output = Path(args.output_dir)
+    en = download_official_gpc_translation_sync(output / "en", language_code="en", file_format="xml")
+    nl = download_official_gpc_translation_sync(output / "nl", language_code="nl", file_format="xml")
+    report = compare_publications(en["file_path"], nl["file_path"])
+    report["english_source"] = en
+    report["dutch_source"] = nl
+    report_path = output / "gpc-en-nl-validation-report.json"
+    report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    missing_path = output / "gpc-missing-dutch.csv"
+    with missing_path.open("w", newline="", encoding="utf-8-sig") as handle:
+        writer = csv.DictWriter(handle, fieldnames=("entity_type", "entity_code", "english_text"))
+        writer.writeheader()
+        writer.writerows(report["missing"])
+    print(json.dumps({**report, "report_path": str(report_path), "missing_path": str(missing_path)}, ensure_ascii=False, indent=2))
+    return 0 if report["status"] == "complete" else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_live_gpc_language_validation.py
+++ b/backend/tests/test_live_gpc_language_validation.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from app.cli.validate_live_gpc_languages import compare_publications
+
+
+def _write(path: Path, segment_text: str, include_brick: bool = True) -> None:
+    brick = '<brick code="10000001" text="Mosterd" />' if include_brick else ''
+    path.write_text(
+        f'<schema><segment code="50000000" text="{segment_text}"><family code="50010000" text="Familie"><class code="50010100" text="Klasse">{brick}</class></family></segment></schema>',
+        encoding="utf-8",
+    )
+
+
+def test_complete_when_all_codes_exist(tmp_path):
+    en = tmp_path / "en.xml"
+    nl = tmp_path / "nl.xml"
+    _write(en, "Food")
+    _write(nl, "Voeding")
+    report = compare_publications(en, nl)
+    assert report["status"] == "complete"
+    assert report["missing_total"] == 0
+
+
+def test_reports_missing_dutch_code(tmp_path):
+    en = tmp_path / "en.xml"
+    nl = tmp_path / "nl.xml"
+    _write(en, "Food")
+    _write(nl, "Voeding", include_brick=False)
+    report = compare_publications(en, nl)
+    assert report["status"] == "incomplete"
+    assert report["missing_total"] == 1
+    assert report["missing"][0]["entity_code"] == "10000001"


### PR DESCRIPTION
## Doel
Voert een echte live-validatie uit op de officiële Engelse en Nederlandse GS1 GPC-browserpublicaties.

## Functionaliteit
- downloadt expliciet de actuele officiële `en`- en `nl`-publicatie als XML
- vergelijkt Segment, Family, Class, Brick, attribuuttype en attribuutwaarde op vaste GPC-code
- rapporteert ontbrekende Nederlandse codes, extra Nederlandse codes, lege teksten en identieke teksten
- schrijft een JSON-bewijsrapport en CSV met ontbrekende Nederlandse termen
- publiceert de bronbestanden, manifests en rapporten tijdelijk als afgeschermd GitHub Actions-artifact
- faalt de gate wanneer officiële Engelse codes in de Nederlandse publicatie ontbreken

## Live resultaat
Beide officiële publicaties zijn versie `v20260520`.

| Entiteit | Engels | Nederlands | Ontbreekt NL | Extra NL | Leeg NL |
|---|---:|---:|---:|---:|---:|
| Segment | 45 | 45 | 0 | 0 | 0 |
| Family | 162 | 162 | 0 | 0 | 0 |
| Class | 938 | 938 | 0 | 0 | 0 |
| Brick | 5.318 | 5.318 | 0 | 0 | 0 |
| Attribuuttype | 2.085 | 2.085 | 0 | 0 | 0 |
| Attribuutwaarde | 13.733 | 13.733 | 0 | 0 | 0 |

**Conclusie:** de officiële Nederlandse GS1-publicatie heeft 100% codedekking ten opzichte van de Engelse publicatie. Er zijn geen ontbrekende of lege Nederlandse termen.

Bronhashes:
- Engels: `a140104ec2dd8a7c53692389e41924b8da78374f9a0015193bc00c7c9a1a459a`
- Nederlands: `535e3aeed6e27a81b50ceece73f67d4a3b936aa90e3a11d7a711c465cc27d5a2`

## Veiligheid
- geen GPC-bronbestanden worden in GitHub gecommit
- download is alleen een expliciete beheer-/validatieactie
- normale Rezzerv-runtime krijgt geen netwerkafhankelijkheid
- bewijsartifact verloopt automatisch na 14 dagen

## Vervolg na merge
Dezelfde gevalideerde `v20260520`-publicaties gecontroleerd importeren in een kopie van de actuele Rezzerv-database en een import-/rollbackrapport opleveren.